### PR TITLE
Give highest CPU priority to evaluator right after kernel

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -345,6 +345,8 @@ in
           { ExecStart = "@${cfg.package}/bin/hydra-evaluator hydra-evaluator";
             User = "hydra";
             Restart = "always";
+            # Give evaluator highest CPU priority right after kernel
+            Nice = -19;
             WorkingDirectory = baseDir;
           };
       };


### PR DESCRIPTION
We've noticed that when Hydra serves a lot of nars, they hog CPU usage a lot for compression.

This PR gives evalutor the highest priority so builds can get in the pipeline ASAP.

See https://github.com/snabblab/snabblab-nixos/commit/07c3749057b9d28af11149f999aada115e2146d6 for downstream commit.

cc @edolstra 