### PR TITLE
hydra-module: Avoid creating /root/r in compressLogs cronjob

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -270,9 +270,10 @@ in
           '';
 
         compressLogs = pkgs.writeScript "compress-logs" ''
-            #! ${pkgs.stdenv.shell} -e
-           touch -d 'last month' r
-           find /nix/var/log/nix/drvs -type f -a ! -newer r -name '*.drv' | xargs bzip2 -v
+           #! ${pkgs.stdenv.shell} -e
+           find /nix/var/log/nix/drvs \
+                -type f -a ! -newermt 'last month' \
+                -name '*.drv' -exec bzip2 -v {} +
          '';
       in
         [ "*/5 * * * * root  ${checkSpace} &> ${baseDir}/data/checkspace.log"


### PR DESCRIPTION
We really don't need to touch a file in the current working directory to find files that are older than one month. Since findutils 4.3.3 there is a `-newerXY` option which allows to specify timestamps directly (as with `date --date`).

But even when using a reference file, it really causes confusion if people look into `/root` and try to debug where that misterious `r` file is coming from.
