### PR TITLE
Tiny tweaks to the web interface

### DIFF
--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -179,24 +179,24 @@ BLOCK renderBuildStatusIcon;
   buildstatus = buildstatus != undef ? buildstatus : build.buildstatus;
   IF finished;
     IF buildstatus == 0 %]
-      <img src="[% c.uri_for("/static/images/checkmark_${size}.png") %]" alt="Succeeded" class="build-status" />
+      <img src="[% c.uri_for("/static/images/checkmark_${size}.png") %]" alt="Succeeded" title="Succeeded" class="build-status" />
     [% ELSIF buildstatus == 1 %]
-      <img src="[% c.uri_for("/static/images/error_${size}.png") %]" alt="Failed" class="build-status" />
+      <img src="[% c.uri_for("/static/images/error_${size}.png") %]" alt="Failed" title="Failed" class="build-status" />
     [% ELSIF buildstatus == 2 || buildstatus == 5 %]
-      <img src="[% c.uri_for("/static/images/dependency_${size}.png") %]" alt="Dependency failed" class="build-status" />
+      <img src="[% c.uri_for("/static/images/dependency_${size}.png") %]" alt="Dependency failed" title="Dependency failed" class="build-status" />
     [% ELSIF buildstatus == 3 %]
-      <img src="[% c.uri_for("/static/images/warning_${size}.png") %]" alt="Aborted" class="build-status" />
+      <img src="[% c.uri_for("/static/images/warning_${size}.png") %]" alt="Aborted" title="Aborted" class="build-status" />
     [% ELSIF buildstatus == 4 %]
-      <img src="[% c.uri_for("/static/images/forbidden_${size}.png") %]" alt="Cancelled" class="build-status" />
+      <img src="[% c.uri_for("/static/images/forbidden_${size}.png") %]" alt="Cancelled" title="Cancelled" class="build-status" />
     [% ELSIF buildstatus == 6 %]
-      <img src="[% c.uri_for("/static/images/error_${size}.png") %]" alt="Failed (with result)" class="build-status" />
+      <img src="[% c.uri_for("/static/images/error_${size}.png") %]" alt="Failed (with result)" title="Failed (with result)" class="build-status" />
     [% ELSE %]
-      <img src="[% c.uri_for("/static/images/error_${size}.png") %]" alt="Failed" class="build-status" />
+      <img src="[% c.uri_for("/static/images/error_${size}.png") %]" alt="Failed" title="Failed" class="build-status" />
     [% END;
   ELSIF busy %]
-    <img src="[% c.uri_for("/static/images/help_${size}.png") %]" alt="Busy" class="build-status" />
+    <img src="[% c.uri_for("/static/images/help_${size}.png") %]" alt="Busy" title="Busy" class="build-status" />
   [% ELSE %]
-    <img src="[% c.uri_for("/static/images/help_${size}.png") %]" alt="Scheduled" class="build-status" />
+    <img src="[% c.uri_for("/static/images/help_${size}.png") %]" alt="Scheduled" title="Scheduled" class="build-status" />
   [% END;
 END;
 
@@ -482,13 +482,13 @@ BLOCK renderJobsetOverview %]
       <tr>
         <td>
           [% IF j.get_column('nrscheduled') > 0 %]
-            <img src="[% c.uri_for("/static/images/help_16.png") %]" alt="Scheduled" />
+            <img src="[% c.uri_for("/static/images/help_16.png") %]" alt="Scheduled" title="Scheduled" />
           [% ELSIF j.get_column('nrfailed') == 0  %]
-            <img src="[% c.uri_for("/static/images/checkmark_16.png") %]" alt="Succeeded" />
+            <img src="[% c.uri_for("/static/images/checkmark_16.png") %]" alt="Succeeded" title="Succeeded" />
           [% ELSIF j.get_column('nrfailed') > 0 && j.get_column('nrsucceeded') > 0 %]
-            <img src="[% c.uri_for("/static/images/error_some_16.png") %]" alt="Some Failed" />
+            <img src="[% c.uri_for("/static/images/error_some_16.png") %]" alt="Some failed" title="Some failed" />
           [% ELSE %]
-            <img src="[% c.uri_for("/static/images/error_16.png") %]" alt="All Failed" />
+            <img src="[% c.uri_for("/static/images/error_16.png") %]" alt="All failed" title="All failed" />
           [% END %]
         </td>
         <td><span class="[% IF !j.enabled %]disabled-jobset[% END %] [%+ IF j.hidden %]hidden-jobset[% END %]">[% IF showProject; INCLUDE renderFullJobsetName project=j.get_column('project') jobset=j.name inRow=1; ELSE; INCLUDE renderJobsetName project=j.get_column('project') jobset=j.name inRow=1; END %]</span></td>

--- a/src/root/product-list.tt
+++ b/src/root/product-list.tt
@@ -131,7 +131,7 @@
           [% CASE "srpm" %]
             <img src="[% c.uri_for("/static/images/rpm.png") %]" alt="Source RPM" /> Source RPM package <tt>[% product.name %]</tt>
           [% CASE "deb" %]
-            <img src="[% c.uri_for("/static/images/debian.png") %]" alt="RPM" /> Debian package <tt>[% product.name %]</tt>
+            <img src="[% c.uri_for("/static/images/debian.png") %]" alt="Debian" /> Debian package <tt>[% product.name %]</tt>
           [% CASE "iso" %]
             <img src="[% c.uri_for("/static/images/iso.png") %]" alt="ISO" /> ISO-9660 CD/DVD image <tt>[% product.name %]</tt>
           [% CASE "binary-dist" %]

--- a/src/root/topbar.tt
+++ b/src/root/topbar.tt
@@ -131,7 +131,7 @@
       [% WRAPPER makeSubMenu title="Sign in" %]
         <li>
           <a href="#" id="persona-signin">
-            <img src="[% c.uri_for("/static/images/persona_sign_in_blue.png") %]" alt="Sign in with Persona" />
+            <img src="[% c.uri_for("/static/images/persona_sign_in_blue.png") %]" alt="Sign in with Persona" title="Sign in with Persona" />
           </a>
         </li>
         <li class="divider"></li>


### PR DESCRIPTION
Use title= in addition to alt= where appropriate.
This displays a tooltip over status icons, which are often uselessly generic and/or unhelpful for newer users.

Also fix a lone RPM -> Debian typo.