### PR TITLE
Support builds that can abort themselves

### DIFF
--- a/src/hydra-queue-runner/build-result.cc
+++ b/src/hydra-queue-runner/build-result.cc
@@ -43,6 +43,10 @@ BuildOutput getBuildOutput(nix::ref<Store> store,
         if (accessor->stat(failedFile).type == FSAccessor::Type::tRegular)
             res.failed = true;
 
+        Path abortedFile = output + "/nix-support/aborted";
+        if (accessor->stat(abortedFile).type == FSAccessor::Type::tRegular)
+            res.aborted = true;
+
         Path productsFile = output + "/nix-support/hydra-build-products";
         if (accessor->stat(productsFile).type != FSAccessor::Type::tRegular)
             continue;

--- a/src/hydra-queue-runner/build-result.hh
+++ b/src/hydra-queue-runner/build-result.hh
@@ -29,6 +29,11 @@ struct BuildOutput
        $out/nix-support/failed. */
     bool failed = false;
 
+    /* Whether this build has marked itself as aborted, i.e., the build
+       finished with exit code 0 but produced a file
+       $out/nix-support/aborted. */
+    bool aborted = false;
+
     std::string releaseName;
 
     unsigned long long closureSize = 0, size = 0;

--- a/src/hydra-queue-runner/builder.cc
+++ b/src/hydra-queue-runner/builder.cc
@@ -224,6 +224,12 @@ State::StepResult State::doBuildStep(nix::ref<Store> destStore,
             res = getBuildOutput(destStore, ref<FSAccessor>(result.accessor), step->drv);
         }
 
+        if (res.aborted) {
+            result.stepStatus = bsAborted;
+            result.errorMsg = "Build aborted itself";
+            result.canRetry = true;
+        }
+
         result.accessor = 0;
         result.tokens = 0;
     }


### PR DESCRIPTION
If a build creates the file `/nix-support/aborted` and returns exit
status 0, Hydra will mark the build as aborted, and schedule it for
retry (just like it does for  builds that are manually aborted).
This way, if a build can identify a transient error, it can instruct
Hydra to try the build again.

I believe this could fix the issues #436 and #354.