### PR TITLE
Add a restart-jobs role

### DIFF
--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -188,7 +188,7 @@ sub cancel : Chained('evalChain') PathPart('cancel') Args(0) {
 
 sub restart {
     my ($self, $c, $condition) = @_;
-    requireProjectOwner($c, $c->stash->{eval}->project);
+    requireRestartPrivileges($c, $c->stash->{eval}->project);
     my $builds = $c->stash->{eval}->builds->search({ finished => 1, buildstatus => $condition });
     my $n = restartBuilds($c->model('DB')->schema, $builds);
     $c->flash->{successMsg} = "$n builds have been restarted.";

--- a/src/root/user.tt
+++ b/src/root/user.tt
@@ -80,6 +80,7 @@
           <select multiple="multiple" name="roles" class="span3" [% IF !c.check_user_roles('admin') %]disabled="disabled"[% END %]>
             [% INCLUDE roleoption role="admin" %]
             [% INCLUDE roleoption role="create-projects" %]
+            [% INCLUDE roleoption role="restart-jobs" %]
           </select>
         </div>
       </div>


### PR DESCRIPTION
Frequently users want Hydra access just to restart jobs. However,
prior to this commit the only way to grant that access was by giving
them full Admin access which isn't necessarily what we want to do.

By having a restart-jobs role, we can grant this privilege to users
who are known to the community and want to help, but aren't long-time
members.

~I haven't tested this commit, but as a very novice Perl user, it looks good to me...~ @globin has tested this PR.