### PR TITLE
hydra-queue-{runner,evaluator}: don't clutter the system log with debug messages

### DIFF
--- a/src/script/hydra-evaluator
+++ b/src/script/hydra-evaluator
@@ -301,7 +301,7 @@ while (1) {
             # isn't updated properly.
             sleep 1;
         } else {
-            print STDERR "sleeping...\n";
+            # print STDERR "sleeping...\n";
             sleep 30;
         }
     };

--- a/src/script/hydra-queue-runner
+++ b/src/script/hydra-queue-runner
@@ -69,7 +69,7 @@ sub findBuildDependencyInQueue {
 
 
 sub checkBuilds {
-    print "looking for runnable builds...\n";
+    # print "looking for runnable builds...\n";
 
     my @buildsStarted;
 
@@ -182,6 +182,6 @@ while (1) {
     };
     warn $@ if $@;
 
-    print "sleeping...\n";
+    # print "sleeping...\n";
     sleep(5);
 }


### PR DESCRIPTION
These messages clutter the system log without conveying any useful information, IMHO.
