### PR TITLE
Move build logic for the core hydra package into its own default.nix.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,111 @@
+{ stdenv
+, hydraSrc ? { outPath = ./.; revCount = 1234; rev = "abcdef"; }
+, version ? builtins.readFile ./version + "." + toString hydraSrc.revCount + "." + hydraSrc.rev
+, makeWrapper, libtool, unzip, nukeReferences, sqlite, libpqxx
+, guile ? null
+, perl, nix, postgresql92, perlPackages, openssh, buildEnv
+, autoreconfHook, pkgconfig, topGit, mercurial, darcs, subversion, bazaar
+, openssl, bzip2, libxslt, docbook_xsl, coreutils, findutils, pixz, gzip
+, lzma, gnutar, git, gnused, rpm, dpkg, cdrkit, boehmgc, aws-sdk-cpp
+}: assert builtins.compareVersions "6" stdenv.cc.cc.version < 1;
+let perlDeps = buildEnv {
+      name = "hydra-perl-deps";
+      paths = with perlPackages;
+        [ ModulePluggable
+          CatalystActionREST
+          CatalystAuthenticationStoreDBIxClass
+          CatalystDevel
+          CatalystDispatchTypeRegex
+          CatalystPluginAccessLog
+          CatalystPluginAuthorizationRoles
+          CatalystPluginCaptcha
+          CatalystPluginSessionStateCookie
+          CatalystPluginSessionStoreFastMmap
+          CatalystPluginStackTrace
+          CatalystPluginUnicodeEncoding
+          CatalystTraitForRequestProxyBase
+          CatalystViewDownload
+          CatalystViewJSON
+          CatalystViewTT
+          CatalystXScriptServerStarman
+          CryptRandPasswd
+          DBDPg
+          DBDSQLite
+          DataDump
+          DateTime
+          DigestSHA1
+          EmailMIME
+          EmailSender
+          FileSlurp
+          IOCompress
+          IPCRun
+          JSONXS
+          LWP
+          LWPProtocolHttps
+          NetAmazonS3
+          NetStatsd
+          PadWalker
+          Readonly
+          SQLSplitStatement
+          SetScalar
+          Starman
+          SysHostnameLong
+          TestMore
+          TextDiff
+          TextTable
+          XMLSimple
+          nix
+          nix.perl-bindings
+          git
+          boehmgc
+          aws-sdk-cpp
+        ];
+    };
+in stdenv.mkDerivation {
+  name = "hydra-${version}";
+  src = hydraSrc;
+  buildInputs =
+    [ makeWrapper autoreconfHook libtool unzip nukeReferences pkgconfig sqlite libpqxx
+      topGit mercurial darcs subversion bazaar openssl bzip2 libxslt
+      guile # optional, for Guile + Guix support
+      perlDeps perl nix
+      postgresql92 # for running the tests
+    ];
+
+  hydraPath = stdenv.lib.makeBinPath (
+    [ sqlite subversion openssh nix coreutils findutils pixz
+      gzip bzip2 lzma gnutar unzip git topGit mercurial darcs gnused bazaar
+    ] ++ stdenv.lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
+
+  configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
+
+
+  preHook = ''
+    PATH=$(pwd)/src/hydra-evaluator:$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$PATH
+    PERL5LIB=$(pwd)/src/lib:$PERL5LIB;
+  '';
+
+  preCheck = ''
+    patchShebangs .
+    export LOGNAME=${LOGNAME:-foo}
+  '';
+
+  postInstall = ''
+    mkdir -p $out/nix-support
+
+    for i in $out/bin/*; do #*/
+        read -n 4 chars < $i
+        if [[ $chars =~ ELF ]]; then continue; fi
+        wrapProgram $i \
+            --prefix PERL5LIB ':' $out/libexec/hydra/lib:$PERL5LIB \
+            --prefix PATH ':' $out/bin:$hydraPath \
+            --set HYDRA_RELEASE ${version} \
+            --set HYDRA_HOME $out/libexec/hydra \
+            --set NIX_RELEASE ${nix.name or "unknown"}
+    done
+  '';
+
+  dontStrip = true;
+
+  passthru.perlDeps = perlDeps;
+}

--- a/release.nix
+++ b/release.nix
@@ -29,8 +29,6 @@ let
       environment.systemPackages = [ pkgs.perlPackages.LWP pkgs.perlPackages.JSON ];
     };
 
-  version = builtins.readFile ./version + "." + toString hydraSrc.revCount + "." + hydraSrc.rev;
-
 in
 
 rec {
@@ -47,141 +45,24 @@ rec {
           customMemoryManagement = false;
         };
 
-        /*
-      nix = overrideDerivation nixUnstable (attrs: {
-        src = fetchFromGitHub {
-          owner = "NixOS";
-          repo = "nix";
-          rev = "4be4f6de56f4de77f6a376f1a40ed75eb641bb89";
-          sha256 = "0icvbwpca1jh8qkdlayxspdxl5fb0qjjd1kn74x6gs6iy66kndq6";
-        };
-        buildInputs = attrs.buildInputs ++ [ autoreconfHook bison flex ];
-        nativeBuildInputs = attrs.nativeBuildInputs ++ [ aws-sdk-cpp' autoconf-archive ];
-        configureFlags = attrs.configureFlags + " --disable-doc-gen";
-        preConfigure = "./bootstrap.sh; mkdir -p $doc $man";
-      });
-      */
-      nix = nixUnstable;
-
-      perlDeps = buildEnv {
-        name = "hydra-perl-deps";
-        paths = with perlPackages;
-          [ ModulePluggable
-            CatalystActionREST
-            CatalystAuthenticationStoreDBIxClass
-            CatalystDevel
-            CatalystDispatchTypeRegex
-            CatalystPluginAccessLog
-            CatalystPluginAuthorizationRoles
-            CatalystPluginCaptcha
-            CatalystPluginSessionStateCookie
-            CatalystPluginSessionStoreFastMmap
-            CatalystPluginStackTrace
-            CatalystPluginUnicodeEncoding
-            CatalystTraitForRequestProxyBase
-            CatalystViewDownload
-            CatalystViewJSON
-            CatalystViewTT
-            CatalystXScriptServerStarman
-            CryptRandPasswd
-            DBDPg
-            DBDSQLite
-            DataDump
-            DateTime
-            DigestSHA1
-            EmailMIME
-            EmailSender
-            FileSlurp
-            IOCompress
-            IPCRun
-            JSONXS
-            LWP
-            LWPProtocolHttps
-            NetAmazonS3
-            NetStatsd
-            PadWalker
-            Readonly
-            SQLSplitStatement
-            SetScalar
-            Starman
-            SysHostnameLong
-            TestMore
-            TextDiff
-            TextTable
-            XMLSimple
-            nix
-            nix.perl-bindings
-            git
-            boehmgc
-            aws-sdk-cpp'
-          ];
-      };
-
+      stdenv6 = overrideCC stdenv gcc6;
     in
 
-    releaseTools.nixBuild {
-      name = "hydra-${version}";
-
-      src = if shell then null else hydraSrc;
-
-      stdenv = overrideCC stdenv gcc6;
-
-      buildInputs =
-        [ makeWrapper autoconf automake libtool unzip nukeReferences pkgconfig sqlite libpqxx
-          gitAndTools.topGit mercurial darcs subversion bazaar openssl bzip2 libxslt
-          guile # optional, for Guile + Guix support
-          perlDeps perl nix
-          postgresql92 # for running the tests
-        ];
-
-      hydraPath = lib.makeBinPath (
-        [ sqlite subversion openssh nix coreutils findutils pixz
-          gzip bzip2 lzma gnutar unzip git gitAndTools.topGit mercurial darcs gnused bazaar
-        ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
-
-      postUnpack = optionalString (!shell) ''
-        # Clean up when building from a working tree.
-        (cd $sourceRoot && (git ls-files -o --directory | xargs -r rm -rfv)) || true
-      '';
-
-      configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
-
-      preHook = ''
-        PATH=$(pwd)/src/hydra-evaluator:$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$PATH
-        PERL5LIB=$(pwd)/src/lib:$PERL5LIB;
-      '';
-
-      preConfigure = "autoreconf -vfi";
-
-      enableParallelBuilding = true;
-
-      preCheck = ''
-        patchShebangs .
-        export LOGNAME=${LOGNAME:-foo}
-      '';
-
-      postInstall = ''
-        mkdir -p $out/nix-support
-
-        for i in $out/bin/*; do
-            read -n 4 chars < $i
-            if [[ $chars =~ ELF ]]; then continue; fi
-            wrapProgram $i \
-                --prefix PERL5LIB ':' $out/libexec/hydra/lib:$PERL5LIB \
-                --prefix PATH ':' $out/bin:$hydraPath \
-                --set HYDRA_RELEASE ${version} \
-                --set HYDRA_HOME $out/libexec/hydra \
-                --set NIX_RELEASE ${nix.name or "unknown"}
-        done
-      ''; # */
-
-      dontStrip = true;
-
-      meta.description = "Build of Hydra on ${system}";
-      passthru.perlDeps = perlDeps;
+    callPackage ./. {
+      stdenv = stdenv6 // { mkDerivation = args: releaseTools.nixBuild (args // {
+        stdenv = stdenv6;
+        postUnpack = optionalString (!shell) ''
+          # Clean up when building from a working tree.
+          (cd $sourceRoot && (git ls-files -o --directory | xargs -r rm -rfv)) || true
+        '';
+      }); };
+      inherit (gitAndTools) topGit;
+      nix = nixUnstable;
+      aws-sdk-cpp = aws-sdk-cpp';
+      hydraSrc = if shell then null else hydraSrc;
     });
 
-  manual = pkgs.runCommand "hydra-manual-${version}"
+  manual = pkgs.runCommand "hydra-manual-${build.x86_64-linux.version}"
     { build = build.x86_64-linux;
     }
     ''


### PR DESCRIPTION
This allows users to build hydra using a normal mkDerivation, package overrides, etc.