### PR TITLE
release.nix use makeBinPath to construct PATH

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -133,7 +133,7 @@ rec {
           }))
         ];
 
-      hydraPath = lib.makeSearchPath "bin" (
+      hydraPath = lib.makeBinPath (
         [ libxslt sqlite subversion openssh nix coreutils findutils
           gzip bzip2 lzma gnutar unzip git gitAndTools.topGit mercurial darcs gnused bazaar
         ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );


### PR DESCRIPTION
makeBinPath takes care to use the correct output.

nix-repl> lib.makeSearchPath "bin" [pkgs.nix]
"/nix/store/zpp83pr21ihxwsr15l6mkzwkr49zj71d-nix-1.11.2-dev/bin"

nix-repl> lib.makeBinPath [pkgs.nix]
"/nix/store/9n8c3g541qn43yjjs94f1a0m69wp8scg-nix-1.11.2/bin"