### PR TITLE
Trigger ssh like urls from github pushes

### DIFF
--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -254,7 +254,7 @@ sub push_github : Chained('api') PathPart('push-github') Args(0) {
     triggerJobset($self, $c, $_) foreach $c->model('DB::Jobsets')->search(
         { 'project.enabled' => 1, 'me.enabled' => 1 },
         { join => 'project'
-        , where => \ [ 'exists (select 1 from JobsetInputAlts where project = me.project and jobset = me.name and value like ?)', [ 'value', "%github.com%/$owner/$repo.git%" ] ]
+        , where => \ [ 'exists (select 1 from JobsetInputAlts where project = me.project and jobset = me.name and value like ?)', [ 'value', "%github.com%$owner/$repo.git%" ] ]
         });
 }
 


### PR DESCRIPTION
URLs like "git@github.com:owner/repo.git

This commit removes the need for a forward slash between 'github.com' and
'owner'.