### PR TITLE
Set nix.package to the same version that hydra is using

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -217,6 +217,8 @@ in
 
     nix.trustedUsers = [ "hydra-queue-runner" ];
 
+    nix.package = (import ./nix.nix pkgs).nix;
+
     services.hydra-dev.package = mkDefault ((import ./release.nix {}).build.x86_64-linux);
 
     services.hydra-dev.extraConfig =

--- a/nix.nix
+++ b/nix.nix
@@ -1,0 +1,26 @@
+pkgs : with pkgs; rec {
+  aws-sdk-cpp' =
+    lib.overrideDerivation (aws-sdk-cpp.override {
+      apis = ["s3"];
+      customMemoryManagement = false;
+    }) (attrs: {
+      src = fetchFromGitHub {
+        owner = "edolstra";
+        repo = "aws-sdk-cpp";
+        rev = "d1e2479f79c24e2a1df8a3f3ef3278a1c6383b1e";
+        sha256 = "1vhgsxkhpai9a7dk38q4r239l6dsz2jvl8hii24c194lsga3g84h";
+      };
+    });
+  nix = lib.overrideDerivation nixUnstable (attrs: {
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "nix";
+      rev = "4be4f6de56f4de77f6a376f1a40ed75eb641bb89";
+      sha256 = "0icvbwpca1jh8qkdlayxspdxl5fb0qjjd1kn74x6gs6iy66kndq6";
+    };
+    buildInputs = attrs.buildInputs ++ [ autoreconfHook bison flex ];
+    nativeBuildInputs = attrs.nativeBuildInputs ++ [ aws-sdk-cpp' autoconf-archive ];
+    configureFlags = attrs.configureFlags + " --disable-doc-gen";
+    preConfigure = "./bootstrap.sh; mkdir -p $doc $man";
+  });
+}

--- a/release.nix
+++ b/release.nix
@@ -36,37 +36,11 @@ in
 rec {
 
   build = genAttrs' (system:
-
-    with import <nixpkgs> { inherit system; };
-
+    let pkgsSystem = import <nixpkgs> { inherit system; };
+        nixTools = import ./nix.nix pkgsSystem;
+    in with pkgsSystem;
+       with nixTools;
     let
-
-      aws-sdk-cpp' =
-        lib.overrideDerivation (aws-sdk-cpp.override {
-          apis = ["s3"];
-          customMemoryManagement = false;
-        }) (attrs: {
-          src = fetchFromGitHub {
-            owner = "edolstra";
-            repo = "aws-sdk-cpp";
-            rev = "d1e2479f79c24e2a1df8a3f3ef3278a1c6383b1e";
-            sha256 = "1vhgsxkhpai9a7dk38q4r239l6dsz2jvl8hii24c194lsga3g84h";
-          };
-        });
-
-      nix = overrideDerivation nixUnstable (attrs: {
-        src = fetchFromGitHub {
-          owner = "NixOS";
-          repo = "nix";
-          rev = "4be4f6de56f4de77f6a376f1a40ed75eb641bb89";
-          sha256 = "0icvbwpca1jh8qkdlayxspdxl5fb0qjjd1kn74x6gs6iy66kndq6";
-        };
-        buildInputs = attrs.buildInputs ++ [ autoreconfHook bison flex ];
-        nativeBuildInputs = attrs.nativeBuildInputs ++ [ aws-sdk-cpp' autoconf-archive ];
-        configureFlags = attrs.configureFlags + " --disable-doc-gen";
-        preConfigure = "./bootstrap.sh; mkdir -p $doc $man";
-      });
-
       perlDeps = buildEnv {
         name = "hydra-perl-deps";
         paths = with perlPackages;


### PR DESCRIPTION
In the process of debugging #433 @FPtje and I stumbled upon an interesting problem. Our hydra machine is deployed with a nixos-16.09 revision of nixpkgs. This means that its nix db has schema version 7. The machine uses hydra-HEAD however which [uses](https://github.com/NixOS/hydra/blob/master/release.nix#L57) a newer version of the nix tools. When the nix tools that hydra uses touch the DB they will upgrade its schema to version 10. However since the nix-daemon running on the machine only knows version 7 it will give errors.

The solution is for the hydra-module to set `nix.package` to the version it's using itself.