### PR TITLE
templates: Use uri_for to reference static paths.

### DIFF
--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -402,8 +402,8 @@
       <div id="placeholder" style="width:800px;height:400px;"></div>
       <div id="overview" style="margin-left:50px;margin-top:20px;width:600px;height:50px"></div>
 
-      <script src="/static/js/flot/jquery.flot.js" type="text/javascript"></script>
-      <script src="/static/js/flot/jquery.flot.selection.js" type="text/javascript"></script>
+      <script src="[% c.uri_for("/static/js/flot/jquery.flot.js") %]" type="text/javascript"></script>
+      <script src="[% c.uri_for("/static/js/flot/jquery.flot.selection.js") %]" type="text/javascript"></script>
       <script type="text/javascript">
         $(function() {
           var d = [];

--- a/src/root/clone-build.tt
+++ b/src/root/clone-build.tt
@@ -44,7 +44,7 @@
     </tbody>
   </table>
 
-  <p><button type="submit"><img alt="Add" src="/static/images/success.gif" />Add to queue</button></p>
+  <p><button type="submit"><img alt="Add" src="[% c.uri_for("/static/images/success.gif") %]" />Add to queue</button></p>
 
 </form>
 

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -195,24 +195,24 @@ BLOCK renderBuildStatusIcon;
   buildstatus = buildstatus != undef ? buildstatus : build.buildstatus;
   IF finished;
     IF buildstatus == 0 %]
-      <img src="/static/images/checkmark_[% size %].png" alt="Succeeded" />
+      <img src="[% c.uri_for("/static/images/checkmark_${size}.png") %]" alt="Succeeded" />
     [% ELSIF buildstatus == 1 %]
-      <img src="/static/images/error_[% size %].png" alt="Failed" />
+      <img src="[% c.uri_for("/static/images/error_${size}.png") %]" alt="Failed" />
     [% ELSIF buildstatus == 2 || buildstatus == 5 %]
-      <img src="/static/images/dependency_[% size %].png" alt="Dependency failed" />
+      <img src="[% c.uri_for("/static/images/dependency_${size}.png") %]" alt="Dependency failed" />
     [% ELSIF buildstatus == 3 %]
-      <img src="/static/images/warning_[% size %].png" alt="Aborted" />
+      <img src="[% c.uri_for("/static/images/warning_${size}.png") %]" alt="Aborted" />
     [% ELSIF buildstatus == 4 %]
-      <img src="/static/images/forbidden_[% size %].png" alt="Cancelled" />
+      <img src="[% c.uri_for("/static/images/forbidden_${size}.png") %]" alt="Cancelled" />
     [% ELSIF buildstatus == 6 %]
-      <img src="/static/images/error_[% size %].png" alt="Failed (with result)" />
+      <img src="[% c.uri_for("/static/images/error_${size}.png") %]" alt="Failed (with result)" />
     [% ELSE %]
-      <img src="/static/images/error_[% size %].png" alt="Failed" />
+      <img src="[% c.uri_for("/static/images/error_${size}.png") %]" alt="Failed" />
     [% END;
   ELSIF busy %]
-    <img src="/static/images/help_[% size %].png" alt="Busy" />
+    <img src="[% c.uri_for("/static/images/help_${size}.png") %]" alt="Busy" />
   [% ELSE %]
-    <img src="/static/images/help_[% size %].png" alt="Scheduled" />
+    <img src="[% c.uri_for("/static/images/help_${size}.png") %]" alt="Scheduled" />
   [% END;
 END;
 
@@ -456,7 +456,7 @@ BLOCK renderLogLinks %]
 
 BLOCK makeLazyTab %]
   <div id="[% tabName %]" class="tab-pane">
-    <center><img src="/static/images/ajax-loader.gif" alt="Loading..." /></center>
+    <center><img src="[% c.uri_for("/static/images/ajax-loader.gif") %]" alt="Loading..." /></center>
   </div>
   <script>
     $(function() { makeLazyTab("[% tabName %]", "[% uri %]"); });

--- a/src/root/jobset-jobs-tab.tt
+++ b/src/root/jobset-jobs-tab.tt
@@ -6,7 +6,7 @@
     <button type="button" class="btn btn-info [% IF showInactive %]active[% END %]" id="active-toggle">Show inactive jobs</button>
   </div>
   &nbsp;
-  <img src="/static/images/ajax-loader.gif" alt="Loading..." style="display: none;" id="filter-loading" />
+  <img src="[% c.uri_for("/static/images/ajax-loader.gif") %]" alt="Loading..." style="display: none;" id="filter-loading" />
 </form>
 
 <script>

--- a/src/root/layout.tt
+++ b/src/root/layout.tt
@@ -15,25 +15,25 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <script type="text/javascript" src="/static/bootstrap/js/bootstrap.min.js"></script>
-    <link href="/static/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
+    <script type="text/javascript" src="[% c.uri_for("/static/bootstrap/js/bootstrap.min.js") %]"></script>
+    <link href="[% c.uri_for("/static/bootstrap/css/bootstrap.min.css") %]" rel="stylesheet" />
 
     <!-- hydra.css must be included before bootstrap-responsive to
          make the @media rule work. -->
-    <link rel="stylesheet" href="/static/css/hydra.css" type="text/css" />
-    <link rel="stylesheet" href="/static/css/rotated-th.css" type="text/css" />
-    <link href="/static/bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="[% c.uri_for("/static/css/hydra.css") %]" type="text/css" />
+    <link rel="stylesheet" href="[% c.uri_for("/static/css/rotated-th.css") %]" type="text/css" />
+    <link href="[% c.uri_for("/static/bootstrap/css/bootstrap-responsive.min.css") %]" rel="stylesheet" />
 
     <style>
       .popover { max-width: 40%; }
     </style>
 
-    <script type="text/javascript" src="/static/js/bootbox.min.js"></script>
+    <script type="text/javascript" src="[% c.uri_for("/static/js/bootbox.min.js") %]"></script>
 
-    <link rel="stylesheet" href="/static/css/tree.css" type="text/css" />
-    <link rel="stylesheet" href="/static/css/logfile.css" type="text/css" />
+    <link rel="stylesheet" href="[% c.uri_for("/static/css/tree.css") %]" type="text/css" />
+    <link rel="stylesheet" href="[% c.uri_for("/static/css/logfile.css") %]" type="text/css" />
 
-    <script type="text/javascript" src="/static/js/common.js"></script>
+    <script type="text/javascript" src="[% c.uri_for("/static/js/common.js") %]"></script>
 
     [% tracker %]
 

--- a/src/root/product-list.tt
+++ b/src/root/product-list.tt
@@ -40,7 +40,7 @@
           <tr class="product">
             <td>
             <a href="[% contents %]">
-              <img src="/static/images/error_32.png" alt="Source" />
+              <img src="[% c.uri_for("/static/images/error_32.png") %]" alt="Source" />
               Failed build produced output. Click here to inspect the output.
             </a>
             [% WRAPPER makePopover title="Help" classes="btn-mini" %]
@@ -59,7 +59,7 @@
             <td>
             [% uri = c.uri_for('/build' build.id 'nix' 'pkg' "${build.nixname}-${build.system}.nixpkg") %]
             <a href="[% uri %]">
-              <img src="/static/images/nix-build.png" alt="Source" />
+              <img src="[% c.uri_for("/static/images/nix-build.png") %]" alt="Source" />
               One-click install of Nix package <tt>[% build.nixname %]</tt>
             </a>
             [% WRAPPER makePopover title="Help" classes="btn-mini" %]
@@ -87,7 +87,7 @@
             [% uri = c.uri_for('/build' build.id 'nix' 'closure' filename ) %]
 
             <a href="[% uri %]">
-              <img src="/static/images/nix-build.png" alt="Source" />
+              <img src="[% c.uri_for("/static/images/nix-build.png") %]" alt="Source" />
               Nix closure of path <tt>[% product.path %]</tt>
             </a>
 
@@ -127,17 +127,17 @@
         <a href="[% uri %]">
           [% SWITCH product.subtype %]
           [% CASE "source-dist" %]
-            <img src="/static/images/source-dist.png" alt="Source" /> Source distribution <tt>[% product.name %]</tt>
+            <img src="[% c.uri_for("/static/images/source-dist.png") %]" alt="Source" /> Source distribution <tt>[% product.name %]</tt>
           [% CASE "rpm" %]
-            <img src="/static/images/rpm.png" alt="RPM" /> RPM package <tt>[% product.name %]</tt>
+            <img src="[% c.uri_for("/static/images/rpm.png") %]" alt="RPM" /> RPM package <tt>[% product.name %]</tt>
           [% CASE "srpm" %]
-            <img src="/static/images/rpm.png" alt="Source RPM" /> Source RPM package <tt>[% product.name %]</tt>
+            <img src="[% c.uri_for("/static/images/rpm.png") %]" alt="Source RPM" /> Source RPM package <tt>[% product.name %]</tt>
           [% CASE "deb" %]
-            <img src="/static/images/debian.png" alt="RPM" /> Debian package <tt>[% product.name %]</tt>
+            <img src="[% c.uri_for("/static/images/debian.png") %]" alt="RPM" /> Debian package <tt>[% product.name %]</tt>
           [% CASE "iso" %]
-            <img src="/static/images/iso.png" alt="ISO" /> ISO-9660 CD/DVD image <tt>[% product.name %]</tt>
+            <img src="[% c.uri_for("/static/images/iso.png") %]" alt="ISO" /> ISO-9660 CD/DVD image <tt>[% product.name %]</tt>
           [% CASE "binary-dist" %]
-            <img src="/static/images/binary-dist.png" alt="Binary distribution" /> Binary distribution <tt>[% product.name %]</tt>
+            <img src="[% c.uri_for("/static/images/binary-dist.png") %]" alt="Binary distribution" /> Binary distribution <tt>[% product.name %]</tt>
           [% CASE DEFAULT %]
             File <tt>[% product.name %]</tt> of type <tt>[% product.subtype %]</tt>
           [% END %]
@@ -160,7 +160,7 @@
       <tr class="product">
         <td>
         <a href="[% uri %]">
-          <img src="/static/images/report.png" alt="Report" />
+          <img src="[% c.uri_for("/static/images/report.png") %]" alt="Report" />
           [% SWITCH product.subtype %]
           [% CASE "coverage" %]
             Code coverage analysis report
@@ -177,9 +177,9 @@
         <td>
         <a href="[% uri %]">
           [% IF product.type == "doc-pdf" %]
-            <img src="/static/images/pdf.png" alt="PDF document" />
+            <img src="[% c.uri_for("/static/images/pdf.png") %]" alt="PDF document" />
           [% ELSE %]
-            <img src="/static/images/document.png" alt="Document" />
+            <img src="[% c.uri_for("/static/images/document.png") %]" alt="Document" />
           [% END %]
           [% SWITCH product.subtype %]
           [% CASE "readme" %]

--- a/src/root/project.tt
+++ b/src/root/project.tt
@@ -32,13 +32,13 @@
             <tr>
               <td>
                 [% IF j.get_column('nrscheduled') > 0 %]
-                  <img src="/static/images/help_16.png" alt="Scheduled" />
+                  <img src="[% c.uri_for("/static/images/help_16.png") %]" alt="Scheduled" />
                 [% ELSIF j.get_column('nrfailed') == 0  %]
-                  <img src="/static/images/checkmark_16.png" alt="Succeeded" />
+                  <img src="[% c.uri_for("/static/images/checkmark_16.png") %]" alt="Succeeded" />
                 [% ELSIF j.get_column('nrfailed') > 0 && j.get_column('nrsucceeded') > 0 %]
-                  <img src="/static/images/error_some_16.png" alt="Some Failed" />
+                  <img src="[% c.uri_for("/static/images/error_some_16.png") %]" alt="Some Failed" />
                 [% ELSE %]
-                  <img src="/static/images/error_16.png" alt="All Failed" />
+                  <img src="[% c.uri_for("/static/images/error_16.png") %]" alt="All Failed" />
                 [% END %]
               </td>
               <td><span class="[% IF !j.enabled %]disabled-jobset[% END %] [%+ IF j.hidden %]hidden-jobset[% END %]">[% INCLUDE renderJobsetName project=project.name jobset=j.name inRow=1 %]</span></td>

--- a/src/root/view.tt
+++ b/src/root/view.tt
@@ -27,11 +27,11 @@
       <tr>
         <td>
           [% IF result.status == 0 %]
-            <img src="/static/images/checkmark_16.png" />
+            <img src="[% c.uri_for("/static/images/checkmark_16.png") %]" />
           [% ELSIF result.status == 1 %]
-            <img src="/static/images/error_16.png" />
+            <img src="[% c.uri_for("/static/images/error_16.png") %]" />
           [% ELSIF result.status == 2 %]
-            <img src="/static/images/help_16.png" />
+            <img src="[% c.uri_for("/static/images/help_16.png") %]" />
           [% END %]
         </td>
         <td><a class="row-link" href="[% c.uri_for('/view' project.name view.name result.id) %]">[% result.id %]</a></td>
@@ -48,9 +48,9 @@
             [% IF j.build %]
               <a href="[% c.uri_for('/build' j.build.id) %]">
                 [% IF j.build.get_column('buildstatus') == 0 %]
-                  <img src="/static/images/checkmark_16.png" />
+                  <img src="[% c.uri_for("/static/images/checkmark_16.png") %]" />
                 [% ELSE %]
-                  <img src="/static/images/error_16.png" />
+                  <img src="[% c.uri_for("/static/images/error_16.png") %]" />
                 [% END %]
               </a>
             [% END %]


### PR DESCRIPTION
This change is essentially provided by (`**/*.t` is Zsh syntax and something like a `find -name '*.t'`):

``` sh
sed -i 's|/static[^"]*|[% c.uri_for("&") %]|;s/\[% size %\]/${size}/' **/*.tt
```

And the reason for this change is to make it easier to change the base path with headers like X-Request-Base to be served within a URI prefix, especially when behind a reverse proxy.
