### PR TITLE
All args to matchless lambda

### DIFF
--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -183,16 +183,16 @@ static void findJobsWrapped(EvalState & state, JSONObject & top,
             /* Pass all the remaining args. */
             Value v2, * arg = state.allocValue();
             state.mkAttrs(*arg, argsLeft.size());
-            for (const auto & arg : argsLeft) {
-                if (arg.second.size() != 1) {
+            for (const auto & a : argsLeft) {
+                if (a.second.size() != 1) {
                     /* Currently don't support multiple values for an arg, so
                      * fall back on the old behavior
                      */
                     throw TypeError(format("unsupported value: %1%") % v);
                 }
-                arg->attrs->push_back(Attr(arg.first, arg.second.front()));
+                arg->attrs->push_back(Attr(a.first, a.second.front()));
             }
-            arg->attrs.sort();
+            arg->attrs->sort();
             mkApp(v, v2, *arg);
             findJobs(state, top, argsLeft, v2, attrPath);
             return;

--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -171,7 +171,7 @@ static void findJobsWrapped(EvalState & state, JSONObject & top,
         }
     }
 
-    else if (v.type == tLambda && v.lambda.fun->matchAttrs) {
+    else if (v.type == tLambda) {
         if (v.lambda.fun->matchAttrs) {
             Bindings & tmp(*state.allocBindings(0));
             tryJobAlts(state, top, argsLeft, attrPath, v,

--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -193,7 +193,7 @@ static void findJobsWrapped(EvalState & state, JSONObject & top,
                 arg->attrs->push_back(Attr(a.first, a.second.front()));
             }
             arg->attrs->sort();
-            mkApp(v, v2, *arg);
+            mkApp(v2, v, *arg);
             findJobs(state, top, argsLeft, v2, attrPath);
             return;
         }


### PR DESCRIPTION
If the hydra expression is a lambda with no formals, just pass in all args.

This makes it possible to have a shared `release.nix` for multiple projects with similar structures that vary in their inputs.