### PR TITLE
[ Fix #531 ] Trim github pr plugin store paths.

### DIFF
--- a/src/lib/Hydra/Plugin/GithubPulls.pm
+++ b/src/lib/Hydra/Plugin/GithubPulls.pm
@@ -56,8 +56,8 @@ sub fetchInput {
     print $fh encode_json \%pulls;
     close $fh;
     system("jq -S . < $filename > $tempdir/github-pulls-sorted.json");
-    my $storePath = `nix-store --add "$tempdir/github-pulls-sorted.json"`
-        or die "cannot copy path $filename to the Nix store.\n";
+    my $storePath = trim(`nix-store --add "$tempdir/github-pulls-sorted.json"`
+        or die "cannot copy path $filename to the Nix store.\n");
     my $timestamp = time;
     return { storePath => $storePath, revision => strftime "%Y%m%d%H%M%S", gmtime($timestamp) };
 }


### PR DESCRIPTION
``nix-store --add`` returns a trailing LF which caused wrong include
paths for the github PR plugin JSON input.