### PR TITLE
Allow to specify channel attribute path in jobsets.

### DIFF
--- a/src/lib/Hydra/Controller/Jobset.pm
+++ b/src/lib/Hydra/Controller/Jobset.pm
@@ -72,7 +72,8 @@ sub jobset_PUT {
             # Note: $jobsetName is validated in updateProject, which will
             # abort the transaction if the name isn't valid.
             $jobset = $c->stash->{project}->jobsets->create(
-                {name => ".tmp", nixexprinput => "", nixexprpath => "", emailoverride => ""});
+                {name => ".tmp", nixexprinput => "", nixexprpath => "",
+                 emailoverride => "", channelattr => ""});
             updateJobset($c, $jobset);
         });
 
@@ -225,6 +226,7 @@ sub updateJobset {
         , description => trim($c->stash->{params}->{"description"})
         , nixexprpath => $nixExprPath
         , nixexprinput => $nixExprInput
+        , channelattr => $c->stash->{params}->{"channelattr"}
         , enabled => $enabled
         , enableemail => defined $c->stash->{params}->{enableemail} ? 1 : 0
         , emailoverride => trim($c->stash->{params}->{emailoverride}) || ""

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -63,6 +63,11 @@ __PACKAGE__->table("Jobsets");
   data_type: 'text'
   is_nullable: 0
 
+=head2 channelattr
+
+  data_type: 'text'
+  is_nullable: 1
+
 =head2 errormsg
 
   data_type: 'text'
@@ -142,6 +147,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "nixexprpath",
   { data_type => "text", is_nullable => 0 },
+  "channelattr",
+  { data_type => "text", is_nullable => 1 },
   "errormsg",
   { data_type => "text", is_nullable => 1 },
   "errortime",
@@ -320,8 +327,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2014-04-23 23:13:51
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CO0aE+jrjB+UrwGRzWZLlw
+# Created by DBIx::Class::Schema::Loader v0.07033 @ 2015-03-30 04:42:59
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:JPQyW/9O8fCaPtRS2mWPhA
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/View/CustomNixExprs.pm
+++ b/src/lib/Hydra/View/CustomNixExprs.pm
@@ -1,0 +1,41 @@
+package Hydra::View::CustomNixExprs;
+
+use strict;
+use base qw/Catalyst::View/;
+use IO::Compress::Bzip2 qw(bzip2);
+use File::Find;
+use File::Spec;
+use IPC::Open2;
+
+sub process {
+    my ($self, $c) = @_;
+
+    my $storePath = $c->stash->{storePath};
+
+    my ($tarentries, $tardata);
+    open2($tardata, $tarentries, "tar", "c", "-C", $storePath,
+        "--null", "-T", "-", "--no-recursion", "--no-unquote",
+        "--transform", "s,^,channel/,");
+
+    sub addFile {
+        return if $File::Find::name eq $storePath;
+        my $rel = File::Spec->abs2rel($File::Find::name, $storePath);
+        print $tarentries "$rel\0";
+    }
+
+    find({
+        preprocess => sub { return sort @_ },
+        wanted => \&addFile,
+    }, $storePath);
+
+    close $tarentries;
+
+    my $bzip2data;
+    bzip2 $tardata => \$bzip2data;
+
+    $c->response->content_type('application/x-bzip2');
+    $c->response->body($bzip2data);
+    return 1;
+}
+
+1;

--- a/src/root/edit-jobset.tt
+++ b/src/root/edit-jobset.tt
@@ -92,6 +92,13 @@
     </div>
 
     <div class="control-group">
+      <label class="control-label">Channel job attribute</label>
+      <div class="controls">
+        <input type="text" class="span3" name="channelattr" [% HTML.attributes(value => jobset.channelattr) %]/>
+      </div>
+    </div>
+
+    <div class="control-group">
       <label class="control-label">Check interval</label>
       <div class="controls">
         <div class="input-append">

--- a/src/root/jobset.tt
+++ b/src/root/jobset.tt
@@ -133,6 +133,10 @@
         </td>
       </tr>
       <tr>
+        <th>Channel job attribute:</th>
+        <td>[% HTML.escape(jobset.channelattr) %]</td>
+      </tr>
+      <tr>
         <th>Check interval:</th>
         <td>[% jobset.checkinterval || "<em>disabled</em>"  %]</td>
       </tr>

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -52,6 +52,7 @@ create table Jobsets (
     description   text,
     nixExprInput  text not null, -- name of the jobsetInput containing the Nix or Guix expression
     nixExprPath   text not null, -- relative path of the Nix or Guix expression
+    channelAttr   text, -- attribute path to use for channel expressions
     errorMsg      text, -- used to signal the last evaluation error etc. for this jobset
     errorTime     integer, -- timestamp associated with errorMsg
     lastCheckedTime integer, -- last time the evaluator looked at this jobset

--- a/src/sql/upgrade-33.sql
+++ b/src/sql/upgrade-33.sql
@@ -1,0 +1,1 @@
+alter table Jobsets add column channelAttr text;

--- a/tests/channels.nix
+++ b/tests/channels.nix
@@ -1,0 +1,26 @@
+let
+  channel = derivation {
+    name = "channel";
+    system = builtins.currentSystem;
+    builder = "/run/current-system/sw/bin/sh";
+    args = [
+      (builtins.toFile "builder.sh" ''
+        #OVERRIDE# will be substituted in channels.pl
+        /run/current-system/sw/bin/mkdir -p "$out"
+        echo '"magic"' > "$out/default.nix"
+      '')
+    ];
+  };
+
+in {
+  inherit channel;
+  nested.channel = channel;
+  another.name = channel;
+  unrelatedJob = builtins.toFile "unrelated" "unrelated";
+  another.unrelatedJob = builtins.toFile "unrelated" "unrelated";
+  failedJob = derivation {
+    name = "fail";
+    system = builtins.currentSystem;
+    builder = "/run/current-system/sw/bin/false";
+  };
+}

--- a/tests/channels.pl
+++ b/tests/channels.pl
@@ -1,0 +1,130 @@
+use strict;
+use File::Basename;
+use File::Copy;
+use Hydra::Model::DB;
+use Hydra::Helper::Nix;
+use Nix::Store;
+use Cwd;
+
+my $db = Hydra::Model::DB->new;
+
+use Test::Simple tests => 10;
+
+$db->resultset('Users')->create({
+    username => "root",
+    emailaddress => 'root@invalid.org',
+    password => ''
+});
+
+my $project = $db->resultset('Projects')->create({
+    name => "tests",
+    displayname => "",
+    owner => "root"
+});
+
+my $jobset = $project->jobsets->create({
+    name => "basic",
+    nixexprinput => "jobs",
+    nixexprpath => "default.nix",
+    channelattr => "channel",
+    emailoverride => ""
+});
+
+my $jobsetInput = $jobset->jobsetinputs->create({
+    name => "jobs",
+    type => "path"
+});
+
+$jobsetInput->jobsetinputalts->create({
+    altnr => 0,
+    value => "/tmp/jobs"
+});
+
+my $channelUrl = "http://localhost:3000/jobset/tests/basic/channel/latest";
+my $channelPath = "/nix/var/nix/profiles/per-user/hydra/channels/test";
+
+sub rebuild {
+    system("hydra-evaluator " . $jobset->project->name . " " . $jobset->name);
+    my $success = 1;
+    foreach my $build ($jobset->builds->search({finished => 0})) {
+        system("hydra-build " . $build->id);
+
+        my $result = $db->resultset('Builds')->find($build->id)->buildstatus;
+
+        print "result: ".$result."\n";
+
+        if ($build->job->name eq "failedJob") {
+            ok($result != 0, "expect failedJob to fail");
+        } else {
+            $success = $result == 0 ? $success : 0;
+        }
+    }
+    return $success;
+}
+
+sub exprContent {
+    open my $chanExpr, '<', "$channelPath/default.nix";
+    local $/;
+    my $content = <$chanExpr>;
+    close $chanExpr;
+    return $content;
+}
+
+ok(rebuild, "rebuild succeeded");
+
+system("nix-channel --add $channelUrl test");
+system("nix-channel --update");
+
+ok(-e "$channelPath/default.nix", "channel expression file existing");
+
+ok(exprContent eq "\"magic\"\n", "expression content is valid");
+
+system("sed -i -e 's/#OVERRIDE#.*/exit 1/' /tmp/jobs/default.nix");
+
+ok(!rebuild, "rebuild failed");
+
+system("nix-channel --update");
+
+ok(exprContent eq "\"magic\"\n", "expression content is still valid");
+
+system("sed -i -e '/exit 1/d' -e 's/\"magic\"/42/' /tmp/jobs/default.nix");
+
+ok(rebuild, "rebuild succeeded");
+
+system("nix-channel --update");
+
+ok(exprContent eq "42\n", "new expression content has arrived");
+
+my $unrelatedProject = $db->resultset('Projects')->create({
+    name => "unrelated",
+    displayname => "",
+    owner => "root"
+});
+
+my $unrelatedJobset = $unrelatedProject->jobsets->create({
+    name => "basic",
+    nixexprinput => "jobs",
+    nixexprpath => "default.nix",
+    channelattr => "channel",
+    emailoverride => ""
+});
+
+my $unrelatedJobsetInput = $unrelatedJobset->jobsetinputs->create({
+    name => "jobs",
+    type => "path"
+});
+
+mkdir "/tmp/jobs2";
+copy("/tmp/jobs/default.nix", "/tmp/jobs2/default.nix");
+system("sed -i -e 's/42/666/' /tmp/jobs2/default.nix");
+
+$unrelatedJobsetInput->jobsetinputalts->create({
+    altnr => 0,
+    value => "/tmp/jobs2"
+});
+
+ok(rebuild, "rebuild succeeded");
+
+system("nix-channel --update");
+
+ok(exprContent eq "42\n", "it's still the same expression content");


### PR DESCRIPTION
This should make channels actually useful the same way as it is done for the official Nix(OS) channels, but without the need for [external scripts](https://github.com/NixOS/nixos-channel-scripts) or [rewriting-proxies like this](https://gist.github.com/aszlig/6948b38f3807d42da51b#file-webserver-nix-L26-L76) to create them.

When creating or editing jobsets, there is now a new channel field, where you can specify the attribute path leading to the Nix expression which then is delivered as the channel tarball.