### PR TITLE
hydra-module: fix useSubstitutes configuration option

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -324,7 +324,7 @@ in
           IN_SYSTEMD = "1"; # to get log severity levels
         };
         serviceConfig =
-          { ExecStart = "@${cfg.package}/bin/hydra-queue-runner hydra-queue-runner -v --option build-use-substitutes ${if optionalString cfg.useSubstitutes then "true" else "false"}";
+          { ExecStart = "@${cfg.package}/bin/hydra-queue-runner hydra-queue-runner -v --option build-use-substitutes ${if cfg.useSubstitutes then "true" else "false"}";
             ExecStopPost = "${cfg.package}/bin/hydra-queue-runner --unlock";
             User = "hydra-queue-runner";
             Restart = "always";


### PR DESCRIPTION
Without this I get:
```
error: value is a function while a Boolean was expected
```