### PR TITLE
Sort inputs table

### DIFF
--- a/src/root/edit-jobset.tt
+++ b/src/root/edit-jobset.tt
@@ -47,7 +47,7 @@
       <tr><th></th><th>Input name</th><th>Type</th><th style="width: 50%">Value</th><th>Notify committers</th></tr>
     </thead>
     <tbody class="inputs">
-      [% inputs = createFromEval ? eval.jobsetevalinputs : jobset.jobsetinputs; FOREACH input IN inputs %]
+      [% inputs = createFromEval ? eval.jobsetevalinputs : jobset.jobsetinputs; FOREACH input IN inputs.sort('name') %]
         [% INCLUDE renderJobsetInput input=input baseName="input-$input.name" %]
       [% END %]
       <tr>

--- a/src/root/jobset.tt
+++ b/src/root/jobset.tt
@@ -33,7 +33,7 @@
       <tr><th>Input name</th><th>Type</th><th>Values</th></tr>
     </thead>
     <tbody class="inputs">
-      [% FOREACH input IN jobset.jobsetinputs %]
+      [% FOREACH input IN jobset.jobsetinputs.sort('name') %]
         [% INCLUDE renderJobsetInput input=input baseName="input-$input.name" %]
       [% END %]
     </tbody>


### PR DESCRIPTION
When having a huge input table, it's really hard to reason about inputs when they're not sorted every time you want to edit them. This PR sorts them by name:

![2016-08-12-130844_1023x724_scrot](https://cloud.githubusercontent.com/assets/126339/17620630/f5259bc8-608d-11e6-99c4-8513868092e1.png)

Fixes https://github.com/NixOS/hydra/issues/371

cc  @edolstra 