### PR TITLE
fix github pulls json to be deterministic

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -341,7 +341,7 @@ in
       { wantedBy = [ "multi-user.target" ];
         requires = [ "hydra-init.service" ];
         after = [ "hydra-init.service" "network.target" ];
-        path = [ pkgs.nettools cfg.package ];
+        path = with pkgs; [ nettools cfg.package jq ];
         environment = env;
         serviceConfig =
           { ExecStart = "@${cfg.package}/bin/hydra-evaluator hydra-evaluator";

--- a/src/lib/Hydra/Plugin/GithubPulls.pm
+++ b/src/lib/Hydra/Plugin/GithubPulls.pm
@@ -55,7 +55,8 @@ sub fetchInput {
     open(my $fh, ">", $filename) or die "Cannot open $filename for writing: $!";
     print $fh encode_json \%pulls;
     close $fh;
-    my $storePath = `nix-store --add "$filename"`
+    system("jq -S . < $filename > $tempdir/github-pulls-sorted.json");
+    my $storePath = `nix-store --add "$tempdir/github-pulls-sorted.json"`
         or die "cannot copy path $filename to the Nix store.\n";
     my $timestamp = time;
     return { storePath => $storePath, revision => strftime "%Y%m%d%H%M%S", gmtime($timestamp) };


### PR DESCRIPTION
the json produced by perls encode_json has the keys in a random order, this sorts them, preventing hydra from making a new job every 60 seconds