### PR TITLE
hydra-queue-runner: don't clutter the system log with debug message

### DIFF
--- a/src/script/hydra-queue-runner
+++ b/src/script/hydra-queue-runner
@@ -111,9 +111,11 @@ sub checkBuilds {
                 { join => ['project'], order_by => ["priority DESC", "timestamp"],
                   rows => $extraAllowed });
 
-            print "system type `", $system->system,
-                "': $nrActive active, $max allowed, ",
-                "starting ", scalar(@builds), " builds\n";
+            if (scalar(@builds) > 0) {
+              print "system type `", $system->system,
+                  "': $nrActive active, $max allowed, ",
+                  "starting ", scalar(@builds), " builds\n";
+            }
 
             foreach my $build (@builds) {
                 my $depbuild = findBuildDependencyInQueue($build);


### PR DESCRIPTION
Avoid the frequently printed

  hydra-queue-runner[10293]: system type `x86_64-linux': 2 active, 2 allowed, starting 0 builds

message. That information is only interesting when some build are
actually started.
