### PR TITLE
hydra-module: Use PermissionsStartOnly in init.

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -197,6 +197,7 @@ in
           ''}
         '';
         serviceConfig.ExecStart = "${cfg.package}/bin/hydra-init";
+        serviceConfig.PermissionsStartOnly = true;
         serviceConfig.User = "hydra";
         serviceConfig.Type = "oneshot";
         serviceConfig.RemainAfterExit = true;


### PR DESCRIPTION
Oops, forgot to add this in f75509099a558ecfdd2f60a036c6e71de430920a.

This is necessary because we actually want to run the `preStart` script as `root` (because it chmod/chowns stuff and also needs to create the database using PostgreSQL's superuser) and the actual creation of the database as user `hydra`.
