### PR TITLE
common.tt: Properly generate URL for /api/scmdiff.

### DIFF
--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -271,7 +271,13 @@ BLOCK renderDiffUri;
     url = res.0;
     branch = res.1;
     IF bi1.type == "hg" || bi1.type == "git" %]
-      <a target="_blank" href="[% HTML.escape("/api/scmdiff?uri=$url&rev1=$bi1.revision&rev2=$bi2.revision&type=$bi1.type&branch=$branch") %]">[% contents %]</a>
+      <a target="_blank" href="[% HTML.escape(c.uri_for('/api/scmdiff', {
+        uri = url,
+        rev1 = bi1.revision,
+        rev2 = bi2.revision,
+        type = bi1.type,
+        branch = branch
+      })) %]">[% contents %]</a>
     [% ELSE;
       contents;
     END;


### PR DESCRIPTION
If Hydra isn't hosted on `https://example.com/` but something like `https://example.com/hydra/`, the URL for `/api/scmdiff` would have ended up on `/api/scmdiff` rather than `/hydra/api/scmdiff`.

This is because we didn't use the URI resolver from the controller, hence we're using it now to build up the whole URL including the query string.