### PR TITLE
Fix problem with delegating builds to localhost due to nix-store not being in the PATH

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -292,7 +292,7 @@ in
       { wantedBy = [ "multi-user.target" ];
         requires = [ "hydra-init.service" ];
         after = [ "hydra-init.service" "network.target" ];
-        path = [ cfg.package pkgs.nettools pkgs.ssmtp pkgs.openssh pkgs.bzip2 ];
+        path = [ cfg.package pkgs.nettools pkgs.ssmtp pkgs.openssh pkgs.bzip2 config.nix.package ];
         environment = env // {
           PGPASSFILE = "${baseDir}/pgpass-queue-runner"; # grrr
           IN_SYSTEMD = "1"; # to get log severity levels


### PR DESCRIPTION
In one of my private instances, I want to build stuff on localhost. Unfortunately, it seems to get stuck and the queue-runner log reports the following:

`/nix/store/0naxglgmy5cpg0qghmznha1s700pifvd-bash-4.3.tar.gz.drv’ on ‘localhost’: cannot connect to ‘localhost’: error: cannot start ssh: No such file or directory`

Further inspection with strace reveals the following:

[pid  3309] execve("/nix/store/m04qal8fw9pchqj4h5q9m54hvqh4grrd-systemd-229/bin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/qq1rk7zyap4rwwyswcz0wi03a05m1d90-hydra-0.1.1234.abcdef/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/2p669lkmx6nsmq3zxzcx7vn60aphz0xz-net-tools-1.60_p20120127084908/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/nib7qnddnlwqqpv1csn5skrlx4qqmlsk-ssmtp-2.64/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/58n3ir5sln7773d301bk4za67zcmfhg0-openssh-7.2p2/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/pks0f2gg6h8fjcg2fdaqwxqw4ps456wl-bzip2-1.0.6/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/fbb5afz59r0x2w4w8wsn21lq4jvxpz0w-coreutils-8.25/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/1mirmaabxbkzr3gya7f67613nfws3zq8-findutils-4.4.2/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/94d6pflxmi1g3rjgl57dqnkmq0j6888v-gnugrep-2.22/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/rwqh31ccqcjcnikgnqi64hvfaddmn44z-gnused-4.2.2/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] execve("/nix/store/m04qal8fw9pchqj4h5q9m54hvqh4grrd-systemd-229/sbin/nix-store", ["nix-store", "--serve", "--write"], [/* 53 vars */]) = -1 ENOENT (No such file or directory)
[pid  3309] write(2, "error: ", 7)      = 7
[pid  3309] write(2, "cannot start ssh: No such file o"..., 43) = 43
[pid  3309] write(2, "\n", 1)           = 1
[pid  3309] exit_group(1)               = ?
[pid  3309] +++ exited with 1 +++
[pid  3249] <... restart_syscall resumed> ) = ? ERESTART_RESTARTBLOCK (Interrupted by signal)
[pid  3249] --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=3309, si_uid=1000, si_status=1, si_utime=0, si_stime=0} ---
[pid  3249] restart_syscall(<... resuming interrupted restart_syscall ...> <unfinished ...>
[pid  3303] <... vfork resumed> )       = 3308
[pid  3303] close(11)                   = 0
[pid  3303] close(14)                   = 0
[pid  3303] close(21)                   = 0
[pid  3303] write(12, "\353\235\f9\0\0\0\0\2\2\0\0\0\0\0\0", 16) = -1 EPIPE (Broken pipe)
[pid  3303] --- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER, si_pid=3249, si_uid=1000} ---
[pid  3303] read(13, "", 32768)         = 0
[pid  3303] wait4(3308, [{WIFEXITED(s) && WEXITSTATUS(s) == 1}], 0, NULL) = 3308
[pid  3303] open("/var/lib/hydra/build-logs/q4/1vlsd4z6a3b8ga0rhfg0359j94028y-bash43-008.drv", O_RDONLY) = 11
[pid  3303] fstat(11, {st_mode=S_IFREG|0644, st_size=51, ...}) = 0
[pid  3303] read(11, "error: cannot start ssh: No such"..., 51) = 51
[pid  3303] close(11)                   = 0
[pid  3303] close(13)                   = 0
[pid  3303] close(12)                   = 0
[pid  3303] lstat("/tmp/nix-3249-6", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
[pid  3303] open("/tmp/nix-3249-6", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 11
[pid  3303] fstat(11, {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
[pid  3303] getdents(11, /* 2 entries */, 32768) = 48
[pid  3303] getdents(11, /* 0 entries */, 32768) = 0
[pid  3303] close(11)                   = 0
[pid  3303] unlink("/tmp/nix-3249-6")   = -1 EISDIR (Is a directory)
[pid  3303] rmdir("/tmp/nix-3249-6")    = 0
[pid  3303] unlink("/var/lib/hydra/build-logs/q4/1vlsd4z6a3b8ga0rhfg0359j94028y-bash43-008.drv") = 0
[pid  3303] futex(0x7ffd04dddf44, FUTEX_WAKE_OP_PRIVATE, 1, 1, 0x7ffd04dddf40, {FUTEX_OP_SET, 0, FUTEX_OP_CMP_GT, 1}) = 1
[pid  3303] ioctl(2, TCGETS, 0x7f079a2f0400) = -1 ENOTTY (Inappropriate ioctl for device)
[pid  3303] write(2, "<3>possibly transient failure bu"..., 210<3>possibly transient failure building ‘/nix/store/q41vlsd4z6a3b8ga0rhfg0359j94028y-bash43-008.drv’ on ‘localhost’: cannot connect to ‘localhost’: error: cannot start ssh: No such file or directory
) = 210

It seems that ssh is not missing but nix-store. Modifying the systemd service for the queue runner seemed to do the trick for me.
