### PR TITLE
Make it easier to spin up a development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ This will run the following commands:
 
 The `setup-database` command is used for setting up a temporary database living
 in the `inst/database` subdirectory of the project root. It also sets up the
-required environment variables `HYDRA_HOME`, `HYDRA_DATA` and `HYDRA_DBI`.
+required environment variables `HYDRA_HOME`, `HYDRA_DATA` and `HYDRA_DBI` as
+well as the `PG*` environment variables so that if you want to start a database
+shell it's a matter of simply running:
+
+    $ pgsql
 
 Or, if you just want to build from source (on `x86_64-linux`):
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-To start hacking on Hydra, run:
+To quickly start hacking on Hydra, run:
+
+    $ nix-shell --command 'setup-dev-env; return'
+
+This will run the following commands:
 
     $ bootstrap
     $ nix-shell
     $ ./configure $configureFlags --prefix=/opt/hydra
     $ make
-    $ make install
+    $ setup-database
 
-Or, if you just want to build from source (on x86_64-linux):
+The `setup-database` command is used for setting up a temporary database living
+in the `inst/database` subdirectory of the project root. It also sets up the
+required environment variables `HYDRA_HOME`, `HYDRA_DATA` and `HYDRA_DBI`.
+
+Or, if you just want to build from source (on `x86_64-linux`):
 
     $ nix-build -A build.x86_64-linux release.nix

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This will run the following commands:
     $ ./configure $configureFlags --prefix=/opt/hydra
     $ make
     $ setup-database
+    $ hydra-create-user admin --password admin --role admin
 
 The `setup-database` command is used for setting up a temporary database living
 in the `inst/database` subdirectory of the project root. It also sets up the

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ shell it's a matter of simply running:
 
     $ pgsql
 
+If you want to do all of the setup together with starting the Hydra web server,
+you can do that as well in one command:
+
+    $ nix-shell --command 'setup-dev-env && hydra-server'
+
+The shell and the server will go down once you press `CTRL+C`. If this is not
+desired, you can append `; return` to the command so that you will return to
+the `nix-shell` after you press `CTRL+C`.
+
 Or, if you just want to build from source (on `x86_64-linux`):
 
     $ nix-build -A build.x86_64-linux release.nix

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,37 @@
+{ nix ? null, ... }@args:
+
+
+let
+  pkgs = import <nixpkgs> {};
+
+  workingNix = let
+    src = pkgs.lib.overrideDerivation (pkgs.fetchFromGitHub {
+      owner = "NixOS";
+      repo = "nix";
+      rev = "1a714952732c56b4735f65dea49d406aacc7c595";
+      sha256 = "1fkmz7gv73qm50xz1hm1wkhm0yij0p7h4wx0760lvm9gkf4x4bn8";
+    }) (drv: {
+      postFetch = (drv.postFetch or "") + ''
+        # Don't hardcode XSL namespace URL:
+        # https://github.com/NixOS/nix/pull/959
+        sed -i -e '/^docbookxsl/s,xsl-ns/.*$,xsl-ns/current,' \
+          "$out/doc/manual/local.mk"
+
+        # Nix's release.nix sets src to null if in nix shell. This means that if
+        # you try to open a nix-shell on this default.nix, Nix will fail to
+        # build.
+        # Let's patch it until https://github.com/NixOS/nix/pull/960 got merged.
+        sed -i -e 's/lib\.inNixShell/false/g' "$out/release.nix"
+      '';
+    });
+    release = import "${src}/release.nix" {};
+  in pkgs.lib.overrideDerivation release.build.${builtins.currentSystem} (_: {
+    # The checks for this revision are broken, they try to create a /nix/var
+    # directory which results in a permission denied error.
+    doInstallCheck = false;
+  });
+
+in (import ./release.nix (args // {
+  nix = if nix == null then workingNix else nix;
+  shell = pkgs.lib.inNixShell;
+})).build.${builtins.currentSystem}

--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,7 @@
 { hydraSrc ? { outPath = ./.; revCount = 1234; rev = "abcdef"; }
 , officialRelease ? false
 , shell ? false
+, nix ? null
 }:
 
 with import <nixpkgs/lib>;
@@ -31,9 +32,14 @@ let
 
   version = builtins.readFile ./version + "." + toString hydraSrc.revCount + "." + hydraSrc.rev;
 
+  getNixPackageFor = system:
+    if nix == null
+    then (import <nixpkgs> { inherit system; }).nixUnstable
+    else nix;
+  nixVersion = getVersion (getNixPackageFor builtins.currentSystem);
 in
 
-assert versionAtLeast (getVersion pkgs.nixUnstable) "1.11pre4244_133a421";
+assert versionAtLeast nixVersion "1.11pre4244_133a421";
 
 rec {
 
@@ -42,8 +48,7 @@ rec {
     with import <nixpkgs> { inherit system; };
 
     let
-
-      nix = nixUnstable;
+      nix = getNixPackageFor system;
 
       NetStatsd = buildPerlPackage {
         name = "Net-Statsd-0.11";

--- a/release.nix
+++ b/release.nix
@@ -184,47 +184,7 @@ rec {
       meta.description = "Build of Hydra on ${system}";
       passthru.perlDeps = perlDeps;
     } // lib.optionalAttrs shell {
-      shellHook = ''
-        hydra_devdir="$PWD/inst"
-        export HYDRA_HOME="$PWD/src"
-
-        function setup-dev-env() {
-          HYDRA_DATA="$hydra_devdir/data"
-          HYDRA_DBI="dbi:Pg:dbname=hydra;port=5432;host=$hydra_devdir/sockets"
-          export HYDRA_DATA HYDRA_DBI
-        }
-
-        function stop-database() {
-          if [ -e "$hydra_devdir/database/postmaster.pid" ]; then
-            pg_ctl -D "$hydra_devdir/database" stop
-          fi
-        }
-
-        function start-database() {
-          mkdir -p "$hydra_devdir/sockets"
-          pg_ctl -D "$hydra_devdir/database" \
-            -o "-F -k '$hydra_devdir/sockets' -p 5432 -h '''" -w start
-          trap stop-database EXIT
-        }
-
-        if [ -e "$hydra_devdir/database" ]; then
-          setup-dev-env
-          start-database
-        fi
-
-        function setup-database() {
-          if [ ! -e "$HYDRA_HOME/sql/hydra-postgresql.sql" ]; then
-            echo "hydra-postgresql.sql doesn't exist, please run make!" >&2
-            return 1
-          fi
-          initdb -D "$hydra_devdir/database" && \
-          start-database && \
-          setup-dev-env && \
-          createdb -p 5432 -h "$hydra_devdir/sockets" hydra && \
-          mkdir -p "$HYDRA_DATA" && \
-          hydra-init
-        }
-      '';
+      shellHook = readFile ./shell-hook.sh;
     }));
 
 

--- a/release.nix
+++ b/release.nix
@@ -136,7 +136,7 @@ rec {
               sha256 = "1vhgsxkhpai9a7dk38q4r239l6dsz2jvl8hii24c194lsga3g84h";
             };
           }))
-        ];
+        ] ++ lib.optional (shell && stdenv.isLinux) utillinux;
 
       hydraPath = lib.makeBinPath (
         [ libxslt sqlite subversion openssh nix coreutils findutils

--- a/release.nix
+++ b/release.nix
@@ -107,7 +107,7 @@ rec {
             TextTable
             XMLSimple
             nix git boehmgc
-          ];
+          ] ++ lib.optional (shell && stdenv.isLinux) LinuxInotify2;
       };
 
     in

--- a/release.nix
+++ b/release.nix
@@ -114,7 +114,7 @@ rec {
 
     in
 
-    releaseTools.nixBuild {
+    releaseTools.nixBuild ({
       name = "hydra-${version}";
 
       src = if shell then null else hydraSrc;
@@ -183,7 +183,49 @@ rec {
 
       meta.description = "Build of Hydra on ${system}";
       passthru.perlDeps = perlDeps;
-    });
+    } // lib.optionalAttrs shell {
+      shellHook = ''
+        hydra_devdir="$PWD/inst"
+        export HYDRA_HOME="$PWD/src"
+
+        function setup-dev-env() {
+          HYDRA_DATA="$hydra_devdir/data"
+          HYDRA_DBI="dbi:Pg:dbname=hydra;port=5432;host=$hydra_devdir/sockets"
+          export HYDRA_DATA HYDRA_DBI
+        }
+
+        function stop-database() {
+          if [ -e "$hydra_devdir/database/postmaster.pid" ]; then
+            pg_ctl -D "$hydra_devdir/database" stop
+          fi
+        }
+
+        function start-database() {
+          mkdir -p "$hydra_devdir/sockets"
+          pg_ctl -D "$hydra_devdir/database" \
+            -o "-F -k '$hydra_devdir/sockets' -p 5432 -h '''" -w start
+          trap stop-database EXIT
+        }
+
+        if [ -e "$hydra_devdir/database" ]; then
+          setup-dev-env
+          start-database
+        fi
+
+        function setup-database() {
+          if [ ! -e "$HYDRA_HOME/sql/hydra-postgresql.sql" ]; then
+            echo "hydra-postgresql.sql doesn't exist, please run make!" >&2
+            return 1
+          fi
+          initdb -D "$hydra_devdir/database" && \
+          start-database && \
+          setup-dev-env && \
+          createdb -p 5432 -h "$hydra_devdir/sockets" hydra && \
+          mkdir -p "$HYDRA_DATA" && \
+          hydra-init
+        }
+      '';
+    }));
 
 
   tests.install = genAttrs' (system:

--- a/release.nix
+++ b/release.nix
@@ -14,9 +14,7 @@ let
 
   hydraServer = hydraPkg:
     { config, pkgs, ... }:
-    { imports = [ ./hydra-module.nix ];
-
-      virtualisation.memorySize = 1024;
+    { virtualisation.memorySize = 1024;
       virtualisation.writableStore = true;
 
       services.hydra.enable = true;

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -2,38 +2,38 @@ hydra_devdir="$PWD/inst"
 export HYDRA_HOME="$PWD/src"
 
 function setup-dev-env() {
-  HYDRA_DATA="$hydra_devdir/data"
-  HYDRA_DBI="dbi:Pg:dbname=hydra;port=5432;host=$hydra_devdir/sockets"
-  export HYDRA_DATA HYDRA_DBI
+    HYDRA_DATA="$hydra_devdir/data"
+    HYDRA_DBI="dbi:Pg:dbname=hydra;port=5432;host=$hydra_devdir/sockets"
+    export HYDRA_DATA HYDRA_DBI
 }
 
 function stop-database() {
-  if [ -e "$hydra_devdir/database/postmaster.pid" ]; then
-    pg_ctl -D "$hydra_devdir/database" stop
-  fi
+    if [ -e "$hydra_devdir/database/postmaster.pid" ]; then
+        pg_ctl -D "$hydra_devdir/database" stop
+    fi
 }
 
 function start-database() {
-  mkdir -p "$hydra_devdir/sockets"
-  pg_ctl -D "$hydra_devdir/database" \
-    -o "-F -k '$hydra_devdir/sockets' -p 5432 -h ''" -w start
-  trap stop-database EXIT
+    mkdir -p "$hydra_devdir/sockets"
+    pg_ctl -D "$hydra_devdir/database" \
+        -o "-F -k '$hydra_devdir/sockets' -p 5432 -h ''" -w start
+    trap stop-database EXIT
 }
 
 if [ -e "$hydra_devdir/database" ]; then
-  setup-dev-env
-  start-database
+    setup-dev-env
+    start-database
 fi
 
 function setup-database() {
-  if [ ! -e "$HYDRA_HOME/sql/hydra-postgresql.sql" ]; then
-    echo "hydra-postgresql.sql doesn't exist, please run make!" >&2
-    return 1
-  fi
-  initdb -D "$hydra_devdir/database" && \
-  start-database && \
-  setup-dev-env && \
-  createdb -p 5432 -h "$hydra_devdir/sockets" hydra && \
-  mkdir -p "$HYDRA_DATA" && \
-  hydra-init
+    if [ ! -e "$HYDRA_HOME/sql/hydra-postgresql.sql" ]; then
+        echo "hydra-postgresql.sql doesn't exist, please run make!" >&2
+        return 1
+    fi
+    initdb -D "$hydra_devdir/database" \
+        && start-database \
+        && setup-dev-env \
+        && createdb -p 5432 -h "$hydra_devdir/sockets" hydra \
+        && mkdir -p "$HYDRA_DATA" \
+        && hydra-init
 }

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -1,27 +1,28 @@
-hydra_devdir="$PWD/inst"
-export HYDRA_HOME="$PWD/src"
+sourceRoot="$PWD"
+hydraDevDir="$sourceRoot/inst"
+export HYDRA_HOME="$sourceRoot/src"
 
-function setup-dev-env() {
-    HYDRA_DATA="$hydra_devdir/data"
-    HYDRA_DBI="dbi:Pg:dbname=hydra;port=5432;host=$hydra_devdir/sockets"
+function setupEnvVars() {
+    HYDRA_DATA="$hydraDevDir/data"
+    HYDRA_DBI="dbi:Pg:dbname=hydra;port=5432;host=$hydraDevDir/sockets"
     export HYDRA_DATA HYDRA_DBI
 }
 
 function stop-database() {
-    if [ -e "$hydra_devdir/database/postmaster.pid" ]; then
-        pg_ctl -D "$hydra_devdir/database" stop
+    if [ -e "$hydraDevDir/database/postmaster.pid" ]; then
+        pg_ctl -D "$hydraDevDir/database" stop
     fi
 }
 
 function start-database() {
-    mkdir -p "$hydra_devdir/sockets"
-    pg_ctl -D "$hydra_devdir/database" \
-        -o "-F -k '$hydra_devdir/sockets' -p 5432 -h ''" -w start
+    mkdir -p "$hydraDevDir/sockets"
+    pg_ctl -D "$hydraDevDir/database" \
+        -o "-F -k '$hydraDevDir/sockets' -p 5432 -h ''" -w start
     trap stop-database EXIT
 }
 
-if [ -e "$hydra_devdir/database" ]; then
-    setup-dev-env
+if [ -e "$hydraDevDir/database" ]; then
+    setupEnvVars
     start-database
 fi
 
@@ -30,10 +31,10 @@ function setup-database() {
         echo "hydra-postgresql.sql doesn't exist, please run make!" >&2
         return 1
     fi
-    initdb -D "$hydra_devdir/database" \
+    initdb -D "$hydraDevDir/database" \
         && start-database \
         && setup-dev-env \
-        && createdb -p 5432 -h "$hydra_devdir/sockets" hydra \
+        && createdb -p 5432 -h "$hydraDevDir/sockets" hydra \
         && mkdir -p "$HYDRA_DATA" \
         && hydra-init
 }

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -38,3 +38,18 @@ function setup-database() {
         && mkdir -p "$HYDRA_DATA" \
         && hydra-init
 }
+
+function setup-dev-env() {
+    if [ ! -e "$sourceRoot/configure" ]; then
+        "$sourceRoot/bootstrap"
+    fi
+    if [ ! -e Makefile ]; then
+        "$sourceRoot/configure" $configureFlags
+    fi
+    if [ ! -e "$HYDRA_HOME/sql/hydra-postgresql.sql" ]; then
+        make
+    fi
+    if [ ! -e "$hydraDevDir/database" ]; then
+        setup-database
+    fi
+}

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -36,20 +36,22 @@ function setup-database() {
         && setup-dev-env \
         && createdb -p 5432 -h "$hydraDevDir/sockets" hydra \
         && mkdir -p "$HYDRA_DATA" \
-        && hydra-init
+        && hydra-init \
+        && return 0
+    return 1
 }
 
 function setup-dev-env() {
     if [ ! -e "$sourceRoot/configure" ]; then
-        "$sourceRoot/bootstrap"
+        "$sourceRoot/bootstrap" || return 1
     fi
     if [ ! -e Makefile ]; then
-        "$sourceRoot/configure" $configureFlags
+        "$sourceRoot/configure" $configureFlags || return 1
     fi
     if [ ! -e "$HYDRA_HOME/sql/hydra-postgresql.sql" ]; then
-        make
+        make || return 1
     fi
     if [ ! -e "$hydraDevDir/database" ]; then
-        setup-database
+        setup-database || return 1
     fi
 }

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -22,8 +22,12 @@ function start-database() {
         && pg_ctl -D "$hydraDevDir/database" status &> /dev/null \
         && return 0
     mkdir -p "$hydraDevDir/sockets"
-    local setsid="$(type -P setsid 2> /dev/null || :)"
-    $setsid pg_ctl -D "$hydraDevDir/database" \
+    if type -P setsid &> /dev/null; then
+        local ctl="setsid -w pg_ctl"
+    else
+        local ctl=pg_ctl
+    fi
+    $ctl -D "$hydraDevDir/database" \
         -o "-F -k '$hydraDevDir/sockets' -p 5432 -h ''" -w start
     trap stop-database EXIT
 }

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -56,5 +56,6 @@ function setup-dev-env() {
     fi
     if [ ! -e "$hydraDevDir/database" ]; then
         setup-database || return 1
+        hydra-create-user admin --password admin --role admin || return 1
     fi
 }

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -3,9 +3,12 @@ hydraDevDir="$sourceRoot/inst"
 export HYDRA_HOME="$sourceRoot/src"
 
 function setupEnvVars() {
+    PGDATABASE=hydra
+    PGHOST="$hydraDevDir/sockets"
+    PGPORT=5432
     HYDRA_DATA="$hydraDevDir/data"
-    HYDRA_DBI="dbi:Pg:dbname=hydra;port=5432;host=$hydraDevDir/sockets"
-    export HYDRA_DATA HYDRA_DBI
+    HYDRA_DBI="dbi:Pg:dbname=$PGDATABASE;port=$PGPORT;host=$PGHOST"
+    export PGDATABASE PGHOST PGPORT HYDRA_DATA HYDRA_DBI
 }
 
 function stop-database() {

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -18,6 +18,7 @@ function stop-database() {
 }
 
 function start-database() {
+    [ -e "$hydraDevDir/database/postmaster.pid" ] || return 0
     mkdir -p "$hydraDevDir/sockets"
     local setsid="$(type -P setsid 2> /dev/null || :)"
     $setsid pg_ctl -D "$hydraDevDir/database" \

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -19,7 +19,8 @@ function stop-database() {
 
 function start-database() {
     mkdir -p "$hydraDevDir/sockets"
-    pg_ctl -D "$hydraDevDir/database" \
+    local setsid="$(type -P setsid 2> /dev/null || :)"
+    $setsid pg_ctl -D "$hydraDevDir/database" \
         -o "-F -k '$hydraDevDir/sockets' -p 5432 -h ''" -w start
     trap stop-database EXIT
 }

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -38,10 +38,6 @@ if [ -e "$hydraDevDir/database" ]; then
 fi
 
 function setup-database() {
-    if [ ! -e "$HYDRA_HOME/sql/hydra-postgresql.sql" ]; then
-        echo "hydra-postgresql.sql doesn't exist, please run make!" >&2
-        return 1
-    fi
     setupEnvVars
     initdb -D "$hydraDevDir/database" \
         && start-database \

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -1,0 +1,39 @@
+hydra_devdir="$PWD/inst"
+export HYDRA_HOME="$PWD/src"
+
+function setup-dev-env() {
+  HYDRA_DATA="$hydra_devdir/data"
+  HYDRA_DBI="dbi:Pg:dbname=hydra;port=5432;host=$hydra_devdir/sockets"
+  export HYDRA_DATA HYDRA_DBI
+}
+
+function stop-database() {
+  if [ -e "$hydra_devdir/database/postmaster.pid" ]; then
+    pg_ctl -D "$hydra_devdir/database" stop
+  fi
+}
+
+function start-database() {
+  mkdir -p "$hydra_devdir/sockets"
+  pg_ctl -D "$hydra_devdir/database" \
+    -o "-F -k '$hydra_devdir/sockets' -p 5432 -h ''" -w start
+  trap stop-database EXIT
+}
+
+if [ -e "$hydra_devdir/database" ]; then
+  setup-dev-env
+  start-database
+fi
+
+function setup-database() {
+  if [ ! -e "$HYDRA_HOME/sql/hydra-postgresql.sql" ]; then
+    echo "hydra-postgresql.sql doesn't exist, please run make!" >&2
+    return 1
+  fi
+  initdb -D "$hydra_devdir/database" && \
+  start-database && \
+  setup-dev-env && \
+  createdb -p 5432 -h "$hydra_devdir/sockets" hydra && \
+  mkdir -p "$HYDRA_DATA" && \
+  hydra-init
+}

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -19,7 +19,7 @@ function stop-database() {
 
 function start-database() {
     [ -e "$hydraDevDir/database/postmaster.pid" ] \
-        && kill -0 "$(< "$hydraDevDir/database/postmaster.pid")" \
+        && pg_ctl -D "$hydraDevDir/database" status &> /dev/null \
         && return 0
     mkdir -p "$hydraDevDir/sockets"
     local setsid="$(type -P setsid 2> /dev/null || :)"

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -18,7 +18,9 @@ function stop-database() {
 }
 
 function start-database() {
-    [ -e "$hydraDevDir/database/postmaster.pid" ] || return 0
+    [ -e "$hydraDevDir/database/postmaster.pid" ] \
+        && kill -0 "$(< "$hydraDevDir/database/postmaster.pid")" \
+        && return 0
     mkdir -p "$hydraDevDir/sockets"
     local setsid="$(type -P setsid 2> /dev/null || :)"
     $setsid pg_ctl -D "$hydraDevDir/database" \

--- a/shell-hook.sh
+++ b/shell-hook.sh
@@ -34,9 +34,9 @@ function setup-database() {
         echo "hydra-postgresql.sql doesn't exist, please run make!" >&2
         return 1
     fi
+    setupEnvVars
     initdb -D "$hydraDevDir/database" \
         && start-database \
-        && setup-dev-env \
         && createdb -p 5432 -h "$hydraDevDir/sockets" hydra \
         && mkdir -p "$HYDRA_DATA" \
         && hydra-init \

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./release.nix { shell = true; }).build.x86_64-linux
+(import ./release.nix { shell = true; }).build.${builtins.currentSystem}

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,5 @@
-(import ./release.nix { shell = true; }).build.${builtins.currentSystem}
+{ nix ? null } @ args:
+
+(import ./release.nix (args // {
+  shell = true;
+})).build.${builtins.currentSystem}

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,0 @@
-{ nix ? null } @ args:
-
-(import ./release.nix (args // {
-  shell = true;
-})).build.${builtins.currentSystem}

--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -381,7 +382,7 @@ void State::buildRemote(ref<Store> destStore,
         if (info->consecutiveFailures == 0 || info->lastFailure < now - std::chrono::seconds(30)) {
             info->consecutiveFailures = std::min(info->consecutiveFailures + 1, (unsigned int) 4);
             info->lastFailure = now;
-            int delta = retryInterval * powf(retryBackoff, info->consecutiveFailures - 1) + (rand() % 30);
+            int delta = retryInterval * std::pow(retryBackoff, info->consecutiveFailures - 1) + (rand() % 30);
             printMsg(lvlInfo, format("will disable machine ‘%1%’ for %2%s") % machine->sshName % delta);
             info->disabledUntil = now + std::chrono::seconds(delta);
         }

--- a/src/hydra-queue-runner/builder.cc
+++ b/src/hydra-queue-runner/builder.cc
@@ -38,7 +38,7 @@ void State::builder(MachineReservation::ptr reservation)
             step_->tries++;
             nrRetries++;
             if (step_->tries > maxNrRetries) maxNrRetries = step_->tries; // yeah yeah, not atomic
-            int delta = retryInterval * powf(retryBackoff, step_->tries - 1) + (rand() % 10);
+            int delta = retryInterval * std::pow(retryBackoff, step_->tries - 1) + (rand() % 10);
             printMsg(lvlInfo, format("will retry ‘%1%’ after %2%s") % step->drvPath % delta);
             step_->after = std::chrono::system_clock::now() + std::chrono::seconds(delta);
         }

--- a/src/hydra-queue-runner/dispatcher.cc
+++ b/src/hydra-queue-runner/dispatcher.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <thread>
 #include <unordered_map>
 
@@ -119,8 +120,8 @@ system_time State::doDispatch()
         sort(machinesSorted.begin(), machinesSorted.end(),
             [](const MachineInfo & a, const MachineInfo & b) -> bool
             {
-                float ta = roundf(a.currentJobs / a.machine->speedFactor);
-                float tb = roundf(b.currentJobs / b.machine->speedFactor);
+                float ta = std::round(a.currentJobs / a.machine->speedFactor);
+                float tb = std::round(b.currentJobs / b.machine->speedFactor);
                 return
                     ta != tb ? ta < tb :
                     a.machine->speedFactor != b.machine->speedFactor ? a.machine->speedFactor > b.machine->speedFactor :

--- a/src/root/Makefile.am
+++ b/src/root/Makefile.am
@@ -18,9 +18,9 @@ nobase_hydra_DATA = $(EXTRA_DIST)
 
 all:
 	mkdir -p $(srcdir)/static/js
-	unzip -u -d $(srcdir)/static/js/jquery $(JQUERY)
-	unzip -u -d $(srcdir)/static $(BOOTSTRAP)
-	unzip -u -d $(srcdir)/static/js $(FLOT)
+	unzip -u -o -d $(srcdir)/static/js/jquery $(JQUERY)
+	unzip -u -o -d $(srcdir)/static $(BOOTSTRAP)
+	unzip -u -o -d $(srcdir)/static/js $(FLOT)
 
 install-data-local: $(ZIPS)
 	mkdir -p $(hydradir)/static/js


### PR DESCRIPTION
So far the instructions in the `README` for spinning up a development environment were quite terse and also not to its full extent, because in the end the production environment is running PostgreSQL and not SQLite.

With these changes, we now have the ability to quickly spin up a local PostgreSQL cluster within the `inst/database` directory which is started and shut down upon entering/exiting a `nix-shell`.

Using `setup-dev-env` we now have a function inside the Nix shell, which should do all that work on the users behalf.

The main motivation behind this change was that I usually need to be mentally prepared (like: "gosh, I need to set up a dev environment to properly work on Hydra... maybe tomorrow...") for it to go through all these steps and wanted to make it easier for new developers to dive in.

Cc: @edolstra, @domenkozar
