### PR TITLE
Improved NixOS module for Hydra (WIP)

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -37,6 +37,9 @@ with rec {
   haveLocalDB = cfg.dbi == localDB;
 
   hydraExe = name: "${cfg.package}/bin/${name}";
+
+  googleOAuthDocs =
+    "https://developers.google.com/identity/sign-in/web/devconsole-project";
 };
 
 {
@@ -64,7 +67,7 @@ with rec {
       };
 
       package = mkOption {
-        type = types.path;
+        type = types.package;
         # default = pkgs.hydra;
         description = "The Hydra package.";
       };
@@ -188,6 +191,40 @@ with rec {
           are absolute trustworthy.
         '';
       };
+
+      googleClientID = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "35009a79-1a05-49d7-b876-2b884d0f825b";
+        description = ''
+          The Google API client ID to use in the Hydra Google OAuth login.
+
+          More information is available
+          <ulink url="${googleOAuthDocs}">here</ulink>.
+        '';
+      };
+
+      private = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          FIXME: doc
+        '';
+      };
+
+      storeMode = mkOption {
+        type = types.enum [
+          "direct"
+          "local-binary-cache"
+          "s3-binary-cache"
+        ];
+        default = "direct";
+        example = "local-binary-cache";
+        description = ''
+          FIXME: doc
+        '';
+      };
     };
 
   };
@@ -233,6 +270,12 @@ with rec {
       ${optionalString (cfg.logo != null) "hydra_logo ${cfg.logo}"}
       gc_roots_dir ${cfg.gcRootsDir}
       use-substitutes = ${if cfg.useSubstitutes then "1" else "0"}
+      ${optionalString (cfg.googleClientID != null) ''
+        enable_google_login = 1
+        google_client_id = ${cfg.googleClientID}
+      ''}
+      private = ${if cfg.private then "1" else "0"}
+      store_mode = ${cfg.storeMode}
     '';
 
     environment.systemPackages = [cfg.package];

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -36,17 +36,6 @@ with {
         foldl1' = foldToFold1 lists.foldl';
       });
 
-    regex = {
-      # renderRegex
-      #   :: (∀ r . { lit : String → r, alt : [r] → r, star : r → r } → r)
-      #   -> Regex
-      renderRegex = expr: expr {
-        lit  = str: str;
-        alt  = rxs: "(" + strings.intercalate "|" rxs + ")";
-        star = rx: "(" + rx + ")*";
-      };
-    };
-
     types = lib.types // {
       oneof = list: (
         assert lib.isList list;
@@ -280,6 +269,7 @@ with rec {
       maxServers = mkOption {
         type = types.int;
         default = 25;
+        # example = ...;
         description = ''
           FIXME: doc
         '';
@@ -288,6 +278,7 @@ with rec {
       compressThreads = mkOption {
         type = types.int;
         default = 0;
+        # example = ...;
         description = ''
           FIXME: doc
         '';
@@ -297,6 +288,422 @@ with rec {
         type = (
           types.matching "^(file|s3)://(.*)(|?secret-key=(.*))$" types.str);
         default = 0;
+        # example = ...;
+        description = ''
+          FIXME: doc
+        '';
+      };
+
+      plugins.coverity = mkOption {
+        type = types.listOf (types.submodule {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            example = true;
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          jobs = mkOption {
+            type = types.str; # regex
+            example = "foo:bar:.*";
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          project = mkOption {
+            type = types.str;
+            default = [];
+            # example = ...;
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          email = mkOption {
+            type = types.str;
+            example = "hydra@nixos.org";
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          token = mkOption {
+            type = types.str;
+            # example = ...;
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          scanURL = mkOption {
+            type = types.str;
+            default = "http://scan5.coverity.com/cgi-bin/upload.py";
+            description = ''
+              FIXME: doc
+            '';
+          };
+        });
+        default = [];
+        # example = ...;
+        description = ''
+          FIXME: doc
+        '';
+      };
+
+      plugins.github = {
+        auth = mkOption {
+          type = types.attrsOf types.str;
+          default = {};
+          example = { foobar = "fd3t43ijdx"; };
+          description = ''
+            FIXME: doc
+          '';
+        };
+
+        status = mkOption {
+          type = types.listOf (types.submodule {
+            jobs = mkOption {
+              type = types.str; # regex
+              example = "foo:bar:.*";
+              description = ''
+                FIXME: doc
+              '';
+            };
+
+            inputs = mkOption {
+              type = types.listOf types.str;
+              example = ["src"];
+              description = ''
+                FIXME: doc
+              '';
+            };
+
+            exclude = mkOption {
+              type = types.bool;
+              default = true;
+              example = false;
+              description = ''
+                FIXME: doc
+              '';
+            };
+
+            description = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              # example = ...;
+              description = ''
+                FIXME: doc
+              '';
+            };
+
+            context = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              # example = ...;
+              description = ''
+                FIXME: doc
+              '';
+            };
+
+            auth = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              # example = ...;
+              description = ''
+                FIXME: doc
+              '';
+            };
+          });
+          default = [];
+          # example = ...;
+          description = ''
+            FIXME: doc
+          '';
+        };
+      };
+
+      plugins.slack = mkOption {
+        channels = mkOption {
+          type = types.listOf (types.submodule {
+            jobs = mkOption {
+              type = types.str; # regex
+              example = "foo:bar:.*";
+              description = ''
+                FIXME: doc
+              '';
+            };
+
+            url = mkOption {
+              type = types.str;
+              example = ""; # FIXME: example slack webhook
+              description = ''
+                FIXME: doc
+              '';
+            };
+
+            force = mkOption {
+              type = types.bool;
+              default = false;
+              example = true;
+              description = ''
+                FIXME: doc
+              '';
+            };
+          });
+          default = {};
+          # example = ...;
+          description = ''
+            FIXME: doc
+          '';
+        };
+      };
+
+      plugins.s3backup = {
+        buckets = mkOption {
+          type = types.attrsOf (types.submodule {
+            jobs = mkOption {
+              type = types.str; # regex
+              example = "foo:bar:.*";
+              description = ''
+                FIXME: doc
+              '';
+            };
+
+            prefix = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              # example = ...;
+              description = ''
+                FIXME: doc
+              '';
+            };
+
+            compressor = mkOption {
+              type = types.enum [null "xz" "bzip2"];
+              default = "bzip2";
+              example = "xz";
+              description = ''
+                FIXME: doc
+              '';
+            };
+          });
+          default = {};
+          # example = ...;
+          description = ''
+            FIXME: doc
+          '';
+        };
+      };
+
+      projects = mkOption {
+        type = types.attrsOf (types.submodule {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            # example = ...;
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          visible = mkOption {
+            type = types.bool;
+            default = true;
+            # example = ...;
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          displayName = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            # example = ...;
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          description = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            # example = ...;
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          homepage = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = "https://github.com/NixOS/nixpkgs";
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          owner = mkOption {
+            # FIXME: should check that this is a valid user
+            type = types.nullOr types.str;
+            example = "admin";
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          jobsets = mkOption {
+            type = types.attrsOf (types.submodule {
+              enable = mkOption {
+                type = types.bool;
+                default = true;
+                # example = ...;
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              visible = mkOption {
+                type = types.bool;
+                default = true;
+                # example = ...;
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              description = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                # example = ...;
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              expression.file = mkOption {
+                type = types.str;
+                example = "release.nix";
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              expression.input = mkOption {
+                # FIXME: should check that this is one of the inputs
+                type = types.str;
+                example = "src";
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              evaluation.keep = mkOption {
+                type = types.int;
+                example = 3;
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              evaluation.interval = mkOption {
+                type = types.int;
+                example = 10;
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              evaluation.shares = mkOption {
+                type = types.int;
+                example = 1;
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              email.enable = mkOption {
+                type = types.bool;
+                default = true;
+                # example = ...;
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              email.override = mkOption {
+                type = types.str;
+                example = "foobar@example.com";
+                description = ''
+                  FIXME: doc
+                '';
+              };
+
+              inputs = mkOption {
+                type = types.attrsOf (types.submodule {
+                  type = mkOption {
+                    type = types.enum [
+                      "boolean"
+                      "string"
+                      "path"
+                      "nix"
+                      "bzr"
+                      "bzr-checkout"
+                      "darcs"
+                      "git"
+                      "hg"
+                      "svn"
+                      "githubpulls"
+                    ];
+                    description = ''
+                      FIXME: doc
+                    '';
+                  };
+
+                  value = mkOption {
+                    type = types.str;
+                    description = ''
+                      FIXME: doc
+                    '';
+                  };
+
+                  notify = mkOption {
+                    type = types.bool;
+                    default = false;
+                    example = true;
+                    description = ''
+                      FIXME: doc
+                    '';
+                  };
+                });
+              };
+            });
+            default = {};
+            # example = ...;
+            description = ''
+              FIXME: doc
+            '';
+          };
+
+          # Project data:
+          # - enabled?
+          # - visible?
+          # - display name
+          # - description
+          # - homepage
+          # - owner
+          # - declarative spec file
+          # - declarative input type
+          #   - type:  hydra input
+          #            | previous hydra build
+          #            | previous hydra build (same system)
+          #            | previous hydra eval
+          #   - value: string
+        });
+        default = {};
+        # example = ...;
         description = ''
           FIXME: doc
         '';

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -9,6 +9,31 @@ with rec {
       assert builtins.isString str;
       (builtins.match "^${rx}$" str) != null));
   };
+
+  # utilities for generating hydra config
+  hydraConfGen = {
+    replicate = num: val: (
+      assert builtins.isInt num;
+      map (_: val) (lib.range 1 val));
+    replicateStr = num: str: (
+      assert builtins.isInt num;
+      assert builtins.isString str;
+      lib.concatStrings (hc.replicate depth str));
+    indent = depth: str: (
+      assert builtins.isInt depth;
+      assert builtins.isString str;
+      with { ws = lib.concatStrings (map (_: " ") (lib.range 1 depth)); };
+      lib.concatStrings (map (x: ws + x + "\n") (lib.splitString "\n" str)));
+    containsEOF = string: ((builtins.match ".*EOF.*" string) != null);
+
+    def = name: value: name + " = " + value;
+    defLong = key: string: (
+      assert !(containsEOF string);
+      "${key} <<EOF\n${string}\nEOF\n");
+    defList = name: list: lib.concatStrings (map (x: "${name} = ${x}\n") list);
+    stanza = name: body: "<${name}>\n${hc.indent 2 body}\n</${name}>\n";
+    seq = list: lib.concatStrings (map (x: x + "\n") list);
+  };
 };
 
 with rec {

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -12,25 +12,25 @@ let
 
   hydraEnv =
     { HYDRA_DBI = cfg.dbi;
-      HYDRA_CONFIG = "${baseDir}/hydra.conf";
-      HYDRA_DATA = "${baseDir}";
-    };
+    HYDRA_CONFIG = "${baseDir}/hydra.conf";
+    HYDRA_DATA = "${baseDir}";
+  };
 
   env =
     { NIX_REMOTE = "daemon";
-      SSL_CERT_FILE = "/etc/ssl/certs/ca-certificates.crt"; # Remove in 16.03
-      PGPASSFILE = "${baseDir}/pgpass";
-      NIX_REMOTE_SYSTEMS = concatStringsSep ":" cfg.buildMachinesFiles;
-    } // optionalAttrs (cfg.smtpHost != null) {
-      EMAIL_SENDER_TRANSPORT = "SMTP";
-      EMAIL_SENDER_TRANSPORT_host = cfg.smtpHost;
-    } // hydraEnv // cfg.extraEnv;
+    SSL_CERT_FILE = "/etc/ssl/certs/ca-certificates.crt"; # Remove in 16.03
+    PGPASSFILE = "${baseDir}/pgpass";
+    NIX_REMOTE_SYSTEMS = concatStringsSep ":" cfg.buildMachinesFiles;
+  } // optionalAttrs (cfg.smtpHost != null) {
+    EMAIL_SENDER_TRANSPORT = "SMTP";
+    EMAIL_SENDER_TRANSPORT_host = cfg.smtpHost;
+  } // hydraEnv // cfg.extraEnv;
 
   serverEnv = env //
     { HYDRA_TRACKER = cfg.tracker;
-      COLUMNS = "80";
-      PGPASSFILE = "${baseDir}/pgpass-www"; # grrr
-    } // (optionalAttrs cfg.debugServer { DBIC_TRACE = "1"; });
+    COLUMNS = "80";
+    PGPASSFILE = "${baseDir}/pgpass-www"; # grrr
+  } // (optionalAttrs cfg.debugServer { DBIC_TRACE = "1"; });
 
   localDB = "dbi:Pg:dbname=hydra;user=hydra;";
 
@@ -63,7 +63,7 @@ in
 
       package = mkOption {
         type = types.path;
-        #default = pkgs.hydra;
+        # default = pkgs.hydra;
         description = "The Hydra package.";
       };
 
@@ -165,8 +165,8 @@ in
 
       buildMachinesFiles = mkOption {
         type = types.listOf types.path;
-        default = [ "/etc/nix/machines" ];
-        example = [ "/etc/nix/machines" "/var/lib/hydra/provisioner/machines" ];
+        default = ["/etc/nix/machines"];
+        example = ["/etc/nix/machines" "/var/lib/hydra/provisioner/machines"];
         description = "List of files containing build machines.";
       };
 
@@ -192,48 +192,48 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraGroups.hydra = { };
+    users.extraGroups.hydra = {};
 
     users.extraUsers.hydra =
       { description = "Hydra";
-        group = "hydra";
-        createHome = true;
-        home = baseDir;
-        useDefaultShell = true;
-      };
+      group           = "hydra";
+      createHome      = true;
+      home            = baseDir;
+      useDefaultShell = true;
+    };
 
     users.extraUsers.hydra-queue-runner =
       { description = "Hydra queue runner";
-        group = "hydra";
-        useDefaultShell = true;
+      group           = "hydra";
+      useDefaultShell = true;
         home = "${baseDir}/queue-runner"; # really only to keep SSH happy
-      };
+    };
 
     users.extraUsers.hydra-www =
       { description = "Hydra web server";
-        group = "hydra";
-        useDefaultShell = true;
-      };
+      group           = "hydra";
+      useDefaultShell = true;
+    };
 
-    nix.trustedUsers = [ "hydra-queue-runner" ];
+    nix.trustedUsers = ["hydra-queue-runner"];
 
     services.hydra-dev.package = mkDefault ((import ./release.nix {}).build.x86_64-linux);
 
     services.hydra-dev.extraConfig =
       ''
-        using_frontend_proxy 1
-        base_uri ${cfg.hydraURL}
-        notification_sender ${cfg.notificationSender}
-        max_servers 25
-        compress_num_threads 0
+      using_frontend_proxy 1
+      base_uri ${cfg.hydraURL}
+      notification_sender ${cfg.notificationSender}
+      max_servers 25
+      compress_num_threads 0
         ${optionalString (cfg.logo != null) ''
           hydra_logo ${cfg.logo}
         ''}
-        gc_roots_dir ${cfg.gcRootsDir}
-        use-substitutes = ${if cfg.useSubstitutes then "1" else "0"}
-      '';
+      gc_roots_dir ${cfg.gcRootsDir}
+      use-substitutes = ${if cfg.useSubstitutes then "1" else "0"}
+    '';
 
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [cfg.package];
 
     environment.variables = hydraEnv;
 
@@ -248,32 +248,32 @@ in
 
     systemd.services.hydra-init =
       { wantedBy = [ "multi-user.target" ];
-        requires = optional haveLocalDB "postgresql.service";
-        after = optional haveLocalDB "postgresql.service";
-        environment = env;
-        preStart = ''
-          mkdir -p ${baseDir}
-          chown hydra.hydra ${baseDir}
-          chmod 0750 ${baseDir}
+      requires = optional haveLocalDB "postgresql.service";
+      after = optional haveLocalDB "postgresql.service";
+      environment = env;
+      preStart = ''
+        mkdir -p ${baseDir}
+        chown hydra.hydra ${baseDir}
+        chmod 0750 ${baseDir}
 
-          ln -sf ${hydraConf} ${baseDir}/hydra.conf
+        ln -sf ${hydraConf} ${baseDir}/hydra.conf
 
-          mkdir -m 0700 -p ${baseDir}/www
-          chown hydra-www.hydra ${baseDir}/www
+        mkdir -m 0700 -p ${baseDir}/www
+        chown hydra-www.hydra ${baseDir}/www
 
-          mkdir -m 0700 -p ${baseDir}/queue-runner
-          mkdir -m 0750 -p ${baseDir}/build-logs
+        mkdir -m 0700 -p ${baseDir}/queue-runner
+        mkdir -m 0750 -p ${baseDir}/build-logs
           chown hydra-queue-runner.hydra ${baseDir}/queue-runner ${baseDir}/build-logs
 
-          ${optionalString haveLocalDB ''
-            if ! [ -e ${baseDir}/.db-created ]; then
+        ${optionalString haveLocalDB ''
+          if ! [ -e ${baseDir}/.db-created ]; then
               ${config.services.postgresql.package}/bin/createuser hydra
               ${config.services.postgresql.package}/bin/createdb -O hydra hydra
               touch ${baseDir}/.db-created
-            fi
-          ''}
+          fi
+        ''}
 
-          if [ ! -e ${cfg.gcRootsDir} ]; then
+        if [ ! -e ${cfg.gcRootsDir} ]; then
 
             # Move legacy roots directory.
             if [ -e /nix/var/nix/gcroots/per-user/hydra/hydra-roots ]; then
@@ -281,100 +281,100 @@ in
             fi
 
             mkdir -p ${cfg.gcRootsDir}
-          fi
+        fi
 
-          # Move legacy hydra-www roots.
-          if [ -e /nix/var/nix/gcroots/per-user/hydra-www/hydra-roots ]; then
+        # Move legacy hydra-www roots.
+        if [ -e /nix/var/nix/gcroots/per-user/hydra-www/hydra-roots ]; then
             find /nix/var/nix/gcroots/per-user/hydra-www/hydra-roots/ -type f \
-              | xargs -r mv -f -t ${cfg.gcRootsDir}/
+                | xargs -r mv -f -t ${cfg.gcRootsDir}/
             rmdir /nix/var/nix/gcroots/per-user/hydra-www/hydra-roots
-          fi
+        fi
 
-          chown hydra.hydra ${cfg.gcRootsDir}
-          chmod 2775 ${cfg.gcRootsDir}
-        '';
+        chown hydra.hydra ${cfg.gcRootsDir}
+        chmod 2775 ${cfg.gcRootsDir}
+      '';
         serviceConfig.ExecStart = "${cfg.package}/bin/hydra-init";
         serviceConfig.PermissionsStartOnly = true;
         serviceConfig.User = "hydra";
         serviceConfig.Type = "oneshot";
         serviceConfig.RemainAfterExit = true;
-      };
+    };
 
     systemd.services.hydra-server =
       { wantedBy = [ "multi-user.target" ];
-        requires = [ "hydra-init.service" ];
-        after = [ "hydra-init.service" ];
-        environment = serverEnv;
-        restartTriggers = [ hydraConf ];
+      requires = ["hydra-init.service"];
+      after = ["hydra-init.service"];
+      environment = serverEnv;
+      restartTriggers = [hydraConf];
         serviceConfig =
           { ExecStart =
               "@${cfg.package}/bin/hydra-server hydra-server -f -h '${cfg.listenHost}' "
               + "-p ${toString cfg.port} --max_spare_servers 5 --max_servers 25 "
               + "--max_requests 100 ${optionalString cfg.debugServer "-d"}";
-            User = "hydra-www";
-            PermissionsStartOnly = true;
-            Restart = "always";
-          };
+        User                 = "hydra-www";
+        PermissionsStartOnly = true;
+        Restart              = "always";
       };
+    };
 
     systemd.services.hydra-queue-runner =
       { wantedBy = [ "multi-user.target" ];
-        requires = [ "hydra-init.service" ];
-        after = [ "hydra-init.service" "network.target" ];
+      requires = ["hydra-init.service"];
+      after = ["hydra-init.service" "network.target"];
         path = [ cfg.package pkgs.nettools pkgs.openssh pkgs.bzip2 config.nix.package ];
-        restartTriggers = [ hydraConf ];
-        environment = env // {
-          PGPASSFILE = "${baseDir}/pgpass-queue-runner"; # grrr
-          IN_SYSTEMD = "1"; # to get log severity levels
-        };
+      restartTriggers = [hydraConf];
+      environment = env // {
+        PGPASSFILE = "${baseDir}/pgpass-queue-runner"; # grrr
+        IN_SYSTEMD = "1"; # to get log severity levels
+      };
         serviceConfig =
           { ExecStart = "@${cfg.package}/bin/hydra-queue-runner hydra-queue-runner -v";
             ExecStopPost = "${cfg.package}/bin/hydra-queue-runner --unlock";
-            User = "hydra-queue-runner";
-            Restart = "always";
+        User             = "hydra-queue-runner";
+        Restart          = "always";
 
             # Ensure we can get core dumps.
             LimitCORE = "infinity";
-            WorkingDirectory = "${baseDir}/queue-runner";
-          };
+        WorkingDirectory = "${baseDir}/queue-runner";
       };
+    };
 
     systemd.services.hydra-evaluator =
       { wantedBy = [ "multi-user.target" ];
-        requires = [ "hydra-init.service" ];
-        restartTriggers = [ hydraConf ];
-        after = [ "hydra-init.service" "network.target" ];
-        path = with pkgs; [ nettools cfg.package jq ];
-        environment = env;
+      requires = ["hydra-init.service"];
+      restartTriggers = [hydraConf];
+      after = ["hydra-init.service" "network.target"];
+      path = with pkgs; [nettools cfg.package jq];
+      environment = env;
         serviceConfig =
           { ExecStart = "@${cfg.package}/bin/hydra-evaluator hydra-evaluator";
             ExecStopPost = "${cfg.package}/bin/hydra-evaluator --unlock";
-            User = "hydra";
-            Restart = "always";
-            WorkingDirectory = baseDir;
-          };
+        User             = "hydra";
+        Restart          = "always";
+        WorkingDirectory = baseDir;
       };
+    };
 
     systemd.services.hydra-update-gc-roots =
       { requires = [ "hydra-init.service" ];
-        after = [ "hydra-init.service" ];
-        environment = env;
+      after = ["hydra-init.service"];
+      environment = env;
         serviceConfig =
           { ExecStart = "@${cfg.package}/bin/hydra-update-gc-roots hydra-update-gc-roots";
-            User = "hydra";
-          };
-        startAt = "2,14:15";
+        User      = "hydra";
       };
+      startAt = "2,14:15";
+    };
 
     systemd.services.hydra-send-stats =
       { wantedBy = [ "multi-user.target" ];
-        after = [ "hydra-init.service" ];
-        environment = env;
+      after = ["hydra-init.service"];
+      environment = env;
         serviceConfig =
           { ExecStart = "@${cfg.package}/bin/hydra-send-stats hydra-send-stats";
-            User = "hydra";
-          };
+        User      = "hydra";
       };
+    };
 
     # If there is less than a certain amount of free disk space, stop
     # the queue/evaluator to prevent builds from failing or aborting.
@@ -382,16 +382,16 @@ in
       { script =
           ''
             if [ $(($(stat -f -c '%a' /nix/store) * $(stat -f -c '%S' /nix/store))) -lt $((${toString cfg.minimumDiskFree} * 1024**3)) ]; then
-                echo "stopping Hydra queue runner due to lack of free space..."
-                systemctl stop hydra-queue-runner
-            fi
+            echo "stopping Hydra queue runner due to lack of free space..."
+            systemctl stop hydra-queue-runner
+        fi
             if [ $(($(stat -f -c '%a' /nix/store) * $(stat -f -c '%S' /nix/store))) -lt $((${toString cfg.minimumDiskFreeEvaluator} * 1024**3)) ]; then
-                echo "stopping Hydra evaluator due to lack of free space..."
-                systemctl stop hydra-evaluator
-            fi
-          '';
-        startAt = "*:0/5";
-      };
+            echo "stopping Hydra evaluator due to lack of free space..."
+            systemctl stop hydra-evaluator
+        fi
+      '';
+      startAt = "*:0/5";
+    };
 
     # Periodically compress build logs. The queue runner compresses
     # logs automatically after a step finishes, but this doesn't work
@@ -401,25 +401,23 @@ in
         script =
           ''
             find /var/lib/hydra/build-logs -type f -name "*.drv" -mtime +3 -size +0c | xargs -r bzip2 -v -f
-          '';
-        startAt = "Sun 01:45";
-      };
+      '';
+      startAt = "Sun 01:45";
+    };
 
     services.postgresql.enable = mkIf haveLocalDB true;
 
     services.postgresql.identMap = optionalString haveLocalDB
       ''
-        hydra-users hydra hydra
-        hydra-users hydra-queue-runner hydra
-        hydra-users hydra-www hydra
-        hydra-users root hydra
-      '';
+      hydra-users hydra hydra
+      hydra-users hydra-queue-runner hydra
+      hydra-users hydra-www hydra
+      hydra-users root hydra
+    '';
 
     services.postgresql.authentication = optionalString haveLocalDB
       ''
-        local hydra all ident map=hydra-users
-      '';
-
+      local hydra all ident map=hydra-users
+    '';
   };
-
 }

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -225,6 +225,7 @@ with rec {
       useSubstitutes = mkOption {
         type = types.bool;
         default = false;
+        example = true;
         description = ''
           Whether to use binary caches for downloading store paths. Note that
           binary substitutions trigger a potentially large number of additional
@@ -555,7 +556,7 @@ with rec {
                 default = null;
                 # example = …;
                 description = ''
-                  A GitHub authorization token
+                  A GitHub authorization token.
                 '';
               };
             };
@@ -563,7 +564,10 @@ with rec {
           default = [];
           # example = …;
           description = ''
-            Options related to the Hydra GitHub status plugin.
+            A list of GitHub status plugin configuration "stanzas".
+
+            For basic purposes you can probably get away with only having one
+            stanza (i.e.: this is often a singleton list).
           '';
         };
       };
@@ -600,7 +604,8 @@ with rec {
                 default = false;
                 example = true;
                 description = ''
-                  FIXME: doc
+                  If <literal>force = true</literal>, always send messages.
+                  Otherwise, only send a message when the build status changes.
                 '';
               };
             };

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -86,8 +86,8 @@ with rec {
       };
 
       package = mkOption {
-        type = types.package;
-        default = pkgs.hydra;
+        type = types.path;
+        # default = pkgs.hydra;
         description = "The Hydra package.";
       };
 

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -2,8 +2,7 @@
 
 with lib;
 
-let
-
+with rec {
   cfg = config.services.hydra-dev;
 
   baseDir = "/var/lib/hydra";
@@ -36,10 +35,12 @@ let
 
   haveLocalDB = cfg.dbi == localDB;
 
-in
+  hydraExe = name: "${cfg.package}/bin/${name}";
+};
 
 {
   ###### interface
+
   options = {
 
     services.hydra-dev = rec {
@@ -70,7 +71,8 @@ in
       hydraURL = mkOption {
         type = types.str;
         description = ''
-          The base URL for the Hydra webserver instance. Used for links in emails.
+          The base URL for the Hydra webserver instance.
+          Used for links in emails.
         '';
       };
 
@@ -79,8 +81,8 @@ in
         default = "*";
         example = "localhost";
         description = ''
-          The hostname or address to listen on or <literal>*</literal> to listen
-          on all interfaces.
+          The hostname or address to listen on.
+          If <literal>*</literal> is given, listen on all interfaces.
         '';
       };
 
@@ -96,7 +98,8 @@ in
         type = types.int;
         default = 0;
         description = ''
-          Threshold of minimum disk space (GiB) to determine if the queue runner should run or not.
+          Threshold of minimum disk space (GiB) to determine if the queue
+          runner should run or not.
         '';
       };
 
@@ -104,7 +107,8 @@ in
         type = types.int;
         default = 0;
         description = ''
-          Threshold of minimum disk space (GiB) to determine if the evaluator should run or not.
+          Threshold of minimum disk space (GiB) to determine if the evaluator
+          should run or not.
         '';
       };
 
@@ -175,7 +179,7 @@ in
         default = false;
         description = ''
           Whether to use binary caches for downloading store paths. Note that
-          binary substitutions trigger (a potentially large number of) additional
+          binary substitutions trigger a potentially large number of additional
           HTTP requests that slow down the queue monitor thread significantly.
           Also, this Hydra instance will serve those downloaded store paths to
           its users with its own signature attached as if it had built them
@@ -186,7 +190,6 @@ in
     };
 
   };
-
 
   ###### implementation
 

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -293,6 +293,40 @@ with rec {
         '';
       };
 
+      maxSpareServers = mkOption {
+        type = types.int;
+        default = 5;
+        example = 10;
+        description = ''
+          The maximum number of servers to have waiting for requests, as
+          described in the
+          ${mkLink (links.catalystPreforkDocs + "#max_spare_servers")
+                   "Catalyst::Engine::HTTP::Prefork documentation"}.
+        '';
+      };
+
+      maxRequests = mkOption {
+        type = types.int;
+        default = 100;
+        example = 1000;
+        description = ''
+          FIXME: lol
+          The number of requests after which a child will be restarted, as
+          described in the
+          ${mkLink (links.catalystPreforkDocs + "#max_requests")
+                   "Catalyst::Engine::HTTP::Prefork documentation"}.
+        '';
+      };
+
+      maxOutputSize = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 4294967296;
+        description = ''
+          The maximum size of a Hydra build output.
+        '';
+      };
+
       compressCores = mkOption {
         type = types.int;
         default = 0;
@@ -921,7 +955,10 @@ with rec {
         google_client_id = ${cfg.googleClientID}
       ''}
       private = ${if cfg.private then "1" else "0"}
-      ${optionalString (cfg.logPrefix != null) "log_prefix = ${cfg.logPrefix}"}
+      ${optionalString (cfg.logPrefix != null)
+        "log_prefix = ${cfg.logPrefix}"}
+      ${optionalString (cfg.maxOutputSize != null)
+        "max_output_size = ${cfg.maxOutputSize}"}
     '';
 
     # FIXME: add/investigate all of these:
@@ -1018,9 +1055,9 @@ with rec {
             "-f"
             "-h '${cfg.listenHost}'"
             "-p ${toString cfg.port}"
-            "--max_spare_servers 5"
-            "--max_servers 25"
-            "--max_requests 100"
+            "--max_spare_servers ${toString cfg.maxSpareServers}"
+            "--max_servers ${toString cfg.maxServers}"
+            "--max_requests ${toString cfg.maxRequests}"
             (if cfg.debugServer then "-d" else null)
           ]))));
         User                 = "hydra-www";

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -89,8 +89,20 @@ with rec {
 
   hydraExe = name: "${cfg.package}/bin/${name}";
 
-  googleOAuthDocs =
-    "https://developers.google.com/identity/sign-in/web/devconsole-project";
+  mkLink = url: contents: "<link xlink:href=\"${url}\">${contents}</link>";
+
+  links = {
+    googleOAuthDocs =
+      "https://developers.google.com/identity/sign-in/web/devconsole-project";
+    catalystPreforkDocs =
+      "http://search.cpan.org/~agrundma/Catalyst-Engine-HTTP-Prefork/lib/Catalyst/Engine/HTTP/Prefork.pm";
+    pixz =
+      "https://github.com/vasi/pixz";
+    githubStatusDocs =
+      "https://developer.github.com/v3/repos/statuses";
+    slackWebhook =
+      "https://my.slack.com/services/new/incoming-webhook";
+  };
 };
 
 {
@@ -250,8 +262,7 @@ with rec {
         description = ''
           The Google API client ID to use in the Hydra Google OAuth login.
 
-          More information is available
-          <link xlink:href="${googleOAuthDocs}">here</link>.
+          More information is available ${mkLink links.googleOAuthDocs "here"}.
         '';
       };
 
@@ -267,7 +278,7 @@ with rec {
           Note that the Hydra declarative user and project options may not work
           in combination with this option, since the Hydra API is disabled in
           private mode. This issue is tracked
-          <link xlink:href="https://github.com/NixOS/hydra/issues/503">here</link>.
+          ${mkLink "https://github.com/NixOS/hydra/issues/503" "here"}.
         '';
       };
 
@@ -277,9 +288,8 @@ with rec {
         example = 50;
         description = ''
           The maximum number of child servers to start, as described in the
-          <link xlink:href="http://search.cpan.org/~agrundma/Catalyst-Engine-HTTP-Prefork/lib/Catalyst/Engine/HTTP/Prefork.pm#max_servers">
-          Catalyst::Engine::HTTP::Prefork documentation
-          </link>.
+          ${mkLink (links.catalystPreforkDocs + "#max_servers")
+                   "Catalyst::Engine::HTTP::Prefork documentation"}.
         '';
       };
 
@@ -289,7 +299,7 @@ with rec {
         example = 4;
         description = ''
           The number of cores to use when compressing NAR files using
-          <link xlink:href="https://github.com/vasi/pixz">pixz</link>.
+          ${mkLink links.pixz "pixz"}.
 
           If the given number is <literal>0</literal>, then the number of cores
           on the system will be used.
@@ -299,8 +309,6 @@ with rec {
           command line option of <command>pixz</command>.
         '';
       };
-
-      # ([0-9]{1,4}|[1-5][0-9]{4}|6([0-4][0-9]{3}|5([0-4][0-9]{2}|5([0-2][0-9]|3[0-6]))))
 
       storeURI = mkOption {
         type = (
@@ -522,9 +530,8 @@ with rec {
                 description = ''
                   The string to use in the <literal>context</literal> field of a
                   GitHub Status API call, as described in
-                  <link xlink:href="https://developer.github.com/v3/repos/statuses">
-                  this documentation
-                  </link>.
+                  ${mkLink links.githubStatusDocs "this documentation"}.
+
                   If <literal>null</literal>, defaults to an empty string.
                 '';
               };
@@ -568,7 +575,7 @@ with rec {
                 example = "https://hooks.slack.com/services/XXXXXXXXX/YYYYYYYYY/ZZZZZZZZZZZZZZZZZZZZZZZZ";
                 description = ''
                   The URL of a Slack Incoming Webhook; you can create a Slack
-                  webhook with <link xlink:href="https://my.slack.com/services/new/incoming-webhook">this</link>
+                  webhook with ${mkLink links.slackWebhook "this link"}
                   (replace <literal>my.slack.com</literal> with your team name
                   if that link doesn't work properly).
                 '';

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -1,59 +1,15 @@
 { config, pkgs, lib, ... }:
 
-# ------------------------------------------------------------------------------
-# FIXME: send this stuff upstream to nixpkgs
-# vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-
 with rec {
   inherit (lib) mkIf mkOption;
 
-  forceWHNF = x: builtins.seq x x;
-  forceDeep = x: builtins.deepSeq x x;
-
-  strings = lib.strings // {
-    intercalate = str: list: lib.concatStrings (lib.intersperse str list);
-  };
-
-  lists = lib.lists // (
-    with {
-      foldToFold1 = fold: (f: list: (
-        assert builtins.length list > 0;
-        with {
-          mlist = builtins.map (x: { v = x; }) list;
-          merge = a: b: (
-            if a != null
-            then (if b != null then { v = f a.v b.v; } else a)
-            else (if b != null then b                  else null));
-        };
-        (fold merge null mlist).value));
-    };
-
-    {
-      foldr   = lib.lists.fold;
-      foldr1  = foldToFold1 lists.foldr;
-      foldl   = lib.lists.foldl;
-      foldl1  = foldToFold1 lists.foldl;
-      foldl'  = lib.lists.foldl';
-      foldl1' = foldToFold1 lists.foldl';
-    });
-
   types = lib.types // {
-    oneof = list: (
-      assert lib.isList list;
-      # assert lib.all lib.isOptionType list;
-
-      if lib.length list > 0
-        then lists.foldr1 lib.types.either list
-        else throw "lib.types.oneof: empty list");
-
+    # Relevant: https://github.com/NixOS/nixpkgs/issues/28574
     matching = rx: type: (lib.types.addCheck type (str:
       assert builtins.isString str;
       (builtins.match "^${rx}$" str) != null));
   };
 };
-
-# ∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧∧
-# ------------------------------------------------------------------------------
 
 with rec {
   cfg = config.services.hydra-dev;
@@ -310,7 +266,6 @@ with rec {
         default = 100;
         example = 1000;
         description = ''
-          FIXME: lol
           The number of requests after which a child will be restarted, as
           described in the
           ${mkLink (links.catalystPreforkDocs + "#max_requests")

--- a/hydra-repave.py
+++ b/hydra-repave.py
@@ -1,0 +1,140 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python35Packages.requests2
+
+import requests
+import time
+import json
+import http
+import typing
+from typing import Union, Dict
+
+# ------------------------------------------------------------------------------
+
+username = "remyg"
+password = "hunter2"
+
+# ------------------------------------------------------------------------------
+
+def hydraURL(endpoint : str):
+    return "http://127.0.0.1:3000/" + endpoint
+
+jar = http.cookiejar.CookieJar()
+
+RequestData = Union[None, bytes, Dict[str, str]]
+
+def hydraGET(endpoint : str, accept : str = "application/json"):
+    global jar
+    headers = {"Accept": accept, "Referer": hydraURL("")}
+    r = requests.get(hydraURL(endpoint), cookies = jar, headers = headers)
+    jar = r.cookies
+    return r
+
+def hydraPUT(endpoint : str, data : RequestData):
+    global jar
+    headers = {"Accept": "application/json", "Referer": hydraURL("")}
+    r = requests.put(hydraURL(endpoint),
+                     cookies = jar,
+                     data    = data,
+                     headers = headers)
+    jar = r.cookies
+    return r
+
+def hydraPOST(endpoint : str, data : RequestData):
+    global jar
+    headers = {"Accept": "application/json", "Referer": hydraURL("")}
+    r = requests.post(hydraURL(endpoint),
+                      cookies = jar,
+                      data    = data,
+                      headers = headers)
+    jar = r.cookies
+    return r
+
+def hydraDELETE(endpoint : str):
+    global jar
+    headers = {"Accept": "application/json", "Referer": hydraURL("")}
+    r = requests.delete(hydraURL(endpoint), cookies = jar, headers = headers)
+    jar = r.cookies
+    return r
+
+# ------------------------------------------------------------------------------
+
+def hydraLogin():
+    print("Logging in")
+    r = hydraPOST("login", {"username": username, "password": password})
+    assert r.status_code == 200
+    return r
+
+def hydraLogout():
+    print("Logging out")
+    r = hydraPOST("logout", {})
+    assert r.status_code == 204
+    return r
+
+def hydraDeleteProject(project : str):
+    print("Deleting project: " + project)
+    return hydraDELETE("project/" + project)
+
+def hydraDeleteJobset(project : str, jobset : str):
+    print("Deleting jobset:  " + project + ":" + jobset)
+    return hydraDELETE("jobset/" + project + "/" + jobset)
+
+def hydraDeleteAll():
+    r = hydraGET("")
+    assert r.ok
+
+    for project in r.json():
+        name = project["name"]
+        for jobset in project["jobsets"]:
+            hydraDeleteJobset(name, jobset)
+        hydraDeleteProject(name)
+
+    r = hydraGET("")
+    assert r.json() == []
+
+def test():
+    hydraLogin()
+
+    try:
+        hydraDeleteAll()
+
+        r = hydraPUT("project/sample",
+                     {"enabled":     "1",
+                      "hidden":      "0",
+                      "displayname": "Sample",
+                      "description": "foobar",
+                      "owner":       "remyg",
+                      "homepage":    "https://example.com",
+                      "declfile":    "",
+                      "decltype":    "boolean",
+                      "declvalue":   "true"})
+        assert r.ok
+
+        r = hydraPUT("jobset/sample/default",
+                     json.dumps({"enabled":       "0",
+                                 "hidden":        "0",
+                                 "nixexprpath":   "release.nix",
+                                 "nixexprinput":  "src",
+                                 "inputs":        {"src": {"type": "path", "value": "/foo/bar"}},
+                                 "checkinterval": "3600",
+                                 "description":   "rofl"}).encode("utf-8"))
+        assert r.ok
+
+        hydraDeleteAll()
+
+        # r = hydraGET("")
+        # print(r)
+        # print(r.text)
+        #
+        # r = hydraDELETE("project/sample")
+        #
+        # r = hydraGET("")
+        # print(r)
+        # print(r.text)
+    finally:
+        hydraLogout()
+
+# ------------------------------------------------------------------------------
+
+test()
+
+# ------------------------------------------------------------------------------

--- a/temporary.nix
+++ b/temporary.nix
@@ -1,0 +1,309 @@
+{ pkgs }:
+
+# ------------------------------------------------------------------------------
+# This adds a Hydra plugin for users to submit their open source projects
+# to the Coverity Scan system for analysis.
+#
+# First, add a <coverityscan> section to your Hydra config, including the
+# access token, project name, and email, and a regex specifying jobs to
+# upload:
+#
+#     <coverityscan>
+#       project = testrix
+#       jobs    = foobar:.*:coverity.*
+#       email   = aseipp@pobox.com
+#       token   = ${builtins.readFile ./coverity-token}
+#     </coverityscan>
+#
+# This will upload the scan results for any job whose name matches
+# 'coverity.*' in any jobset in the Hydra 'foobar' project, for the
+# Coverity Scan project named 'testrix'.
+#
+# Note that one upload will occur per job matched by the regular
+# expression - so be careful with how many builds you upload.
+#
+# The jobs which are matched by the jobs specification must have a file in
+# their output path of the form:
+#
+#   $out/tarballs/...-cov-int.(xz|lzma|zip|bz2|tgz)
+#
+# The file must have the 'cov-int' directory produced by `cov-build` in
+# the root.
+#
+# (You can also output something into
+# $out/nix-support/hydra-build-products for the Hydra UI.)
+#
+# This file will be found in the store, and uploaded to the service
+# directly using your access credentials. Note the exact extension: don't
+# use .tar.xz, only use .xz specifically.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# EmailNotification?
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# S3Backup?
+# ------------------------------------------------------------------------------
+
+with { inherit (pkgs) lib; };
+
+rec {
+  # ----------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
+
+  hasType = ty: value: ty == (builtins.typeOf value);
+  isEmail = value: lib.strings.parseEmail value != null;
+  checkRegex = lib.strings.checkRegex;
+  isHydraInputType = ty: builtins.elem ty [
+    "boolean" "string" "path" "nix"
+    "bzr" "bzr-checkout" "darcs" "git" "hg" "svn"
+    "githubpulls"
+  ];
+  defaultEmail = "hydra@nixos.org";
+
+  # ----------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
+
+  makeJobsetInput = (
+    { type, value, notify ? false }:
+
+    assert hasType "string" type;
+    assert hasType "string" value;
+    assert hasType "bool"   notify;
+    assert isHydraInputType type;
+
+    { inherit type value; emailresponsible = notify; });
+
+  makeJobsetCore = (
+    { enable,      # bool
+      visible,     # bool
+      description, # string
+      expression,  # { file = string; input = string; }
+      evaluation,  # { keep = int; interval = int; shares = int; }
+      email,       # { enable = bool; override = string; }
+      inputs       # { * = { type = string; value = string; notify = bool; }; }
+    }:
+
+    {
+      enabled          = if enable then 1 else 0;
+      hidden           = !visible;
+      description      = description;
+      enableemail      = email.enable;
+      emailoverride    = email.override;
+      keepnr           = evaluation.keep;
+      checkinterval    = evaluation.interval;
+      schedulingshares = evaluation.shares;
+      inputs           = lib.mapAttrs (_: makeJobsetInput) inputs;
+    });
+
+  makeJobset = (
+    { enable      ? true,
+      visible     ? true,
+      description ? "",
+      expression  ? { file = "release.nix"; input = "src"; },
+      evaluation  ? { keep = 3; interval = 10; shares = 1; },
+      email       ? { enable = true; override = defaultEmail; },
+      inputs      ? {},
+      override    ? (x: x)
+    }:
+
+    assert hasType "bool"   enable;
+    assert hasType "bool"   visible;
+    assert hasType "string" description;
+    assert hasType "set"    expression;
+    assert hasType "set"    evaluation;
+    assert hasType "set"    email;
+    assert hasType "set"    inputs;
+    assert hasType "lambda" override;
+
+    assert (expression ?      file) && (hasType "string" expression.file);
+    assert (expression ?     input) && (hasType "string" expression.input);
+    assert (evaluation ?      keep) && (hasType "int"    evaluation.keep);
+    assert (evaluation ? intervals) && (hasType "int"    evaluation.intervals);
+    assert (evaluation ?    shares) && (hasType "int"    evaluation.shares);
+    assert (email      ?    enable) && (hasType "bool"   email.enable);
+    assert (email      ?  override) && (isEmail          email.override);
+
+    # `expression.input` must correspond to a key in `inputs`
+    assert inputs ? expression.input;
+
+    override (makeJobsetCore {
+      inherit enable visible description expression evaluation email inputs;
+    }));
+
+  # ----------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
+
+  makeOtherHydraConf = (
+    { compress ? true }:
+
+    assert hasType "bool" compress;
+
+    ''
+      compress_build_logs = ${if compress then 1 else 0}
+    '');
+
+  # ----------------------------------------------------------------------------
+
+  makeCoverityScanStanza = (
+    with { defaultScanURL = "http://scan5.coverity.com/cgi-bin/upload.py"; };
+
+    { enable   ? false,         # bool
+      project,                  # string
+      jobs,                     # string
+      email,                    # string
+      token,                    # string
+      scanURL  ? defaultScanURL # string
+    }:
+
+    if !enable then "" else (
+      assert hasType "bool"   enable;
+      assert hasType "string" project;
+      assert hasType "string" jobs;
+      assert hasType "string" email;
+      assert hasType "string" token;
+      assert hasType "string" scanURL;
+
+      assert project != "";
+      assert jobs    != "";
+      assert email   != "";
+      assert token   != "";
+      assert scanURL != "";
+
+      assert isEmail email;
+      assert checkRegex jobs;
+
+      ''
+        <coverityscan>
+          project = ${project}
+          jobs    = ${jobs}
+          email   = ${email}
+          token   = ${token}
+          scanurl = ${scanURL}
+        </coverityscan>
+      ''
+    ));
+
+  # ----------------------------------------------------------------------------
+
+  # There should only be one <github_authorization> stanza.
+  makeGithubAuthStanza = (
+    { users # { * = string; }
+    }:
+
+    with rec {
+      makePair = user: token: "  ${user} = ${token}\n";
+      pairs = lib.mapAttrsToList makePair users;
+    };
+
+    if pairs == [] then "" else ''
+      <github_authorization>
+      ${lib.concatStrings pairs}
+      </github_authorization>
+    '');
+
+  # ----------------------------------------------------------------------------
+
+  # If you authorize with
+  #   `curl -H "Authorization: foo" https://api.github.com`
+  # then you should set `auth = "foo";`.
+  #
+  # There can be multiple <githubstatus> stanzas.
+  makeGithubStatusStanza = (
+    { jobs,                 # string
+      inputs        ? [],   # [string]
+      exclude       ? true, # bool
+      description   ? "",   # string
+      context       ? "",   # string
+      auth          ? ""    # string
+    }:
+
+    with rec {
+      containsEOF = string: ((builtins.match ".*EOF.*" string) != null);
+      inputPairs = map (i: "  inputs = ${i}\n") inputs;
+      heredoc = key: string: (
+        assert !(containsEOF string);
+        "  ${key} <<EOF\n${string}\nEOF\n");
+    };
+
+    assert hasType "string" jobs;
+    assert hasType "list"   inputs;
+    assert hasType "bool"   exclude;
+    assert hasType "string" description;
+    assert hasType "string" context;
+    assert hasType "string" auth;
+
+    assert checkRegex jobs;
+
+    ''
+      <githubstatus>
+        jobs = ${jobs}
+      ${lib.concatStrings inputPairs}
+        excludeBuildFromContext = ${if exclude then 1 else 0}
+      ${if description != "" then heredoc "description"   description else ""}
+      ${if context     != "" then heredoc "context"       context     else ""}
+      ${if auth        != "" then heredoc "authorization" auth        else ""}
+      </githubstatus>
+    '');
+
+  # ----------------------------------------------------------------------------
+
+  # If `force` is true, always send messages. Otherwise, only send them
+  # when the build status changes.
+  # There can be multiple <slack> stanzas, each corresponding to a channel.
+  makeSlackStanza = (
+    { jobs, url, force ? false }:
+
+    assert hasType "string" jobs;
+    assert hasType "string" url;
+    assert hasType "bool"   force;
+
+    assert checkRegex jobs;
+
+    ''
+      <slack>
+        jobs  = ${jobs}
+        url   = ${url}
+        force = ${if force then "true" else "false"}
+      </slack>
+    '');
+
+  # ----------------------------------------------------------------------------
+
+  # The prefix is prepended to the file name to create the S3 key.
+  # There can be multiple <s3backup> stanzas, each corresponding to a bucket.
+  makeS3BackupStanza = (
+    { name,                # string
+      jobs,                # string
+      prefix     ? "",     # string
+      compressor ? "bzip2" # string
+    }:
+
+    with { compressionType = if isNull compressor then "" else compressor; };
+
+    assert hasType "string" name;
+    assert hasType "string" jobs;
+    assert hasType "string" prefix;
+    assert hasType "string" compressionType;
+
+    assert checkRegex jobs;
+
+    assert builtins.elem compressionType ["xz" "bzip2" ""];
+
+    ''
+      <s3backup>
+        name             = ${name}
+        jobs             = ${jobs}
+        prefix           = ${prefix}
+        compression_type = ${compressionType}
+      </s3backup>
+    '');
+
+  # ----------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
+}


### PR DESCRIPTION
I'm working on making the Hydra configuration more declarative; I think the current state of affairs where you literally have to reverse-engineer the Perl source to figure out what options you can give in `services.hydra.extraConfig` is embarrassing; you'd think that Hydra, of all projects, would be really usable with NixOS.

My ultimate plan is what I call "Fully Declarative Hydra": every aspect of Hydra's state should be specified in the NixOS module except the build and evaluation history.