### PR TITLE
module: add default to buildMachinesFiles

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -165,7 +165,7 @@ in
 
       buildMachinesFiles = mkOption {
         type = types.listOf types.path;
-        default = [];
+        default = [ "/etc/nix/machines" ];
         example = [ "/etc/nix/machines" "/var/lib/hydra/provisioner/machines" ];
         description = "List of files containing build machines.";
       };


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/17469 for motivation.

Relevant parts:

---

Currently `nix.buildMachines` remotes are listed in "Machine Status" and enabled in "Manage machines" but won't be used because `hydra.buildMachinesFiles` is empty by default.

This adds `/etc/nix/machines` in the default `hydra.buildMachinesFiles` so remotes defined in`nix.buildMachines` are used without explicit configuration.

---

I suppose upstream Hydra has the same issue. 

```
NIX_REMOTE_SYSTEMS = concatStringsSep ":" cfg.buildMachinesFiles;
```

So if `buildMachinesFiles` is empty, `NIX_REMOTE_SYSTEMS` will be empty too.

On the other hand, Hydra uses `/etc/nix/machines` when `NIX_REMOTE_SYSTEMS` is empty, see  https://github.com/NixOS/hydra/blob/master/src/lib/Hydra/Helper/Nix.pm#L306

So if I understand the code correctly, current default behavior is that Hydra web interface list machines defined in `/etc/nix/machines` but the builder will not use it as `NIX_REMOTE_SYSTEMS` is empty.

---
