### PR TITLE
Merge in the first bits of the API work

### DIFF
--- a/src/lib/Hydra/Base/Controller/ListBuilds.pm
+++ b/src/lib/Hydra/Base/Controller/ListBuilds.pm
@@ -101,7 +101,7 @@ sub latest : Chained('get_builds') PathPart('latest') {
 
     notFound($c, "There is no successful build to redirect to.") unless defined $latest;
 
-    $c->res->redirect($c->uri_for($c->controller('Build')->action_for("view_build"), [$latest->id], @rest));
+    $c->res->redirect($c->uri_for($c->controller('Build')->action_for("build"), [$latest->id], @rest));
 }
 
 
@@ -116,7 +116,7 @@ sub latest_for : Chained('get_builds') PathPart('latest-for') {
 
     notFound($c, "There is no successful build for platform `$system' to redirect to.") unless defined $latest;
 
-    $c->res->redirect($c->uri_for($c->controller('Build')->action_for("view_build"), [$latest->id], @rest));
+    $c->res->redirect($c->uri_for($c->controller('Build')->action_for("build"), [$latest->id], @rest));
 }
 
 

--- a/src/lib/Hydra/Base/Controller/NixChannel.pm
+++ b/src/lib/Hydra/Base/Controller/NixChannel.pm
@@ -2,7 +2,7 @@ package Hydra::Base::Controller::NixChannel;
 
 use strict;
 use warnings;
-use base 'Catalyst::Controller';
+use base 'Hydra::Base::Controller::REST';
 use List::MoreUtils qw(all);
 use Nix::Store;
 use Hydra::Helper::Nix;

--- a/src/lib/Hydra/Base/Controller/REST.pm
+++ b/src/lib/Hydra/Base/Controller/REST.pm
@@ -1,0 +1,18 @@
+package Hydra::Base::Controller::REST;
+
+use strict;
+use warnings;
+use base 'Catalyst::Controller::REST';
+
+__PACKAGE__->config(
+    map => {
+        'text/html' => [ 'View', 'TT' ]
+    },
+    default => 'text/html',
+    'stash_key' => 'resource',
+);
+
+sub begin { my ( $self, $c ) = @_; $c->forward('Hydra::Controller::Root::begin'); }
+sub end { my ( $self, $c ) = @_; $c->forward('Hydra::Controller::Root::end'); }
+
+1;

--- a/src/lib/Hydra/Component/ToJSON.pm
+++ b/src/lib/Hydra/Component/ToJSON.pm
@@ -1,0 +1,43 @@
+use utf8;
+package Hydra::Component::ToJSON;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+sub TO_JSON {
+    my $self = shift;
+    my $json = { $self->get_columns };
+    my $rs = $self->result_source;
+    my @relnames = $rs->relationships;
+    RELLOOP: foreach my $relname (@relnames) {
+        my $relinfo = $rs->relationship_info($relname);
+        next unless defined $relinfo->{attrs}->{accessor};
+        my $accessor = $relinfo->{attrs}->{accessor};
+        if ($accessor eq "single" and exists $self->{_relationship_data}{$relname}) {
+            $json->{$relname} = $self->$relname->TO_JSON;
+        } else {
+            unless (defined $self->{related_resultsets}{$relname}) {
+                my $cond = $relinfo->{cond};
+                if (ref $cond eq 'HASH') {
+                    foreach my $k (keys %{$cond}) {
+                        my $v = $cond->{$k};
+                        $v =~ s/^self\.//;
+                        next RELLOOP unless $self->has_column_loaded($v);
+                    }
+                } #!!! TODO: Handle ARRAY conditions
+            }
+            if (defined $self->related_resultset($relname)->get_cache) {
+                if ($accessor eq "multi") {
+                    $json->{$relname} = [ map { $_->TO_JSON } $self->$relname ];
+                } else {
+                    $json->{$relname} = $self->$relname->TO_JSON;
+                }
+            }
+        }
+    }
+    return $json;
+}
+
+1;

--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -3,7 +3,7 @@ package Hydra::Controller::API;
 use utf8;
 use strict;
 use warnings;
-use base 'Catalyst::Controller';
+use base 'Hydra::Base::Controller::REST';
 use Hydra::Helper::Nix;
 use Hydra::Helper::AddBuilds;
 use Hydra::Helper::CatalystUtils;
@@ -310,6 +310,11 @@ sub push : Chained('api') PathPart('push') Args(0) {
             , where => \ [ 'exists (select 1 from JobsetInputAlts where project = me.project and jobset = me.name and value = ?)', [ 'value', $r ] ]
             });
     }
+
+    $self->status_ok(
+        $c,
+        entity => { jobsetsTriggered => $c->stash->{json}->{jobsetsTriggered} }
+    );
 }
 
 

--- a/src/lib/Hydra/Controller/Jobset.pm
+++ b/src/lib/Hydra/Controller/Jobset.pm
@@ -7,35 +7,143 @@ use Hydra::Helper::Nix;
 use Hydra::Helper::CatalystUtils;
 
 
-sub jobset : Chained('/') PathPart('jobset') CaptureArgs(2) {
+sub jobsetChain :Chained('/') :PathPart('jobset') :CaptureArgs(2) {
     my ($self, $c, $projectName, $jobsetName) = @_;
 
-    my $project = $c->model('DB::Projects')->find($projectName)
-        or notFound($c, "Project $projectName doesn't exist.");
+    my $project = $c->model('DB::Projects')->find($projectName);
 
-    $c->stash->{project} = $project;
+    if ($project) {
+        $c->stash->{project} = $project;
 
-    $c->stash->{jobset_} = $project->jobsets->search({name => $jobsetName});
-    $c->stash->{jobset} = $c->stash->{jobset_}->single
-        or notFound($c, "Jobset $jobsetName doesn't exist.");
+        $c->stash->{jobset_} = $project->jobsets->search({'me.name' => $jobsetName});
+        my $jobset = $c->stash->{jobset_}->single;
+
+        if ($jobset) {
+            $c->stash->{jobset} = $jobset;
+        } else {
+            if ($c->action->name eq "jobset" and $c->request->method eq "PUT") {
+                $c->stash->{jobsetName} = $jobsetName;
+            } else {
+                $self->status_not_found(
+                    $c,
+                    message => "Jobset $jobsetName doesn't exist."
+                );
+                $c->detach;
+            }
+        }
+    } else {
+        $self->status_not_found(
+            $c,
+            message => "Project $projectName doesn't exist."
+        );
+        $c->detach;
+    }
 }
 
 
-sub index : Chained('jobset') PathPart('') Args(0) {
+sub jobset :Chained('jobsetChain') :PathPart('') :Args(0) :ActionClass('REST::ForBrowsers') { }
+
+sub jobset_GET {
     my ($self, $c) = @_;
 
     $c->stash->{template} = 'jobset.tt';
 
-    my $projectName = $c->stash->{project}->name;
-    my $jobsetName = $c->stash->{jobset}->name;
-
     $c->stash->{evals} = getEvals($self, $c, scalar $c->stash->{jobset}->jobsetevals, 0, 10);
 
     ($c->stash->{latestEval}) = $c->stash->{jobset}->jobsetevals->search({}, { limit => 1, order_by => ["id desc"] });
+
+    $self->status_ok(
+        $c,
+        entity => $c->stash->{jobset_}->find({}, {
+                columns => [
+                    'me.name',
+                    'me.project',
+                    'me.errormsg',
+                    'jobsetinputs.name',
+                    {
+                        'jobsetinputs.jobsetinputalts.altnr' => 'jobsetinputalts.altnr',
+                        'jobsetinputs.jobsetinputalts.value' => 'jobsetinputalts.value'
+                    }
+                ],
+                join => { 'jobsetinputs' => 'jobsetinputalts' },
+                collapse => 1,
+                order_by => "me.name"
+            })
+    );
+}
+
+sub jobset_PUT {
+    my ($self, $c) = @_;
+
+    requireProjectOwner($c, $c->stash->{project});
+
+    if (defined $c->stash->{jobset}) {
+        error($c, "Cannot rename jobset `$c->stash->{params}->{oldName}' over existing jobset `$c->stash->{jobset}->name") if defined $c->stash->{params}->{oldName} and $c->stash->{params}->{oldName} ne $c->stash->{jobset}->name;
+        txn_do($c->model('DB')->schema, sub {
+            updateJobset($c, $c->stash->{jobset});
+        });
+
+        if ($c->req->looks_like_browser) {
+            $c->res->redirect($c->uri_for($self->action_for("jobset"),
+                [$c->stash->{project}->name, $c->stash->{jobset}->name]) . "#tabs-configuration");
+        } else {
+            $self->status_no_content($c);
+        }
+    } elsif (defined $c->stash->{params}->{oldName}) {
+        my $jobset = $c->stash->{project}->jobsets->find({'me.name' => $c->stash->{params}->{oldName}});
+
+        if (defined $jobset) {
+            txn_do($c->model('DB')->schema, sub {
+                updateJobset($c, $jobset);
+            });
+
+            my $uri = $c->uri_for($self->action_for("jobset"), [$c->stash->{project}->name, $jobset->name]);
+
+            if ($c->req->looks_like_browser) {
+                $c->res->redirect($uri . "#tabs-configuration");
+            } else {
+                $self->status_created(
+                    $c,
+                    location => "$uri",
+                    entity => { name => $jobset->name, uri => "$uri", type => "jobset" }
+                );
+            }
+        } else {
+            $self->status_not_found(
+                $c,
+                message => "Jobset $c->stash->{params}->{oldName} doesn't exist."
+            );
+        }
+    } else {
+        my $exprType =
+            $c->stash->{params}->{"nixexprpath"} =~ /.scm$/ ? "guile" : "nix";
+
+        error($c, "Invalid jobset name: ‘$c->stash->{jobsetName}’") if $c->stash->{jobsetName} !~ /^$jobsetNameRE$/;
+
+        my $jobset;
+        txn_do($c->model('DB')->schema, sub {
+            # Note: $jobsetName is validated in updateProject, which will
+            # abort the transaction if the name isn't valid.
+            $jobset = $c->stash->{project}->jobsets->create(
+                {name => $c->stash->{jobsetName}, nixexprinput => "", nixexprpath => "", emailoverride => ""});
+            updateJobset($c, $jobset);
+        });
+
+        my $uri = $c->uri_for($self->action_for("jobset"), [$c->stash->{project}->name, $jobset->name]);
+        if ($c->req->looks_like_browser) {
+            $c->res->redirect($uri . "#tabs-configuration");
+        } else {
+            $self->status_created(
+                $c,
+                location => "$uri",
+                entity => { name => $jobset->name, uri => "$uri", type => "jobset" }
+            );
+        }
+    }
 }
 
 
-sub jobs_tab : Chained('jobset') PathPart('jobs-tab') Args(0) {
+sub jobs_tab : Chained('jobsetChain') PathPart('jobs-tab') Args(0) {
     my ($self, $c) = @_;
     $c->stash->{template} = 'jobset-jobs-tab.tt';
 
@@ -64,7 +172,7 @@ sub jobs_tab : Chained('jobset') PathPart('jobs-tab') Args(0) {
 }
 
 
-sub status_tab : Chained('jobset') PathPart('status-tab') Args(0) {
+sub status_tab : Chained('jobsetChain') PathPart('status-tab') Args(0) {
     my ($self, $c) = @_;
     $c->stash->{template} = 'jobset-status-tab.tt';
 
@@ -101,7 +209,7 @@ sub status_tab : Chained('jobset') PathPart('status-tab') Args(0) {
 
 
 # Hydra::Base::Controller::ListBuilds needs this.
-sub get_builds : Chained('jobset') PathPart('') CaptureArgs(0) {
+sub get_builds : Chained('jobsetChain') PathPart('') CaptureArgs(0) {
     my ($self, $c) = @_;
     $c->stash->{allBuilds} = $c->stash->{jobset}->builds;
     $c->stash->{jobStatus} = $c->model('DB')->resultset('JobStatusForJobset')
@@ -115,7 +223,7 @@ sub get_builds : Chained('jobset') PathPart('') CaptureArgs(0) {
 }
 
 
-sub edit : Chained('jobset') PathPart Args(0) {
+sub edit : Chained('jobsetChain') PathPart Args(0) {
     my ($self, $c) = @_;
 
     requireProjectOwner($c, $c->stash->{project});
@@ -125,10 +233,9 @@ sub edit : Chained('jobset') PathPart Args(0) {
 }
 
 
-sub submit : Chained('jobset') PathPart Args(0) {
+sub submit : Chained('jobsetChain') PathPart Args(0) {
     my ($self, $c) = @_;
 
-    requireProjectOwner($c, $c->stash->{project});
     requirePost($c);
 
     if (($c->request->params->{submit} // "") eq "delete") {
@@ -137,15 +244,17 @@ sub submit : Chained('jobset') PathPart Args(0) {
             $c->stash->{jobset}->builds->delete_all;
             $c->stash->{jobset}->delete;
         });
-        return $c->res->redirect($c->uri_for($c->controller('Project')->action_for("view"), [$c->stash->{project}->name]));
+        return $c->res->redirect($c->uri_for($c->controller('Project')->action_for("project"), [$c->stash->{project}->name]));
     }
 
-    txn_do($c->model('DB')->schema, sub {
-        updateJobset($c, $c->stash->{jobset});
-    });
-
-    $c->res->redirect($c->uri_for($self->action_for("index"),
-        [$c->stash->{project}->name, $c->stash->{jobset}->name]) . "#tabs-configuration");
+    my $newName = trim $c->stash->{params}->{name};
+    my $oldName = trim $c->stash->{jobset}->name;
+    unless ($oldName eq $newName) {
+        $c->stash->{params}->{oldName} = $oldName;
+        $c->stash->{jobsetName} = $newName;
+        undef $c->stash->{jobset};
+    }
+    jobset_PUT($self, $c);
 }
 
 
@@ -153,29 +262,13 @@ sub nixExprPathFromParams {
     my ($c) = @_;
 
     # The Nix expression path must be relative and can't contain ".." elements.
-    my $nixExprPath = trim $c->request->params->{"nixexprpath"};
+    my $nixExprPath = trim $c->stash->{params}->{"nixexprpath"};
     error($c, "Invalid Nix expression path: $nixExprPath") if $nixExprPath !~ /^$relPathRE$/;
 
-    my $nixExprInput = trim $c->request->params->{"nixexprinput"};
+    my $nixExprInput = trim $c->stash->{params}->{"nixexprinput"};
     error($c, "Invalid Nix expression input name: $nixExprInput") unless $nixExprInput =~ /^\w+$/;
 
     return ($nixExprPath, $nixExprInput);
-}
-
-
-sub checkInput {
-    my ($c, $baseName) = @_;
-
-    my $inputName = trim $c->request->params->{"input-$baseName-name"};
-    error($c, "Invalid input name: $inputName") unless $inputName =~ /^[[:alpha:]]\w*$/;
-
-    my $inputType = trim $c->request->params->{"input-$baseName-type"};
-    error($c, "Invalid input type: $inputType") unless
-        $inputType eq "svn" || $inputType eq "svn-checkout" || $inputType eq "hg" || $inputType eq "tarball" ||
-        $inputType eq "string" || $inputType eq "path" || $inputType eq "boolean" || $inputType eq "bzr" || $inputType eq "bzr-checkout" ||
-        $inputType eq "git" || $inputType eq "build" || $inputType eq "sysbuild" ;
-
-    return ($inputName, $inputType);
 }
 
 
@@ -191,50 +284,62 @@ sub checkInputValue {
 sub updateJobset {
     my ($c, $jobset) = @_;
 
-    my $jobsetName = trim $c->request->params->{"name"};
+    my $jobsetName = $c->stash->{jobsetName} or $jobset->name;
     error($c, "Invalid jobset name: ‘$jobsetName’") if $jobsetName !~ /^$jobsetNameRE$/;
 
     # When the expression is in a .scm file, assume it's a Guile + Guix
     # build expression.
     my $exprType =
-        $c->request->params->{"nixexprpath"} =~ /.scm$/ ? "guile" : "nix";
+        $c->stash->{params}->{"nixexprpath"} =~ /.scm$/ ? "guile" : "nix";
 
     my ($nixExprPath, $nixExprInput) = nixExprPathFromParams $c;
 
     $jobset->update(
         { name => $jobsetName
-        , description => trim($c->request->params->{"description"})
+        , description => trim($c->stash->{params}->{"description"})
         , nixexprpath => $nixExprPath
         , nixexprinput => $nixExprInput
-        , enabled => defined $c->request->params->{enabled} ? 1 : 0
-        , enableemail => defined $c->request->params->{enableemail} ? 1 : 0
-        , emailoverride => trim($c->request->params->{emailoverride}) || ""
-        , hidden => defined $c->request->params->{visible} ? 0 : 1
-        , keepnr => int(trim($c->request->params->{keepnr})) || 3
-        , checkinterval => int(trim($c->request->params->{checkinterval}))
+        , enabled => defined $c->stash->{params}->{enabled} ? 1 : 0
+        , enableemail => defined $c->stash->{params}->{enableemail} ? 1 : 0
+        , emailoverride => trim($c->stash->{params}->{emailoverride}) || ""
+        , hidden => defined $c->stash->{params}->{visible} ? 0 : 1
+        , keepnr => int(trim($c->stash->{params}->{keepnr})) || 3
+        , checkinterval => int(trim($c->stash->{params}->{checkinterval}))
         , triggertime => $jobset->triggertime // time()
         });
 
-    my %inputNames;
-
     # Process the inputs of this jobset.
-    foreach my $param (keys %{$c->request->params}) {
-        next unless $param =~ /^input-(\w+)-name$/;
-        my $baseName = $1;
-        next if $baseName eq "template";
+    unless (defined $c->stash->{params}->{inputs}) {
+        $c->stash->{params}->{inputs} = {};
+        foreach my $param (keys %{$c->stash->{params}}) {
+            next unless $param =~ /^input-(\w+)-name$/;
+            my $baseName = $1;
+            next if $baseName eq "template";
+            $c->stash->{params}->{inputs}->{$c->stash->{params}->{$param}} = { type => $c->stash->{params}->{"input-$baseName-type"}, values => $c->stash->{params}->{"input-$baseName-values"} };
+            unless ($baseName =~ /^\d+$/) { # non-numeric base name is an existing entry
+                $c->stash->{params}->{inputs}->{$c->stash->{params}->{$param}}->{oldName} = $baseName;
+            }
+        }
+    }
 
-        my ($inputName, $inputType) = checkInput($c, $baseName);
+    foreach my $inputName (keys %{$c->stash->{params}->{inputs}}) {
+        my $inputData = $c->stash->{params}->{inputs}->{$inputName};
+        error($c, "Invalid input name: $inputName") unless $inputName =~ /^[[:alpha:]]\w*$/;
 
-        $inputNames{$inputName} = 1;
+        my $inputType = $inputData->{type};
+        error($c, "Invalid input type: $inputType") unless
+            $inputType eq "svn" || $inputType eq "svn-checkout" || $inputType eq "hg" || $inputType eq "tarball" ||
+            $inputType eq "string" || $inputType eq "path" || $inputType eq "boolean" || $inputType eq "bzr" || $inputType eq "bzr-checkout" ||
+            $inputType eq "git" || $inputType eq "build" || $inputType eq "sysbuild" ;
 
         my $input;
-        if ($baseName =~ /^\d+$/) { # numeric base name is auto-generated, i.e. a new entry
-            $input = $jobset->jobsetinputs->create(
+        unless (defined $inputData->{oldName}) {
+            $input = $jobset->jobsetinputs->update_or_create(
                 { name => $inputName
                 , type => $inputType
                 });
         } else { # it's an existing input
-            $input = ($jobset->jobsetinputs->search({name => $baseName}))[0];
+            $input = ($jobset->jobsetinputs->search({name => $inputData->{oldName}}))[0];
             die unless defined $input;
             $input->update({name => $inputName, type => $inputType});
         }
@@ -242,7 +347,7 @@ sub updateJobset {
         # Update the values for this input.  Just delete all the
         # current ones, then create the new values.
         $input->jobsetinputalts->delete_all;
-        my $values = $c->request->params->{"input-$baseName-values"};
+        my $values = $inputData->{values};
         $values = [] unless defined $values;
         $values = [$values] unless ref($values) eq 'ARRAY';
         my $altnr = 0;
@@ -255,12 +360,12 @@ sub updateJobset {
     # Get rid of deleted inputs.
     my @inputs = $jobset->jobsetinputs->all;
     foreach my $input (@inputs) {
-        $input->delete unless defined $inputNames{$input->name};
+        $input->delete unless defined $c->stash->{params}->{inputs}->{$input->name};
     }
 }
 
 
-sub clone : Chained('jobset') PathPart('clone') Args(0) {
+sub clone : Chained('jobsetChain') PathPart('clone') Args(0) {
     my ($self, $c) = @_;
 
     my $jobset = $c->stash->{jobset};
@@ -270,14 +375,14 @@ sub clone : Chained('jobset') PathPart('clone') Args(0) {
 }
 
 
-sub clone_submit : Chained('jobset') PathPart('clone/submit') Args(0) {
+sub clone_submit : Chained('jobsetChain') PathPart('clone/submit') Args(0) {
     my ($self, $c) = @_;
 
     my $jobset = $c->stash->{jobset};
     requireProjectOwner($c, $jobset->project);
     requirePost($c);
 
-    my $newJobsetName = trim $c->request->params->{"newjobset"};
+    my $newJobsetName = trim $c->stash->{params}->{"newjobset"};
     error($c, "Invalid jobset name: $newJobsetName") unless $newJobsetName =~ /^[[:alpha:]][\w\-]*$/;
 
     my $newJobset;
@@ -304,7 +409,9 @@ sub clone_submit : Chained('jobset') PathPart('clone/submit') Args(0) {
 }
 
 
-sub evals : Chained('jobset') PathPart('evals') Args(0) {
+sub evals :Chained('jobsetChain') :PathPart('evals') :Args(0) :ActionClass('REST') { }
+
+sub evals_GET {
     my ($self, $c) = @_;
 
     $c->stash->{template} = 'evals.tt';
@@ -318,12 +425,45 @@ sub evals : Chained('jobset') PathPart('evals') Args(0) {
     $c->stash->{page} = $page;
     $c->stash->{resultsPerPage} = $resultsPerPage;
     $c->stash->{total} = $evals->search({hasnewbuilds => 1})->count;
-    $c->stash->{evals} = getEvals($self, $c, $evals, ($page - 1) * $resultsPerPage, $resultsPerPage)
+    my $offset = ($page - 1) * $resultsPerPage;
+    $c->stash->{evals} = getEvals($self, $c, $evals, $offset, $resultsPerPage);
+    my %entity = (
+        evals => [ $evals->search({ 'me.hasnewbuilds' => 1 }, {
+                    columns => [
+                        'me.hasnewbuilds',
+                        'me.id',
+                        'jobsetevalinputs.name',
+                        'jobsetevalinputs.altnr',
+                        'jobsetevalinputs.revision',
+                        'jobsetevalinputs.type',
+                        'jobsetevalinputs.uri',
+                        'jobsetevalinputs.dependency',
+                        'jobsetevalmembers.build',
+                    ],
+                    join => [ 'jobsetevalinputs', 'jobsetevalmembers' ],
+                    collapse => 1,
+                    rows => $resultsPerPage,
+                    offset => $offset,
+                    order_by => "me.id DESC",
+                 }) ],
+        first => "?page=1",
+        last => "?page=" . POSIX::ceil($c->stash->{total}/$resultsPerPage)
+    );
+    if ($page > 1) {
+        $entity{previous} = "?page=" . ($page - 1);
+    }
+    if ($page < POSIX::ceil($c->stash->{total}/$resultsPerPage)) {
+        $entity{next} = "?page=" . ($page + 1);
+    }
+    $self->status_ok(
+        $c,
+        entity => \%entity
+    );
 }
 
 
 # Redirect to the latest finished evaluation of this jobset.
-sub latest_eval : Chained('jobset') PathPart('latest-eval') {
+sub latest_eval : Chained('jobsetChain') PathPart('latest-eval') {
     my ($self, $c, @args) = @_;
     my $eval = getLatestFinishedEval($c, $c->stash->{jobset})
         or notFound($c, "No evaluation found.");

--- a/src/lib/Hydra/Controller/Release.pm
+++ b/src/lib/Hydra/Controller/Release.pm
@@ -66,13 +66,13 @@ sub submit : Chained('release') PathPart('submit') Args(0) {
         txn_do($c->model('DB')->schema, sub {
             $c->stash->{release}->delete;
         });
-        $c->res->redirect($c->uri_for($c->controller('Project')->action_for('view'),
+        $c->res->redirect($c->uri_for($c->controller('Project')->action_for('project'),
             [$c->stash->{project}->name]));
     } else {
         txn_do($c->model('DB')->schema, sub {
             updateRelease($c, $c->stash->{release});
         });
-        $c->res->redirect($c->uri_for($self->action_for("view"),
+        $c->res->redirect($c->uri_for($self->action_for("project"),
             [$c->stash->{project}->name, $c->stash->{release}->name]));
     }
 }

--- a/src/lib/Hydra/Controller/View.pm
+++ b/src/lib/Hydra/Controller/View.pm
@@ -118,7 +118,7 @@ sub submit : Chained('view') PathPart('submit') Args(0) {
     requireProjectOwner($c, $c->stash->{project});
     if (($c->request->params->{submit} || "") eq "delete") {
         $c->stash->{view}->delete;
-        $c->res->redirect($c->uri_for($c->controller('Project')->action_for('view'),
+        $c->res->redirect($c->uri_for($c->controller('Project')->action_for('project'),
             [$c->stash->{project}->name]));
     }
     txn_do($c->model('DB')->schema, sub {
@@ -224,7 +224,7 @@ sub result : Chained('view') PathPart('') {
         notFound($c, "View doesn't have a job named ‘$jobName’" . ($system ? " for ‘$system’" : "") . ".")
             unless defined $build;
         error($c, "Job `$jobName' isn't unique.") if @others;
-        return $c->res->redirect($c->uri_for($c->controller('Build')->action_for('view_build'),
+        return $c->res->redirect($c->uri_for($c->controller('Build')->action_for('build'),
             [$build->{build}->id], @args));
     }
 }

--- a/src/lib/Hydra/Helper/CatalystUtils.pm
+++ b/src/lib/Hydra/Helper/CatalystUtils.pm
@@ -202,7 +202,7 @@ sub sendEmail {
 # always returns a request parameter as a list.
 sub paramToList {
     my ($c, $name) = @_;
-    my $x = $c->request->params->{$name};
+    my $x = $c->stash->{params}->{$name};
     return () unless defined $x;
     return @$x if ref($x) eq 'ARRAY';
     return ($x);

--- a/src/lib/Hydra/Schema/BuildInputs.pm
+++ b/src/lib/Hydra/Schema/BuildInputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<BuildInputs>
 
 =cut
@@ -156,7 +168,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:byU/SLN03zNJlSFbi/3Bcg
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:tKZAybbNaRIMs9n5tHkqPw
 
 1;

--- a/src/lib/Hydra/Schema/BuildOutputs.pm
+++ b/src/lib/Hydra/Schema/BuildOutputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<BuildOutputs>
 
 =cut
@@ -82,8 +94,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-30 16:22:11
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UpVoKdd3OwMvlvyMjcYNVA
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:V8MbzKvZNEaeHBJV67+ZMQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/BuildProducts.pm
+++ b/src/lib/Hydra/Schema/BuildProducts.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<BuildProducts>
 
 =cut
@@ -138,8 +150,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:KHwh/Np40jxKXc3ijMImEQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+0LkZiaRL5tGJvbLxnwD/g
 
 # You can replace this text with custom content, and it will be preserved on regeneration
 1;

--- a/src/lib/Hydra/Schema/BuildStepOutputs.pm
+++ b/src/lib/Hydra/Schema/BuildStepOutputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<BuildStepOutputs>
 
 =cut
@@ -107,8 +119,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-30 16:22:11
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:dC1yX7arRVu9K3wG9dAjCg
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:A/4v3ugXYbuYoKPlOvC6mg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/BuildSteps.pm
+++ b/src/lib/Hydra/Schema/BuildSteps.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<BuildSteps>
 
 =cut
@@ -154,7 +166,7 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-30 16:36:03
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZiA1nv73Fpp0/DTi4sLfEQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OZsXJniZ/7EB2iSz7p5y4A
 
 1;

--- a/src/lib/Hydra/Schema/Builds.pm
+++ b/src/lib/Hydra/Schema/Builds.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<Builds>
 
 =cut
@@ -457,8 +469,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-05-03 14:35:11
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aYVEk+AeDsgTRi5GAqOhEw
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:isCEXACY/PwkvgKHcXvAIg
 
 __PACKAGE__->has_many(
   "dependents",

--- a/src/lib/Hydra/Schema/CachedBazaarInputs.pm
+++ b/src/lib/Hydra/Schema/CachedBazaarInputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<CachedBazaarInputs>
 
 =cut
@@ -71,8 +83,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "revision");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07014 @ 2011-12-05 14:15:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ONhBo6Xhq7uwYFdEzbp3dg
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zvun8uhxwrr7B8EsqBoCjA
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/CachedCVSInputs.pm
+++ b/src/lib/Hydra/Schema/CachedCVSInputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<CachedCVSInputs>
 
 =cut
@@ -87,8 +99,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "module", "sha256hash");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07014 @ 2011-12-05 14:15:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:IcSVN/tlfQQtX88Ix+aKnw
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Vi1qzjW52Lnsl0JSmGzy0w
 
 # You can replace this text with custom content, and it will be preserved on regeneration
 1;

--- a/src/lib/Hydra/Schema/CachedGitInputs.pm
+++ b/src/lib/Hydra/Schema/CachedGitInputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<CachedGitInputs>
 
 =cut
@@ -80,7 +92,7 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "branch", "revision");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07014 @ 2011-12-05 14:15:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:fx3yosWMmJ+MnvL/dSWtFA
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:I4hI02FKRMkw76WV/KBocA
 
 1;

--- a/src/lib/Hydra/Schema/CachedHgInputs.pm
+++ b/src/lib/Hydra/Schema/CachedHgInputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<CachedHgInputs>
 
 =cut
@@ -80,8 +92,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "branch", "revision");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07014 @ 2011-12-05 14:15:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:xFLnuCBAcJCg+N3b4aajZQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qS/eiiZXmpc7KpTHdtaT7g
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/CachedPathInputs.pm
+++ b/src/lib/Hydra/Schema/CachedPathInputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<CachedPathInputs>
 
 =cut
@@ -78,7 +90,7 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("srcpath", "sha256hash");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07014 @ 2011-12-05 14:15:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4KzXhMnUldVgNuuNXWIYjw
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:28rja0vR1glJJ15hzVfjsQ
 
 1;

--- a/src/lib/Hydra/Schema/CachedSubversionInputs.pm
+++ b/src/lib/Hydra/Schema/CachedSubversionInputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<CachedSubversionInputs>
 
 =cut
@@ -71,7 +83,7 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "revision");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07014 @ 2011-12-05 14:15:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1rjwWtZXGEowHqhfjLqjmA
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3qXfnvkOVj25W94bfhQ65w
 
 1;

--- a/src/lib/Hydra/Schema/Jobs.pm
+++ b/src/lib/Hydra/Schema/Jobs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<Jobs>
 
 =cut
@@ -126,7 +138,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-05-23 16:09:46
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:JgxEaCz/TW9YKa+HavRzXw
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:t2CCfUjFEz/lO4szROz1AQ
 
 1;

--- a/src/lib/Hydra/Schema/JobsetEvalInputs.pm
+++ b/src/lib/Hydra/Schema/JobsetEvalInputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<JobsetEvalInputs>
 
 =cut
@@ -154,8 +166,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ng+Q6tMX5EJMD7DxRWVy7Q
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1Dp8B58leBLh4GK0GPw2zg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/JobsetEvalMembers.pm
+++ b/src/lib/Hydra/Schema/JobsetEvalMembers.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<JobsetEvalMembers>
 
 =cut
@@ -98,8 +110,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:EVwSR9WBqbBdIHq1ANQMHg
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ccPNQe/QnSjTAC3uGWe8Ng
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/JobsetEvals.pm
+++ b/src/lib/Hydra/Schema/JobsetEvals.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<JobsetEvals>
 
 =cut
@@ -176,8 +188,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qElGj6zzuI0xo426np3r1w
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SlEiF8oN6FBK262uSiMKiw
 
 __PACKAGE__->has_many(
   "buildIds",

--- a/src/lib/Hydra/Schema/JobsetInputAlts.pm
+++ b/src/lib/Hydra/Schema/JobsetInputAlts.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<JobsetInputAlts>
 
 =cut
@@ -109,7 +121,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:M3pNBRLfxgSScrPj1zaajA
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UUO37lIuEYm0GiR92m/fyA
 
 1;

--- a/src/lib/Hydra/Schema/JobsetInputs.pm
+++ b/src/lib/Hydra/Schema/JobsetInputs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<JobsetInputs>
 
 =cut
@@ -130,7 +142,7 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:xjioYUPo6visoLAVDkDZ0Q
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UXBzqO0vHPql4LYyXpgEQg
 
 1;

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<Jobsets>
 
 =cut
@@ -260,7 +272,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-05-02 14:50:55
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:q4amPCWRoWMThnRa/n/y1w
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:tsGR8MhZRIUeNwpcVczMUw
 
 1;

--- a/src/lib/Hydra/Schema/NewsItems.pm
+++ b/src/lib/Hydra/Schema/NewsItems.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<NewsItems>
 
 =cut
@@ -88,7 +100,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:lnA5Utkwk5WTyKA/M5mlyg
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3CRNsvd+YnZp9c80tuZREQ
 
 1;

--- a/src/lib/Hydra/Schema/ProjectMembers.pm
+++ b/src/lib/Hydra/Schema/ProjectMembers.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<ProjectMembers>
 
 =cut
@@ -91,8 +103,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zW87n6E7xWaShcFbgFkVuw
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:imPoiaitrTbX0vVNlF6dPA
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/Projects.pm
+++ b/src/lib/Hydra/Schema/Projects.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<Projects>
 
 =cut
@@ -255,8 +267,8 @@ Composing rels: L</projectmembers> -> username
 __PACKAGE__->many_to_many("usernames", "projectmembers", "username");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OCuhmxs8pZxvmk81eVLLcQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:RffghAo9jAaqYk41y1Sdqw
 # These lines were loaded from '/home/rbvermaa/src/hydra/src/lib/Hydra/Schema/Projects.pm' found in @INC.
 # They are now part of the custom portion of this file
 # for you to hand-edit.  If you do not either delete

--- a/src/lib/Hydra/Schema/ReleaseMembers.pm
+++ b/src/lib/Hydra/Schema/ReleaseMembers.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<ReleaseMembers>
 
 =cut
@@ -123,7 +135,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eP00w5UJp1uTtiB7D5IhTQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:7M7WPlGQT6rNHKJ+82/KSA
 
 1;

--- a/src/lib/Hydra/Schema/Releases.pm
+++ b/src/lib/Hydra/Schema/Releases.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<Releases>
 
 =cut
@@ -107,7 +119,7 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UTUE3Hb89fT7prwnwwBgvQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qISBiwvboB8dIdinaE45mg
 
 1;

--- a/src/lib/Hydra/Schema/SchemaVersion.pm
+++ b/src/lib/Hydra/Schema/SchemaVersion.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<SchemaVersion>
 
 =cut
@@ -33,8 +45,8 @@ __PACKAGE__->table("SchemaVersion");
 __PACKAGE__->add_columns("version", { data_type => "integer", is_nullable => 0 });
 
 
-# Created by DBIx::Class::Schema::Loader v0.07014 @ 2012-02-29 00:47:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:LFD28W0GvvrOOylCM98SEQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:08/7gbEQp1TqBiWFJXVY0w
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/SystemTypes.pm
+++ b/src/lib/Hydra/Schema/SystemTypes.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<SystemTypes>
 
 =cut
@@ -56,7 +68,7 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("system");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07014 @ 2011-12-05 14:15:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zg8db3Cbi0QOv+gLJqH8cQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:8cC34cEw9T3+x+7uRs4KHQ
 
 1;

--- a/src/lib/Hydra/Schema/UriRevMapper.pm
+++ b/src/lib/Hydra/Schema/UriRevMapper.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<UriRevMapper>
 
 =cut
@@ -55,8 +67,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("baseuri");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07014 @ 2011-12-05 14:15:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hzKzGAgAiCfU0nBOiDnjWw
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:G2GAF/Rb7cRkRegH94LwIA
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/UserRoles.pm
+++ b/src/lib/Hydra/Schema/UserRoles.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<UserRoles>
 
 =cut
@@ -75,7 +87,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:KArPHyemtnm/siwE4x5mGQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aS+ivlFpndqIv8U578zz9A
 
 1;

--- a/src/lib/Hydra/Schema/Users.pm
+++ b/src/lib/Hydra/Schema/Users.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<Users>
 
 =cut
@@ -149,8 +161,8 @@ Composing rels: L</projectmembers> -> project
 __PACKAGE__->many_to_many("projects", "projectmembers", "project");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OAUFl/teGpfeleb6D8FPlw
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hy3MKvFxfL+1bTc7Hcb1zA
 # These lines were loaded from '/home/rbvermaa/src/hydra/src/lib/Hydra/Schema/Users.pm' found in @INC.
 # They are now part of the custom portion of this file
 # for you to hand-edit.  If you do not either delete

--- a/src/lib/Hydra/Schema/ViewJobs.pm
+++ b/src/lib/Hydra/Schema/ViewJobs.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<ViewJobs>
 
 =cut
@@ -139,7 +151,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:cbSUw113ENPypbd/sICfgg
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hz912vBfYw0rHslBPqJW2w
 
 1;

--- a/src/lib/Hydra/Schema/Views.pm
+++ b/src/lib/Hydra/Schema/Views.pm
@@ -15,6 +15,18 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
 =head1 TABLE: C<Views>
 
 =cut
@@ -105,7 +117,7 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-01-22 13:29:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Vyd2+0RAF3XGTpq3KswfAQ
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:U23GZ3k5KZk2go6j2LYLHA
 
 1;

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -9,6 +9,7 @@ PERL_MODULES =					\
   $(wildcard Hydra/Base/*.pm)			\
   $(wildcard Hydra/Base/Controller/*.pm) 	\
   $(wildcard Hydra/Script/*.pm)			\
+  $(wildcard Hydra/Component/*.pm)		\
   $(wildcard Hydra/Plugin/*.pm)
 
 EXTRA_DIST = \

--- a/src/root/queue.tt
+++ b/src/root/queue.tt
@@ -7,7 +7,7 @@
 
 [% ELSE %]
 
-  [% INCLUDE renderBuildList builds=queue showSchedulingInfo=1 hideResultInfo=1 %]
+  [% INCLUDE renderBuildList builds=resource showSchedulingInfo=1 hideResultInfo=1 %]
 
 [% END %]
 

--- a/src/root/status.tt
+++ b/src/root/status.tt
@@ -6,7 +6,7 @@
     <tr><th>Machine</th><th>Job</th><th>Type</th><th>Build</th><th>Step</th><th>What</th><th>Since</th></tr>
   </thead>
   <tbody>
-    [% FOREACH step IN steps %]
+    [% FOREACH step IN resource %]
       <tr>
         <td><tt>[% IF step.machine; step.machine.match('@(.*)').0; ELSE; 'localhost'; END %]</tt></td>
         <td><tt>[% INCLUDE renderFullJobName project = step.build.project.name jobset = step.build.jobset.name job = step.build.job.name %]</tt></td>

--- a/src/root/topbar.tt
+++ b/src/root/topbar.tt
@@ -37,7 +37,7 @@
     [% WRAPPER makeSubMenu title="Project"  %]
       <li class="nav-header">[% HTML.escape(project.name) %]</li>
       <li class="divider"></li>
-      [% INCLUDE menuItem uri = c.uri_for(c.controller('Project').action_for('view'), [project.name]) title = "Overview" %]
+      [% INCLUDE menuItem uri = c.uri_for(c.controller('Project').action_for('project'), [project.name]) title = "Overview" %]
       [% INCLUDE menuItem uri = c.uri_for(c.controller('Project').action_for('all'), [project.name]) title = "Latest builds" %]
       [% INCLUDE menuItem uri = c.uri_for(c.controller('Project').action_for('jobstatus'), [project.name]) title = "Job status" %]
       [% INCLUDE menuItem uri = c.uri_for(c.controller('Project').action_for('errors'), [project.name]) title = "Errors" %]
@@ -56,7 +56,7 @@
       <li class="nav-header">[% HTML.escape(jobset.name) %]</li>
       <li class="divider"></li>
       [% INCLUDE menuItem
-        uri = c.uri_for(c.controller('Jobset').action_for('index'), [project.name, jobset.name])
+        uri = c.uri_for(c.controller('Jobset').action_for('jobset'), [project.name, jobset.name])
         title = "Overview" %]
       [% INCLUDE menuItem
         uri = c.uri_for(c.controller('Jobset').action_for('evals'), [project.name, jobset.name])

--- a/src/sql/Makefile.am
+++ b/src/sql/Makefile.am
@@ -16,4 +16,4 @@ hydra-sqlite.sql: hydra.sql
 update-dbix: hydra-sqlite.sql
 	rm -f tmp.sqlite
 	sqlite3 tmp.sqlite < hydra-sqlite.sql
-	perl -MDBIx::Class::Schema::Loader=make_schema_at,dump_to_dir:../lib -e 'make_schema_at("Hydra::Schema", { naming => { ALL => "v5" }, relationships => 1, moniker_map => sub {return "$$_";} }, ["dbi:SQLite:tmp.sqlite"])'
+	perl -I ../lib -MDBIx::Class::Schema::Loader=make_schema_at,dump_to_dir:../lib -e 'make_schema_at("Hydra::Schema", { naming => { ALL => "v5" }, relationships => 1, moniker_map => sub {return "$$_";}, components => [ "+Hydra::Component::ToJSON" ], }, ["dbi:SQLite:tmp.sqlite"])'

--- a/tests/api-test.nix
+++ b/tests/api-test.nix
@@ -1,0 +1,12 @@
+let
+  builder = builtins.toFile "builder.sh" ''
+    echo -n ${builtins.readFile ./default.nix} > $out
+  '';
+in {
+  job = derivation {
+    name = "job";
+    system = builtins.currentSystem;
+    builder = "/bin/sh";
+    args = [ builder ];
+  };
+}

--- a/tests/api-test.pl
+++ b/tests/api-test.pl
@@ -1,0 +1,63 @@
+use LWP::UserAgent;
+use JSON;
+use Test::Simple tests => 15;
+
+my $ua = LWP::UserAgent->new;
+$ua->cookie_jar({});
+
+sub request_json {
+    my ($opts) = @_;
+    my $req = HTTP::Request->new;
+    $req->method($opts->{method} or "GET");
+    $req->uri("http://localhost:3000$opts->{uri}");
+    $req->header(Accept => "application/json");
+    $req->content(encode_json($opts->{data})) if defined $opts->{data};
+    my $res = $ua->request($req);
+    print $res->as_string();
+    return $res;
+}
+
+my $result = request_json({ uri => "/login", method => "POST", data => { username => "root", password => "foobar" } });
+
+my $user = decode_json($result->content());
+
+ok($user->{username} eq "root", "The root user is named root");
+ok($user->{userroles}->[0]->{role} eq "admin", "The root user is an admin");
+
+$user = decode_json(request_json({ uri => "/current-user" })->content());
+ok($user->{username} eq "root", "The current user is named root");
+ok($user->{userroles}->[0]->{role} eq "admin", "The current user is an admin");
+
+ok(request_json({ uri => '/project/sample' })->code() == 404, "Non-existent projects don't exist");
+
+$result = request_json({ uri => '/project/sample', method => 'PUT', data => { displayname => "Sample", enabled => "1", } });
+ok($result->code() == 201, "PUTting a new project creates it");
+
+my $project = decode_json(request_json({ uri => '/project/sample' })->content());
+
+ok((not @{$project->{jobsets}}), "A new project has no jobsets");
+
+$result = request_json({ uri => '/jobset/sample/default', method => 'PUT', data => { nixexprpath => "default.nix", nixexprinput => "src", inputs => { src => { type => "path", values => "/run/jobset" } }, enabled => "1", checkinterval => "3600"} });
+ok($result->code() == 201, "PUTting a new jobset creates it");
+
+my $jobset = decode_json(request_json({ uri => '/jobset/sample/default' })->content());
+
+ok($jobset->{jobsetinputs}->[0]->{name} eq "src", "The new jobset has an 'src' input");
+ok($jobset->{jobsetinputs}->[0]->{jobsetinputalts}->[0]->{value} eq "/run/jobset", "The 'src' input is in /run/jobset");
+
+system("LOGNAME=root NIX_STORE_DIR=/run/nix/store NIX_LOG_DIR=/run/nix/var/log/nix NIX_STATE_DIR=/run/nix/var/nix HYDRA_DATA=/var/lib/hydra HYDRA_DBI='dbi:Pg:dbname=hydra;user=root;' hydra-evaluator sample default");
+$result = request_json({ uri => '/jobset/sample/default/evals' });
+ok($result->code() == 200, "Can get evals of a jobset");
+my $evals = decode_json($result->content())->{evals};
+my $eval = $evals->[0];
+ok($eval->{hasnewbuilds} == 1, "The first eval of a jobset has new builds");
+
+# Ugh, cached for 30s
+sleep 30;
+system("echo >> /run/jobset/default.nix; LOGNAME=root NIX_STORE_DIR=/run/nix/store NIX_LOG_DIR=/run/nix/var/log/nix NIX_STATE_DIR=/run/nix/var/nix HYDRA_DATA=/var/lib/hydra HYDRA_DBI='dbi:Pg:dbname=hydra;user=root;' hydra-evaluator sample default");
+my $evals = decode_json(request_json({ uri => '/jobset/sample/default/evals' })->content())->{evals};
+ok($evals->[0]->{jobsetevalinputs}->[0]->{revision} != $evals->[1]->{jobsetevalinputs}->[0]->{revision}, "Changing a jobset source changes its revision");
+
+my $build = decode_json(request_json({ uri => "/build/" . $evals->[0]->{jobsetevalmembers}->[0]->{build} })->content());
+ok($build->{job} eq "job", "The build's job name is job");
+ok($build->{finished} == 0, "The build isn't finished yet");


### PR DESCRIPTION
The catalyst-action-rest branch from shlevy/hydra was an exploration of
using Catalyst::Action::REST to create a JSON API for hydra. This commit
merges in the best bits from that experiment, with the goal that further
API endpoints can be added incrementally.

In addition to migrating more endpoints, there is potential for
improvement in what's already been done:
- The web interface can be updated to use the same non-GET endpoints as
  the JSON interface (using x-tunneled-method) instead of having a
  separate endpoint
- The web rendering should use the $c->stash->{resource} data structure
  where applicable rather than putting the same data in two places in
  the stash
- Which columns to render for each endpoint is a completely debatable
  question
- Hydra::Component::ToJSON should turn has_many relations that have
  strings as their primary keys into objects instead of arrays

Fixes NixOS/hydra#98

Signed-off-by: Shea Levy shea@shealevy.com
