### PR TITLE
Add a plugin to commit changes to a git repo.

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -284,7 +284,7 @@ in
       { wantedBy = [ "multi-user.target" ];
         requires = [ "hydra-init.service" ];
         after = [ "hydra-init.service" "network.target" ];
-        path = [ pkgs.nettools pkgs.ssmtp ];
+        path = [ pkgs.nettools pkgs.ssmtp pkgs.patch ];
         environment = env // {
           PGPASSFILE = "${baseDir}/pgpass-queue-runner"; # grrr
           IN_SYSTEMD = "1"; # to get log severity levels

--- a/release.nix
+++ b/release.nix
@@ -128,6 +128,7 @@ rec {
             FileSlurp
             IOCompress
             IPCRun
+            IPCSystemSimple
             JSONXS
             LWP
             LWPProtocolHttps

--- a/src/lib/Hydra/Plugin/GitCommit.pm
+++ b/src/lib/Hydra/Plugin/GitCommit.pm
@@ -1,0 +1,46 @@
+package Hydra::Plugin::GitCommit;
+
+use strict;
+use parent 'Hydra::Plugin';
+use Cwd;
+use Hydra::Helper::CatalystUtils;
+use autodie qw( system );
+
+sub buildFinished {
+    my ($self, $build, $dependents) = @_;
+    return unless $build->buildstatus == 0;
+    my $cfg = $self->{config}->{gitcommit};
+    my @config = defined $cfg ? ref $cfg eq "ARRAY" ? @$cfg : ($cfg) : ();
+
+    undef $cfg;
+    my $jobName = showJobName $build;
+    foreach my $c (@config) {
+        if ($jobName =~ /^$c->{jobs}$/) {
+            $cfg = $c;
+            last;
+        }
+    }
+    return unless defined $cfg;
+    my $patch = ($build->buildoutputs)[0]->path . "/build-support/hydra-git-commit.patch";
+    return unless -e $patch;
+    my $tempdir = File::Temp->newdir("hydra-git-commit-" . $build->id . "-XXXXX", TMPDIR => 1);
+
+    my $dir = getcwd;
+    eval {
+        system("git clone --depth 1 --branch $cfg->{branch} $cfg->{repo} $tempdir/checkout");
+        chdir "$tempdir/checkout" or die;
+        system("patch -Np1 -i $patch");
+        system("git add .");
+        my $id = $build->id;
+        system("git config user.name \"Hydra git plugin\"");
+        system("git config user.email \"<>\"");
+        system("git commit -m \"Automated commit from hydra build $id\"");
+        system("git config push.default simple");
+        system("git push");
+    };
+    my $err = $@;
+    chdir $dir;
+    die $err if defined $err;
+}
+
+1;


### PR DESCRIPTION
First matching `<gitcommit>` block is used:
- jobs: Jobs regexp
- repo: git repo
- branch: git branch

If a build of a matching job creates
$out/build-support/hydra-git-commit.patch, that patch is applied to
the specified branch, committed, and pushed back.
