### PR TITLE
hydra-eval-jobs: Pass all inputs as 'inputs' arg.

### DIFF
--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -266,7 +266,7 @@ int main(int argc, char * * argv)
                     mkString(*v, string(j, 1));
                 autoArgs[inputName].push_back(v);
                 if (first) {
-                    inputsSet->attrs->push_back(Attr(inputName, *v));
+                    inputsSet->attrs->push_back(Attr(inputName, v));
                     first = false;
                 }
             }

--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -257,9 +257,7 @@ int main(int argc, char * * argv)
         state.mkAttrs(*inputsSet, autoArgs_.size());
         for (auto & i : autoArgs_) {
             Symbol inputName = state.symbols.create(i.first);
-            Value * inputAttr = state.allocAttr(*inputsSet, inputName);
-            state.mkList(*inputAttr, i.second.size());
-            int altIndex = 0;
+            bool first = true;
             for (auto & j : i.second) {
                 Value * v = state.allocValue();
                 if (j[0] == 'E')
@@ -267,7 +265,10 @@ int main(int argc, char * * argv)
                 else
                     mkString(*v, string(j, 1));
                 autoArgs[inputName].push_back(v);
-                inputAttr->list.elems[altIndex++] = v;
+                if (first) {
+                    inputsSet->attrs->push_back(Attr(inputName, *v));
+                    first = false;
+                }
             }
         }
         Symbol sInputs = state.symbols.create("inputs");


### PR DESCRIPTION
If there is no input named 'inputs', hydra-eval-jobs now passes in a set
of lists, where each attribute corresponds to an input defined in the
jobset specification and each list element is a different input alt, as
an argument named 'inputs'.

Among other things, this allows for generic hydra expressions to be
shared amongst projects with similar structures but different sets of
specific inputs.