### PR TITLE
Compose release name for an evaluation if none has been defined

### DIFF
--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -132,8 +132,8 @@ sub release : Chained('eval') PathPart('release') Args(0) {
     my $releaseName;
     $releaseName ||= $_->releasename foreach @builds;
 
-    error($c, "No build in this evaluation has a release name.")
-        unless defined $releaseName;
+    # If no release name has been defined by any of the builds, compose one of the project name and evaluation id
+    $releaseName = $eval->project->name."-".$eval->id unless defined $releaseName;
 
     my $release;
 


### PR DESCRIPTION
Currently, an exception is raised, but what I usually want if I use this feature is to compose a release that contains everything in an evaluation, nothing more.

This solution uses <project name>-<eval_id>
