### PR TITLE
Make all content of rotated table header clickable

### DIFF
--- a/src/root/static/css/rotated-th.css
+++ b/src/root/static/css/rotated-th.css
@@ -33,6 +33,7 @@ td.centered {
     transform:skew(-45deg,0deg);
     overflow: hidden;
     border-left: 1px solid #dddddd;
+    z-index: 1;
 }
 
 .table-header-rotated th.rotate-45 span {


### PR DESCRIPTION
Currently if you have multiple rotated table headers in succession, the top part of the `<div>` that holds the content (the link) gets covered up by the next header.