### PR TITLE
Remove logfile.css from templates

### DIFF
--- a/src/root/layout.tt
+++ b/src/root/layout.tt
@@ -37,7 +37,6 @@
     <script type="text/javascript" src="[% c.uri_for("/static/js/bootbox.min.js") %]"></script>
 
     <link rel="stylesheet" href="[% c.uri_for("/static/css/tree.css") %]" type="text/css" />
-    <link rel="stylesheet" href="[% c.uri_for("/static/css/logfile.css") %]" type="text/css" />
 
     <script type="text/javascript" src="[% c.uri_for("/static/js/common.js") %]"></script>
 


### PR DESCRIPTION
It is no longer used and causes unnecessary 404s