### PR TITLE
release.nix: Fix quoting of ${LOGNAME:-foo}

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -157,7 +157,7 @@ rec {
 
       preCheck = ''
         patchShebangs .
-        export LOGNAME=${LOGNAME:-foo}
+        export LOGNAME=''${LOGNAME:-foo}
       '';
 
       postInstall = ''


### PR DESCRIPTION
In order to use `${...}` literally within an indented string we need to prefix it with two single quotes.