### PR TITLE
hydra-module: Don't rely on su being available in shadow.

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -184,7 +184,7 @@ in
         requires = [ "postgresql.service" ];
         after = [ "postgresql.service" ];
         environment = env;
-        script = ''
+        preStart = ''
           mkdir -m 0700 -p ${baseDir}/data
           chown hydra ${baseDir}/data
           ln -sf ${hydraConf} ${baseDir}/data/hydra.conf
@@ -195,8 +195,9 @@ in
               touch ${baseDir}/.db-created
             fi
           ''}
-          ${pkgs.shadow}/bin/su hydra -c ${cfg.package}/bin/hydra-init
         '';
+        serviceConfig.ExecStart = "${cfg.package}/bin/hydra-init";
+        serviceConfig.User = "hydra";
         serviceConfig.Type = "oneshot";
         serviceConfig.RemainAfterExit = true;
       };


### PR DESCRIPTION
The `su` binary is now in a separate output of the `shadow` package and isn't included in the main output path anymore.

But instead of changing the call to use `pkgs.su`, we're now entirely dropping the dependency because systemd is already able to execute processes under a specific user by itself.
