### PR TITLE
Add BitBucket plugin

### DIFF
--- a/src/lib/Hydra/Plugin/BitBucketStatus.pm
+++ b/src/lib/Hydra/Plugin/BitBucketStatus.pm
@@ -36,6 +36,11 @@ sub common {
         while (my $eval = $evals->next) {
             foreach my $i ($eval->jobsetevalinputs){
                 next unless defined $i;
+
+                # Skip if the emailResponsible field is disabled
+                my $input = $eval->jobset->jobsetinputs->find({name => $i->name });
+                next unless $input->emailresponsible;
+
                 my $uri = $i->uri;
                 my $rev = $i->revision;
                 # Skip if the uri is not a bitbucket repo

--- a/src/lib/Hydra/Plugin/BitBucketStatus.pm
+++ b/src/lib/Hydra/Plugin/BitBucketStatus.pm
@@ -1,0 +1,69 @@
+package Hydra::Plugin::BitBucketStatus;
+
+use strict;
+use parent 'Hydra::Plugin';
+use HTTP::Request;
+use JSON;
+use LWP::UserAgent;
+use Hydra::Helper::CatalystUtils;
+
+sub toBitBucketState {
+    my ($buildStatus) = @_;
+    if ($buildStatus == 0) {
+        return "SUCCESSFUL";
+    } else {
+        return "FAILED";
+    }
+}
+
+sub common {
+    my ($self, $build, $dependents, $finished) = @_;
+    my $bitbucket = $self->{config}->{bitbucket};
+    my $baseurl = $self->{config}->{'base_uri'} || "http://localhost:3000";
+
+    foreach my $b ($build, @{$dependents}) {
+        my $jobName = showJobName $b;
+        my $evals = $build->jobsetevals;
+        my $ua = LWP::UserAgent->new();
+        my $body = encode_json(
+            {
+                state => $finished ? toBitBucketState($b->buildstatus) : "INPROGRESS",
+                url => "$baseurl/build/" . $b->id,
+                name => $jobName,
+                key => $jobName,
+                description => "Hydra build #" . $b->id . " of $jobName",
+            });
+        while (my $eval = $evals->next) {
+            foreach my $i ($eval->jobsetevalinputs){
+                next unless defined $i;
+                my $uri = $i->uri;
+                my $rev = $i->revision;
+                # Skip if the uri is not a bitbucket repo
+                next unless index($uri, 'bitbucket') != -1;
+                $uri =~ m![:/]([^/]+)/([^/]+?)?$!;
+                my $owner = $1;
+                my $repo = $2;
+                my $req = HTTP::Request->new('POST', "https://api.bitbucket.org/2.0/repositories/$owner/$repo/commit/$rev/statuses/build");
+                $req->header('Content-Type' => 'application/json');
+                $req->authorization_basic($bitbucket->{username}, $bitbucket->{password});
+                $req->content($body);
+                my $res = $ua->request($req);
+                print STDERR $res->status_line, ": ", $res->decoded_content, "\n" unless $res->is_success;
+            }
+        }
+    }
+}
+
+sub buildQueued {
+    common(@_, [], 0);
+}
+
+sub buildStarted {
+    common(@_, [], 0);
+}
+
+sub buildFinished {
+    common(@_, 1);
+}
+
+1;


### PR DESCRIPTION
This plugin will post to the build status system in BitBucket. In order
to use it you need to add to **ExtraConfig**
```
<bitbucket>
username = bitbucket_username
password = bitbucket_password
</bitbucket>
```
You can use an [application password]( https://blog.bitbucket.org/2016/06/06/app-passwords-bitbucket-cloud/) instead of your password. Or you could also use team name and API key.