### PR TITLE
Construct uri using uri_for, which respects X-Request-Base.

### DIFF
--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -168,7 +168,7 @@ sub showLog {
     }
 
     elsif ($mode eq "tail-reload") {
-        my $url = $c->request->uri->as_string;
+        my $url = $c->uri_for($c->request->uri->path);
         $url =~ s/tail-reload/tail/g;
         $c->stash->{url} = $url;
         $c->stash->{reload} = !$c->stash->{build}->finished;


### PR DESCRIPTION
When using Hydra behind a reverse proxy the tail-reload page does not work because of an incorrect URI.