### PR TITLE
Add a nix expression to build the manual

### DIFF
--- a/doc/manual/default.nix
+++ b/doc/manual/default.nix
@@ -1,0 +1,53 @@
+let
+  pkgs = import <nixpkgs> { };
+  lib = pkgs.lib;
+  sources = lib.sourceFilesBySuffices ./. [".xml"];
+in
+pkgs.stdenv.mkDerivation {
+  name = "hydra-manual";
+
+  buildInputs = with pkgs; [ pandoc libxml2 libxslt zip ];
+
+  xsltFlags = ''
+    --param section.autolabel 1
+    --param section.label.includes.component.label 1
+    --param html.stylesheet 'style.css'
+    --param xref.with.number.and.title 1
+    --param toc.section.depth 3
+    --param admon.style '''
+    --param callout.graphics.extension '.gif'
+  '';
+
+  buildCommand = ''
+    ln -s '${sources}/'*.xml .
+
+    # validate against relaxng schema
+    xmllint --nonet --xinclude --noxincludenode manual.xml --output manual-full.xml
+    ${pkgs.jing}/bin/jing ${pkgs.docbook5}/xml/rng/docbook/docbook.rng manual-full.xml
+
+    dst=$out/share/doc/hydra
+    mkdir -p $dst
+    xsltproc $xsltFlags --nonet --xinclude \
+      --output $dst/manual.html \
+      ${pkgs.docbook5_xsl}/xml/xsl/docbook/xhtml/docbook.xsl \
+      ./manual.xml
+
+    cp ${./style.css} $dst/style.css
+
+    mkdir -p $dst/images/callouts
+    cp "${pkgs.docbook5_xsl}/xml/xsl/docbook/images/callouts/"*.gif $dst/images/callouts/
+
+    mkdir -p $out/nix-support
+    echo "doc manual $dst manual.html" >> $out/nix-support/hydra-build-products
+
+    xsltproc $xsltFlags --nonet --xinclude \
+      --output $dst/epub/ \
+      ${pkgs.docbook5_xsl}/xml/xsl/docbook/epub/docbook.xsl \
+      ./manual.xml
+
+    cp -r $dst/images $dst/epub/OEBPS
+    echo "application/epub+zip" > mimetype
+    zip -0Xq  "$dst/Hydra User's Guide - NixOS community.epub" mimetype
+    zip -Xr9D "$dst/Hydra User's Guide - NixOS community.epub" $dst/epub/*
+  '';
+}

--- a/doc/manual/default.nix
+++ b/doc/manual/default.nix
@@ -3,51 +3,72 @@ let
   lib = pkgs.lib;
   sources = lib.sourceFilesBySuffices ./. [".xml"];
 in
-pkgs.stdenv.mkDerivation {
-  name = "hydra-manual";
+{
+  manual = pkgs.stdenv.mkDerivation {
+    name = "hydra-manual";
 
-  buildInputs = with pkgs; [ pandoc libxml2 libxslt zip ];
+    buildInputs = with pkgs; [ libxml2 libxslt ];
 
-  xsltFlags = ''
-    --param section.autolabel 1
-    --param section.label.includes.component.label 1
-    --param html.stylesheet 'style.css'
-    --param xref.with.number.and.title 1
-    --param toc.section.depth 3
-    --param admon.style '''
-    --param callout.graphics.extension '.gif'
-  '';
+    xsltFlags = ''
+      --param section.autolabel 1
+      --param section.label.includes.component.label 1
+      --param html.stylesheet 'style.css'
+      --param xref.with.number.and.title 1
+      --param toc.section.depth 3
+      --param admon.style '''
+      --param callout.graphics.extension '.gif'
+    '';
 
-  buildCommand = ''
-    ln -s '${sources}/'*.xml .
+    buildCommand = ''
+      ln -s '${sources}/'*.xml .
 
-    # validate against relaxng schema
-    xmllint --nonet --xinclude --noxincludenode manual.xml --output manual-full.xml
-    ${pkgs.jing}/bin/jing ${pkgs.docbook5}/xml/rng/docbook/docbook.rng manual-full.xml
+      # validate against relaxng schema
+      xmllint --nonet --xinclude --noxincludenode manual.xml --output manual-full.xml
+      ${pkgs.jing}/bin/jing ${pkgs.docbook5}/xml/rng/docbook/docbook.rng manual-full.xml
 
-    dst=$out/share/doc/hydra
-    mkdir -p $dst
-    xsltproc $xsltFlags --nonet --xinclude \
-      --output $dst/manual.html \
-      ${pkgs.docbook5_xsl}/xml/xsl/docbook/xhtml/docbook.xsl \
-      ./manual.xml
+      dst=$out/share/doc/hydra
+      mkdir -p $dst
+      xsltproc $xsltFlags --nonet --xinclude \
+        --output $dst/manual.html \
+        ${pkgs.docbook5_xsl}/xml/xsl/docbook/xhtml/docbook.xsl \
+        ./manual.xml
 
-    cp ${./style.css} $dst/style.css
+      cp ${./style.css} $dst/style.css
 
-    mkdir -p $dst/images/callouts
-    cp "${pkgs.docbook5_xsl}/xml/xsl/docbook/images/callouts/"*.gif $dst/images/callouts/
+      mkdir -p $dst/images/callouts
+      cp "${pkgs.docbook5_xsl}/xml/xsl/docbook/images/callouts/"*.gif $dst/images/callouts/
 
-    mkdir -p $out/nix-support
-    echo "doc manual $dst manual.html" >> $out/nix-support/hydra-build-products
+      mkdir -p $out/nix-support
+      echo "doc manual $dst manual.html" >> $out/nix-support/hydra-build-products
+    '';
+  };
 
-    xsltproc $xsltFlags --nonet --xinclude \
-      --output $dst/epub/ \
-      ${pkgs.docbook5_xsl}/xml/xsl/docbook/epub/docbook.xsl \
-      ./manual.xml
+  manualPDF = pkgs.stdenv.mkDerivation {
+    name = "hydra-manual-pdf";
 
-    cp -r $dst/images $dst/epub/OEBPS
-    echo "application/epub+zip" > mimetype
-    zip -0Xq  "$dst/Hydra User's Guide - NixOS community.epub" mimetype
-    zip -Xr9D "$dst/Hydra User's Guide - NixOS community.epub" $dst/epub/*
-  '';
+    buildInputs = with pkgs; [ libxml2 libxslt dblatex dblatex.tex ];
+
+    xsltFlags = ''
+      --param section.autolabel 1
+      --param section.label.includes.component.label 1
+      --param html.stylesheet 'style.css'
+      --param xref.with.number.and.title 1
+      --param toc.section.depth 3
+      --param admon.style '''
+      --param callout.graphics.extension '.gif'
+    '';
+
+    buildCommand = ''
+      ln -s '${sources}/'*.xml .
+ 
+      dst=$out/share/doc/nixos
+      mkdir -p $dst
+      xmllint --xinclude manual.xml | dblatex -o $dst/manual.pdf - \
+        -P doc.collab.show=0 \
+        -P latex.output.revhistory=0
+
+      mkdir -p $out/nix-support
+      echo "doc-pdf manual $dst/manual.pdf" >> $out/nix-support/hydra-build-products
+    '';
+  };
 }

--- a/doc/manual/installation.xml
+++ b/doc/manual/installation.xml
@@ -188,7 +188,7 @@ hydra-init</screen>
 hydra-server</screen>
 
       When the server is started, you can browse to
-      <ulink>http://localhost:3000/</ulink> to start configuring
+      <link xlink:href="http://localhost:3000/">http://localhost:3000/</link> to start configuring
       your Hydra instance.
     </para>
 
@@ -197,20 +197,20 @@ hydra-server</screen>
       server.  There are two other processes that come into play:
 
       <itemizedlist>
-        <listitem>
+        <listitem><para>
           The <emphasis>evaluator</emphasis> is responsible for
           periodically evaluating job sets, checking out their
           dependencies off their version control systems (VCS), and
           queueing new builds if the result of the evaluation changed.
           It is launched by the <command>hydra-evaluator</command>
           command.
-        </listitem>
-        <listitem>
+        </para></listitem>
+        <listitem><para>
           The <emphasis>queue runner</emphasis> launches builds (using
           Nix) as they are queued by the evaluator, scheduling them
           onto the configured Nix hosts.  It is launched using the
           <command>hydra-queue-runner</command> command.
-        </listitem>
+        </para></listitem>
       </itemizedlist>
 
       All three processes must be running for Hydra to be fully

--- a/doc/manual/introduction.xml
+++ b/doc/manual/introduction.xml
@@ -19,50 +19,50 @@
       more in-depth testing than what developers could feasibly do manually:
 
       <itemizedlist>
-        <listitem> <emphasis>Portability testing</emphasis>: The
+        <listitem><para> <emphasis>Portability testing</emphasis>: The
         software may need to be built and tested on many different
         platforms.  It is infeasible for each developer to do this
         before every commit.
-        </listitem>
+        </para></listitem>
 
-        <listitem> Likewise, many projects have very large test sets
+        <listitem><para> Likewise, many projects have very large test sets
         (e.g., regression tests in a compiler, or stress tests in a
         DBMS) that can take hours or days to run to completion.
-        </listitem>
+        </para></listitem>
 
-        <listitem> Many kinds of static and dynamic analyses can be
+        <listitem><para> Many kinds of static and dynamic analyses can be
         performed as part of the tests, such as code coverage runs and
         static analyses.
-        </listitem>
+        </para></listitem>
 
-        <listitem> It may also be necessary to build many different
+        <listitem><para> It may also be necessary to build many different
         <emphasis>variants</emphasis> of the software.  For instance,
         it may be necessary to verify that the component builds with
         various versions of a compiler.
-        </listitem>
+        </para></listitem>
 
-        <listitem> Developers typically use incremental building to
+        <listitem><para> Developers typically use incremental building to
         test their changes (since a full build may take too long), but
         this is unreliable with many build management tools (such as
         Make), i.e., the result of the incremental build might differ
         from a full build.
-        </listitem>
+        </para></listitem>
 
-        <listitem> It ensures that the  software can be built from the
+        <listitem><para> It ensures that the  software can be built from the
         sources under  revision control.  Users  of version management
         systems  such as  CVS  and Subversion  often  forget to  place
         source files under revision control.
-        </listitem>
+        </para></listitem>
 
-        <listitem> The machines on which the continuous integration
+        <listitem><para> The machines on which the continuous integration
         system runs ideally provides a clean, well-defined build
         environment.  If this environment is administered through
         proper SCM techniques, then builds produced by the system can
         be reproduced.  In contrast, developer work environments are
         typically not under any kind of SCM control.
-        </listitem>
+        </para></listitem>
 
-        <listitem> In large projects, developers often work on a
+        <listitem><para> In large projects, developers often work on a
         particular component of the project, and do not build and test
         the composition of those components (again since this is
         likely to take too long).  To prevent the phenomenon of ``big
@@ -70,16 +70,16 @@
         near the end of the development process, it is important to
         test components together as soon as possible (hence
         <emphasis>continuous integration</emphasis>).
-        </listitem>
+        </para></listitem>
 
-        <listitem> It allows software to be
+        <listitem><para> It allows software to be
         <emphasis>released</emphasis> by automatically creating
         packages that users can download and install.  To do this
         manually represents an often prohibitive amount of work, as
         one may want to produce releases for many different platforms:
         e.g., installers for Windows and Mac OS X, RPM or Debian
         packages for certain Linux distributions, and so on.
-        </listitem>
+        </para></listitem>
 
       </itemizedlist>
     </para>
@@ -92,19 +92,19 @@
 
       <itemizedlist>
 
-        <listitem>It obtains the latest version of the component's
+        <listitem><para>It obtains the latest version of the component's
         source code from the version management system.
-        </listitem>
+        </para></listitem>
 
-        <listitem> It runs the component's build process (which
+        <listitem><para> It runs the component's build process (which
         presumably includes the execution of the component's test
         set).
-        </listitem>
+        </para></listitem>
 
-        <listitem> It presents the results of the build (such as error
+        <listitem><para> It presents the results of the build (such as error
         logs and releases) to the developers, e.g., by producing a web
         page.
-        </listitem>
+        </para></listitem>
 
       </itemizedlist>
 
@@ -114,7 +114,7 @@
 
       <itemizedlist>
 
-        <listitem> They do not manage the <emphasis>build
+        <listitem><para> They do not manage the <emphasis>build
         environment</emphasis>.  The build environment consists of the
         dependencies necessary to perform a build action, e.g.,
         compilers, libraries, etc.  Setting up the environment is
@@ -132,9 +132,9 @@
         different directories and manually pass the appropriate paths
         to the build processes of the various components.  But this is
         a rather tiresome and error-prone process.
-        </listitem>
+        </para></listitem>
 
-        <listitem> They do not easily support <emphasis>variability in software
+        <listitem><para> They do not easily support <emphasis>variability in software
         systems</emphasis>.  A system may have a great deal of build-time
         variability: optional functionality, whether to build a debug or
         production version, different versions of dependencies, and so on.
@@ -147,7 +147,7 @@
         of subsystems, e.g., the head revision of a component against stable
         releases of its dependencies, and vice versa, as this can reveal
         various integration problems.
-        </listitem>
+        </para></listitem>
 
       </itemizedlist>
     </para>

--- a/doc/manual/projects.xml
+++ b/doc/manual/projects.xml
@@ -138,15 +138,13 @@ system   String value "i686-linux"
     <title>Release Set</title>
 
     <!-- TODO -->
+    <para>
     there must be one primary job
 
     check the radio button of exactly one job
 
     https://svn.nixos.org/repos/nix/nixpkgs/trunk
-  </section>
-
-  <section>
-    <title>Building Jobs</title>
+    </para>
   </section>
 
   <section>
@@ -219,16 +217,16 @@ in
       and non-GNU free software projects:
 
       <itemizedlist>
-        <listitem>it uses the GNU Build System, namely GNU Autoconf,
+        <listitem><para>it uses the GNU Build System, namely GNU Autoconf,
         and GNU Automake; for users, it means it can be installed
         using the <link
         xlink:href="http://www.gnu.org/prep/standards/html_node/Managing-Releases.html">usual
         <literal>./configure &amp;&amp; make install</literal>
         procedure</link>;
-        </listitem>
-        <listitem>it uses Gettext for internationalization;</listitem>
-        <listitem>it has a Texinfo manual, which can be rendered as PDF
-        with TeX.</listitem>
+        </para></listitem>
+        <listitem><para>it uses Gettext for internationalization;</para></listitem>
+        <listitem><para>it has a Texinfo manual, which can be rendered as PDF
+        with TeX.</para></listitem>
       </itemizedlist>
 
       The file defines a jobset consisting of two jobs:


### PR DESCRIPTION
This add a nix expression to build the manual with `nix-build` in a similar fashion to `nixpkgs`.

```
$ nix-build doc/manual -A manual
$ nix-build doc/manual -A manualPDF
```
