### PR TITLE
queue-monitor: never move lastBuildId forward without processing jobs.

### DIFF
--- a/src/hydra-queue-runner/queue-monitor.cc
+++ b/src/hydra-queue-runner/queue-monitor.cc
@@ -49,7 +49,7 @@ void State::queueMonitorLoop()
             conn->get_notifs();
 
         if (auto lowestId = buildsAdded.get()) {
-            lastBuildId = std::stoi(*lowestId) - 1;
+            lastBuildId = std::min(lastBuildId, static_cast<unsigned>(std::stoul(*lowestId) - 1));
             printMsg(lvlTalkative, "got notification: new builds added to the queue");
         }
         if (buildsRestarted.get()) {


### PR DESCRIPTION
Touchup for fix made in dc5e0b120aac06f1c46bcf0296d14775d72c2354.

Notifications about jobs added shouldn't cause lastBuildId to advance, only to re-scan for possibly missed jobs.

lastBuildId should only advance due to jobs being processed, so take the minimum of the two instead.