### PR TITLE
Insert a github token into the git URI when able

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -102,6 +102,7 @@ rec {
             TestMore
             TextDiff
             TextTable
+            URI
             XMLSimple
             nix git boehmgc
           ];


### PR DESCRIPTION
If the user has specified a github token in the config and the git clone
address is under github.com and the scheme is https then the token will
be used for the fetch. This allows fetching private repositories without
including a username and password in the URI.

There is some bikeshedding to be done over when to insert the token. At
the moment it's done as early as possbile which exposes the token in
logs and elsewhere.

The token is read from the 'authorization' field in the '<githubstatus>'
block. It must be of the format: 'token <40 character hex string>'.

Closes #324