### PR TITLE
WIP Add GithubAPIInput

### DIFF
--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -313,7 +313,7 @@ sub inputsToArgs {
                 unlink $filename or print STDERR "WARNING: unable to remove temporary file $filename\n";
 
                 $storePath =~ s/^\s+|\s+$//g;
-                push @res, "--arg", $input, "builtins.readFile $storePath";
+                push @res, "--arg", $input, "builtins.fromJSON (builtins.readFile $storePath)";
             }
             elsif ($alt->{type} eq "boolean") {
                 push @res, "--arg", $input, booleanToString($exprType, $alt->{value});

--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -294,7 +294,7 @@ sub inputsToArgs {
             if scalar @{$inputInfo->{$input}} == 1
                && defined $inputInfo->{$input}->[0]->{storePath};
         foreach my $alt (@{$inputInfo->{$input}}) {
-            if ($alt->{type} eq "string") {
+            if ($alt->{type} eq "string" || $alt->{type} eq "githubAPI") {
                 push @res, "--argstr", $input, $alt->{value};
             }
             elsif ($alt->{type} eq "boolean") {

--- a/src/lib/Hydra/Plugin/GithubAPIInput.pm
+++ b/src/lib/Hydra/Plugin/GithubAPIInput.pm
@@ -1,0 +1,36 @@
+package Hydra::Plugin::GithubAPIInput;
+
+use strict;
+use parent 'Hydra::Plugin';
+use HTTP::Request;
+use JSON;
+use LWP::UserAgent;
+use Hydra::Helper::CatalystUtils;
+
+sub supportedInputTypes {
+    my ($self, $inputTypes) = @_;
+    $inputTypes->{'githubAPI'} = 'GitHub API Query';
+}
+
+sub fetchInput {
+    my ($self, $type, $name, $value) = @_;
+
+    return undef if $type ne "githubAPI";
+
+    # Use the GithubStatus plugin's authorization.
+    # TODO: move this into a more cleanly shared field.
+    my $config = $self->{config}->{githubstatus};
+
+    my $url = "https://api.github.com" . $value;
+    my $ua = LWP::UserAgent->new();
+    my $req = HTTP::Request->new('GET', $url);
+    $req->header('Accept' => 'application/vnd.github.v3+json');
+    $req->header('Authorization' => $config->{authorization});
+    my $res = $ua->request($req);
+    print STDERR ("Performing GitHub API request: " . $url . "\n");
+
+    return { value => $res->decoded_content };
+}
+
+1;
+


### PR DESCRIPTION
This commit defines a new input type for performing queries against the
GitHub API.

The JSON results of the query is passed to nix expressions as a string.

An example query to get information on pull requests could be
`/repos/username/repositoryname/pulls`.
