### PR TITLE
statsd: add a chance to set hostname and port in hydra.conf

### DIFF
--- a/src/script/hydra-evaluator
+++ b/src/script/hydra-evaluator
@@ -26,6 +26,8 @@ my $plugins = [Hydra::Plugin->instantiate(db => $db, config => $config)];
 
 my $dryRun = defined $ENV{'HYDRA_DRY_RUN'};
 
+$Net::Statsd::HOST = $config->{'statsd_host'} // 'localhost';
+$Net::Statsd::PORT = $config->{'statsd_port'} // 8125;
 
 sub fetchInputs {
     my ($project, $jobset, $inputInfo) = @_;

--- a/src/script/hydra-send-stats
+++ b/src/script/hydra-send-stats
@@ -9,6 +9,11 @@ use JSON;
 STDERR->autoflush(1);
 binmode STDERR, ":encoding(utf8)";
 
+my $config = getHydraConfig();
+
+$Net::Statsd::HOST = $config->{'statsd_host'} // 'localhost';
+$Net::Statsd::PORT = $config->{'statsd_port'} // 8125;
+
 sub gauge {
     my ($name, $val) = @_;
     die unless defined $val;


### PR DESCRIPTION
For those that have statsd on other host than localhost. This pull request adds to hydra.conf two extra optional entries named `statsd_host` and `statsd_port`

These lines are the first that I have written in perl, I hope that it is acceptable :)

I have tested this in https://github.com/matejc/hydra-stack (Hydra inside docker with extra builders for distributed builds)
