### PR TITLE
Improvements of tail-reload output

### DIFF
--- a/src/root/plain-reload.tt
+++ b/src/root/plain-reload.tt
@@ -9,18 +9,23 @@
 
 [% IF reload %]
 <script>
+function scrollDown() {
+    $("#contents").scrollTop($("#contents").get(0).scrollHeight);
+}
+
 function injectTail() {
     $.ajax({
         url: "[% url %]",
         dataType: "text",
         success: function (tail) {
             $("#contents").text(tail);
-            $("#contents").scrollTop($("#contents").get(0).scrollHeight);
+            scrollDown();
         }
     });
 }
 
 $(document).ready(function() {
+    scrollDown();
     injectTail();
     setInterval(injectTail, 5000);
 });

--- a/src/root/plain-reload.tt
+++ b/src/root/plain-reload.tt
@@ -15,6 +15,7 @@ function injectTail() {
         dataType: "text",
         success: function (tail) {
             $("#contents").text(tail);
+            $("#contents").scrollTop($("#contents").get(0).scrollHeight);
         }
     });
 }

--- a/src/root/plain-reload.tt
+++ b/src/root/plain-reload.tt
@@ -9,11 +9,19 @@
 
 [% IF reload %]
 <script>
- $(document).ready(function() {
-     $("#contents").load("[% url %]");
-   var refreshId = setInterval(function() {
-      $("#contents").load("[% url %]");
-   }, 5000);
+function injectTail() {
+    $.ajax({
+        url: "[% url %]",
+        dataType: "text",
+        success: function (tail) {
+            $("#contents").text(tail);
+        }
+    });
+}
+
+$(document).ready(function() {
+    injectTail();
+    setInterval(injectTail, 5000);
 });
 </script>
 [% END %]

--- a/src/root/static/css/hydra.css
+++ b/src/root/static/css/hydra.css
@@ -119,3 +119,9 @@ span.keep-whitespace {
 .build-status {
     max-width: none; /* don't apply responsive design to status images */
 }
+
+pre.taillog {
+    line-height: 1.2em;
+    max-height: 60em;
+    overflow: hidden;
+}


### PR DESCRIPTION
Constrain the visual height of tail-reload outputs to 50 lines. The lines already get capped to 50 lines by the backend, but the backend has no way of knowing the maximum font width, so we're capping it using JavaScript now.

Also, if the build output contains HTML (and possibly something like `<script>`), it wasn't escaped properly, which is fixed now as well.