### PR TITLE
Only set buildMachinesFiles when nix.buildMachines is defined

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -165,7 +165,7 @@ in
 
       buildMachinesFiles = mkOption {
         type = types.listOf types.path;
-        default = [ "/etc/nix/machines" ];
+        default = optional (config.nix.buildMachines != []) "/etc/nix/machines";
         example = [ "/etc/nix/machines" "/var/lib/hydra/provisioner/machines" ];
         description = "List of files containing build machines.";
       };


### PR DESCRIPTION
This should fix #430.

We should set `buildMachinesFiles` to `[ "/etc/nix/machines" ]`only when `nix.buildMachines` is set to a non-empty list because that [causes](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/misc/nix-daemon.nix#L341) that file to be generated. 

This should also be applied to [<nixpkgs/nixos/modules/services/continuous-integration/hydra/default.nix>](
https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/continuous-integration/hydra/default.nix#L169).