### PR TITLE
Pass along drvPath and outputName for inputs that are previous builds.

### DIFF
--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -114,7 +114,7 @@ sub fetchInputBuild {
         , outputName => $mainOutput->name
         };
     if (isValidPath($prevBuild->drvPath)) {
-        $input->{drvPath} = $prevBuild->drvPath;
+        $result->{drvPath} = $prevBuild->drvPath;
     }
 
     return $result;

--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -288,7 +288,7 @@ sub buildInputToString {
             (defined $input->{shortRev} ? "; shortRev = \"" . $input->{shortRev} . "\"" : "") .
             (defined $input->{version} ? "; version = \"" . $input->{version} . "\"" : "") .
             (defined $input->{outputName} ? "; outputName = \"" . $input->{outputName} . "\"" : "") .
-            (defined $input->{drvPath} ? "; drvPath = " . $input->{drvPath} . "" : "") .
+            (defined $input->{drvPath} ? "; drvPath = builtins.storePath " . $input->{drvPath} . "" : "") .
             ";}";
     }
     return $result;

--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -107,13 +107,17 @@ sub fetchInputBuild {
 
     my $mainOutput = getMainOutput($prevBuild);
 
-    return
+    my $result =
         { storePath => $mainOutput->path
         , id => $prevBuild->id
         , version => $version
         , outputName => $mainOutput->name
-        , drvPath => $prevBuild->drvPath
         };
+    if (isValidPath($prevBuild->drvPath)) {
+        $input->{drvPath} = $prevBuild->drvPath;
+    }
+
+    return $result;
 }
 
 

--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -113,8 +113,8 @@ sub fetchInputBuild {
         , version => $version
         , outputName => $mainOutput->name
         };
-    if (isValidPath($prevBuild->drvPath)) {
-        $result->{drvPath} = $prevBuild->drvPath;
+    if (isValidPath($prevBuild->drvpath)) {
+        $result->{drvPath} = $prevBuild->drvpath;
     }
 
     return $result;

--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -105,10 +105,14 @@ sub fetchInputBuild {
     my $relName = ($prevBuild->releasename or $prevBuild->nixname);
     my $version = $2 if $relName =~ /^($pkgNameRE)-($versionRE)$/;
 
+    my $mainOutput = getMainOutput($prevBuild);
+
     return
-        { storePath => getMainOutput($prevBuild)->path
+        { storePath => $mainOutput->path
         , id => $prevBuild->id
         , version => $version
+        , outputName => $mainOutput->name
+        , drvPath => $prevBuild->drvPath
         };
 }
 
@@ -279,6 +283,8 @@ sub buildInputToString {
             (defined $input->{gitTag} ? "; gitTag = \"" . $input->{gitTag} . "\"" : "") .
             (defined $input->{shortRev} ? "; shortRev = \"" . $input->{shortRev} . "\"" : "") .
             (defined $input->{version} ? "; version = \"" . $input->{version} . "\"" : "") .
+            (defined $input->{outputName} ? "; outputName = \"" . $input->{outputName} . "\"" : "") .
+            (defined $input->{drvPath} ? "; drvPath = " . $input->{drvPath} . "" : "") .
             ";}";
     }
     return $result;


### PR DESCRIPTION
This allows importing the .drv and getting the same store paths as if the
input had been passed in as nix expressions defining a proper derivation.