### PR TITLE
Use mktemp for tempdir creation in prefetchers.

### DIFF
--- a/src/script/nix-prefetch-bzr
+++ b/src/script/nix-prefetch-bzr
@@ -43,11 +43,10 @@ fi
 # If we don't know the hash or a path with that hash doesn't exist,
 # download the file and add it to the store.
 if test -z "$finalPath"; then
-    tmpPath=/tmp/bzr-checkout-tmp-$$
-    tmpFile=$tmpPath/$dstFile
-    mkdir $tmpPath
+    tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/bzr-checkout-tmp-XXXXXXXX")"
+    trap "rm -rf \"$tmpPath\"" EXIT
 
-    trap "rm -rf $tmpPath" EXIT
+    tmpFile="$tmpPath/$dstFile"
 
     # Perform the checkout.
     if test "$NIX_PREFETCH_BZR_LEAVE_DOT_BZR" != 1

--- a/src/script/nix-prefetch-git
+++ b/src/script/nix-prefetch-git
@@ -237,11 +237,11 @@ else
   # download the file and add it to the store.
   if test -z "$finalPath"; then
 
-      tmpPath=/tmp/git-checkout-tmp-$$
-      tmpFile=$tmpPath/git-export
-      mkdir $tmpPath $tmpFile
+      tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/git-checkout-tmp-XXXXXXXX")"
+      trap "rm -rf \"$tmpPath\"" EXIT
 
-      trap "rm -rf $tmpPath" EXIT
+      tmpFile="$tmpPath/git-export"
+      mkdir "$tmpFile"
 
       # Perform the checkout.
       clone_user_rev "$tmpFile" "$url" "$rev"

--- a/src/script/nix-prefetch-hg
+++ b/src/script/nix-prefetch-hg
@@ -35,11 +35,10 @@ fi
 # download the file and add it to the store.
 if test -z "$finalPath"; then
 
-    tmpPath=/tmp/hg-checkout-tmp-$$
-    tmpArchive=$tmpPath/hg-archive
-    mkdir $tmpPath
+    tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/hg-checkout-tmp-XXXXXXXX")"
+    trap "rm -rf \"$tmpPath\"" EXIT
 
-    trap "rm -rf $tmpPath" EXIT
+    tmpArchive="$tmpPath/hg-archive"
 
     # Perform the checkout.
     if [[ $url != /* ]]; then


### PR DESCRIPTION
This incorporates the following two commits from [<nixpkgs>](/NixOS/nixpkgs):

NixOS/nixpkgs@f83af95f8a54d0375ac6e159b663de887ba5b6a6
NixOS/nixpkgs@5e7a1cf955e43e1fa3c1c157c0d6961e1bcf9801

Hydra was the original reason why I was fixing tempdir creation in the first place. Seeing that Hydra ships its own versions of these scripts, we need to patch them here as well.

Recently had a collision again:

``` sh
$ journalctl --since=2014-08-27 --until=2014-08-28 _SYSTEMD_UNIT=hydra-evaluator.service \
    | grep -F /tmp/git-checkout | cut -d: -f4- | sort | uniq -dc | sort -n
      2  Initialized empty Git repository in /tmp/git-checkout-tmp-19972/git-export/.git/
      2  Initialized empty Git repository in /tmp/git-checkout-tmp-3895/git-export/.git/
$ 
```
