### PR TITLE
hydra-create-user now has `--password-hash` option

### DIFF
--- a/src/script/hydra-create-user
+++ b/src/script/hydra-create-user
@@ -15,6 +15,7 @@ Usage: $0 NAME
   [--full-name FULLNAME]
   [--email-address EMAIL-ADDRESS]
   [--password PASSWORD]
+  [--password-hash SHA1-HASH]
   [--wipe-roles]
   [--role ROLE]...
 
@@ -30,7 +31,7 @@ EOF
     exit 0;
 }
 
-my ($renameFrom, $type, $fullName, $emailAddress, $password);
+my ($renameFrom, $type, $fullName, $emailAddress, $password, $passwordHash);
 my $wipeRoles = 0;
 my @roles;
 
@@ -39,6 +40,7 @@ GetOptions("rename-from=s" => \$renameFrom,
            "full-name=s" => \$fullName,
            "email-address=s" => \$emailAddress,
            "password=s" => \$password,
+           "password-hash=s" => \$passwordHash,
            "wipe-roles" => \$wipeRoles,
            "role=s" => \@roles,
            "help" => sub { showHelp() }
@@ -77,10 +79,15 @@ txn_do($db, sub {
             if defined $emailAddress;
         die "$0: Google accounts do not have a password.\n"
             if defined $password;
+        die "$0: Google accounts do not have a password.\n"
+            if defined $passwordHash;
         $user->update({ emailaddress => $userName, password => "!" });
     } else {
         $user->update({ emailaddress => $emailAddress }) if defined $emailAddress;
-        $user->update({ password => sha1_hex($password) }) if defined $password;
+        if (defined $password && !(defined $passwordHash)) {
+            $passwordHash = sha1_hex($password);
+        }
+        $user->update({ password => $passwordHash }) if defined $passwordHash;
     }
 
     $user->userroles->delete if $wipeRoles;


### PR DESCRIPTION
When creating a Hydra user with the `hydra-create-user` command, you can now provide a SHA1 password hash with the `--password-hash` flag. This is useful for the upcoming work on Fully Declarative Hydra, since the end user should not have to specify plaintext passwords in their `configuration.nix` file.

I've tested this by ensuring that `nix-build release.nix -A tests.api` builds with/without this patch applied:

```diff
diff --git a/release.nix b/release.nix
index 89e7b2a6..b5c5930c 100644
--- a/release.nix
+++ b/release.nix
@@ -218,7 +218,7 @@ rec {
 
           # Create an admin account and some other state.
           $machine->succeed
-              ( "su - hydra -c \"hydra-create-user root --email-address 'alice\@example.org' --password foobar --role admin\""
+              ( "su - hydra -c \"hydra-create-user root --email-address 'alice\@example.org' --password-hash 8843d7f92416211de9ebb963ff4ce28125932878 --role admin\""
               , "mkdir /run/jobset /tmp/nix"
               , "chmod 755 /run/jobset /tmp/nix"
               , "cp ${./tests/api-test.nix} /run/jobset/default.nix"
```

This is the only testing I have done, however, and I am not very well-versed in Perl, so please review the diff carefully.