### PR TITLE
Enable apache style includes in the config file

### DIFF
--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -38,7 +38,10 @@ sub getHydraConfig {
     return $hydraConfig if defined $hydraConfig;
     my $conf = $ENV{"HYDRA_CONFIG"} || (Hydra::Model::DB::getHydraPath . "/hydra.conf");
     if (-f $conf) {
-        my %h = new Config::General($conf)->getall;
+        my %h = new Config::General( -ConfigFile => $conf
+                                   , -UseApacheInclude => 1
+                                   )->getall;
+
         $hydraConfig = \%h;
     } else {
         $hydraConfig = {};


### PR DESCRIPTION
This enables the include syntax `include filename`. At the moment only `<<include filename>>` is allowed.

This also seems to enable absolute paths as filenames, but I can't find any documentation saying that.