### PR TITLE
GitHub push suffix

### DIFF
--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -246,7 +246,7 @@ sub push_github : Chained('api') PathPart('push-github') Args(0) {
 
     $c->{stash}->{json}->{jobsetsTriggered} = [];
 
-    my $in = decode_json $c->req->body_params->{payload};
+    my $in = $c->request->{data};
     my $owner = $in->{repository}->{owner}->{name} or die;
     my $repo = $in->{repository}->{name} or die;
     print STDERR "got push from GitHub repository $owner/$repo\n";

--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -254,7 +254,7 @@ sub push_github : Chained('api') PathPart('push-github') Args(0) {
     triggerJobset($self, $c, $_) foreach $c->model('DB::Jobsets')->search(
         { 'project.enabled' => 1, 'me.enabled' => 1 },
         { join => 'project'
-        , where => \ [ 'exists (select 1 from JobsetInputAlts where project = me.project and jobset = me.name and value like ?)', [ 'value', "%github.com%$owner/$repo.git%" ] ]
+        , where => \ [ 'exists (select 1 from JobsetInputAlts where project = me.project and jobset = me.name and value like ?)', [ 'value', "%github.com%$owner/$repo%" ] ]
         });
 }
 


### PR DESCRIPTION
This is based on #331 

It will trigger builds where the repository name has the the pushed repository name as a prefix. This was a problem before if the repository name had `.git` in it too. 