### PR TITLE
Allow running on i686-linux

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,7 +6,7 @@ let
 
   pkgs = import <nixpkgs> {};
 
-  genAttrs' = pkgs.lib.genAttrs [ "x86_64-linux" ];
+  genAttrs' = pkgs.lib.genAttrs [ "x86_64-linux" "i686-linux" ];
 
   hydraServer = hydraPkg:
     { config, pkgs, ... }:


### PR DESCRIPTION
Hydra won't build via the instructions at https://nixos.org/wiki/Installing_hydra_as_nixos_module#Letting_nix_handle_the_git_repository without this change.

Specifically where it says "# or i686-linux if appropriate", there is an attribute not found error for i686.

With this change, and after setting up the "hydra" postgres user's password manually, I have Hydra up and running on my i686 laptop without issue.