### PR TITLE
Ensure Hydra user has a UID

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -159,6 +159,7 @@ in
         home = baseDir;
         createHome = true;
         useDefaultShell = true;
+        uid = config.ids.uids.hydra;
       };
 
     nix.extraOptions = ''


### PR DESCRIPTION
This allows the Hydra module to be used when `mutableUsers = false`;
