### PR TITLE
feat: add /eval/<id>/builds endpoint

### DIFF
--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -264,4 +264,15 @@ sub store_paths : Chained('evalChain') PathPart('store-paths') Args(0) {
 }
 
 
+# Return full info about all the builds in this evaluation.
+sub all_builds : Chained('evalChain') PathPart('builds') Args(0) {
+    my ($self, $c) = @_;
+    my @builds = $c->stash->{eval}->builds;
+    $self->status_ok(
+        $c,
+        entity => [@builds],
+    );
+}
+
+
 1;


### PR DESCRIPTION
This endpoint allows efficient retrieval of all the builds in an
evaluation, without making a request for each single build.