### PR TITLE
hydra-module: Allow to specify the listen host.

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -64,6 +64,15 @@ in
         '';
       };
 
+      listenHost = mkOption {
+        default = "*";
+        example = "localhost";
+        description = ''
+          The hostname or address to listen on or <literal>*</literal> to listen
+          on all interfaces.
+        '';
+      };
+
       port = mkOption {
         default = 3000;
         description = ''
@@ -195,7 +204,7 @@ in
         after = [ "hydra-init.service" ];
         environment = serverEnv;
         serviceConfig =
-          { ExecStart = "@${cfg.hydra}/bin/hydra-server hydra-server -f -h \* --max_spare_servers 5 --max_servers 25 --max_requests 100${optionalString cfg.debugServer " -d"}";
+          { ExecStart = "@${cfg.hydra}/bin/hydra-server hydra-server -f -h '${cfg.listenHost}' --max_spare_servers 5 --max_servers 25 --max_requests 100${optionalString cfg.debugServer " -d"}";
             User = "hydra";
             Restart = "always";
           };


### PR DESCRIPTION
It's currently possible to specify the port but not the address or interface you want to listen on. This should be fixed by this commit.
