### PR TITLE
Fix legacy channel URLs

### DIFF
--- a/src/lib/Hydra/Base/Controller/ListBuilds.pm
+++ b/src/lib/Hydra/Base/Controller/ListBuilds.pm
@@ -32,8 +32,8 @@ sub all : Chained('get_builds') PathPart {
 }
 
 
-sub nix : Chained('get_builds') PathPart('channel/latest') CaptureArgs(1) {
-    my ($self, $c, $channelName) = @_;
+sub nix : Chained('get_builds') PathPart('channel/latest') {
+    my ($self, $c) = @_;
 
     $c->stash->{channelName} = $c->stash->{channelBaseName} . "-latest";
     $c->stash->{channelBuilds} = $c->stash->{latestSucceeded}


### PR DESCRIPTION
Regression introduced by 1fdc258de0d7f97af428de34e8be019fca3db251.

The commit introduced a channel/custom PathPart which uses the new custom channel expressions, but I forgot to remove CaptureArgs, so the URL really is channel/latest/ignored-value.

Can't test this right now, so I'd appreciate if someone could test it :-)