### PR TITLE
release.nix: Don't force gcc6

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -103,8 +103,6 @@ rec {
 
       src = if shell then null else hydraSrc;
 
-      stdenv = overrideCC stdenv gcc6;
-
       buildInputs =
         [ makeWrapper autoconf automake libtool unzip nukeReferences pkgconfig sqlite libpqxx
           gitAndTools.topGit mercurial darcs subversion bazaar openssl bzip2 libxslt


### PR DESCRIPTION
When hydra's dependencies are built with gcc7
(particularly nix) using gcc6 doesn't work
as its libstdc++ is too old.

Using gcc6 was done in e0b2921ff2f714fd243a4ef3357c5d01fffba1a5
back in 2016 -- probably to use a /newer/-than-default gcc.