### PR TITLE
nix-prefetch-git: Fix git submodule checkout

### DIFF
--- a/src/script/nix-prefetch-git
+++ b/src/script/nix-prefetch-git
@@ -142,8 +142,8 @@ init_submodules(){
     git submodule status |
     while read l; do
         # checkout each submodule
-        local hash=$(echo $l | sed 's,^.\([0-9a-f]*\) \(.*\) (.*)$,\1,');
-        local dir=$(echo $l | sed 's,^.\([0-9a-f]*\) \(.*\) (.*)$,\2,');
+        local hash=$(echo $l | sed 's,^[-+ ]*\([0-9a-f]*\) \(.*\) (.*)$,\1,');
+        local dir=$(echo $l | sed 's,^[-+ ]*\([0-9a-f]*\) \(.*\) (.*)$,\2,');
         local url=$(sed -n "\,$dir, { :loop; n; s,^.*url = ,,; T loop; p; q }" .git/config);
 
         clone "$dir" "$url" "$hash" "";

--- a/src/script/nix-prefetch-git
+++ b/src/script/nix-prefetch-git
@@ -142,8 +142,8 @@ init_submodules(){
     git submodule status |
     while read l; do
         # checkout each submodule
-        local hash=$(echo $l | sed 's,^-\([0-9a-f]*\) \(.*\) (.*)$,\1,');
-        local dir=$(echo $l | sed 's,^-\([0-9a-f]*\) \(.*\) (.*)$,\2,');
+        local hash=$(echo $l | sed 's,^.\([0-9a-f]*\) \(.*\) (.*)$,\1,');
+        local dir=$(echo $l | sed 's,^.\([0-9a-f]*\) \(.*\) (.*)$,\2,');
         local url=$(sed -n "\,$dir, { :loop; n; s,^.*url = ,,; T loop; p; q }" .git/config);
 
         clone "$dir" "$url" "$hash" "";

--- a/src/script/nix-prefetch-git
+++ b/src/script/nix-prefetch-git
@@ -142,8 +142,8 @@ init_submodules(){
     git submodule status |
     while read l; do
         # checkout each submodule
-        local hash=$(echo $l | sed 's,^-\([0-9a-f]*\) \(.*\)$,\1,');
-        local dir=$(echo $l | sed 's,^-\([0-9a-f]*\) \(.*\)$,\2,');
+        local hash=$(echo $l | sed 's,^-\([0-9a-f]*\) \(.*\) (.*)$,\1,');
+        local dir=$(echo $l | sed 's,^-\([0-9a-f]*\) \(.*\) (.*)$,\2,');
         local url=$(sed -n "\,$dir, { :loop; n; s,^.*url = ,,; T loop; p; q }" .git/config);
 
         clone "$dir" "$url" "$hash" "";


### PR DESCRIPTION
When fetching git submodules, nix-prefetch-git would fail on line 160 with "cd: too many arguments".  I'm not sure if the `git submodule status` output has changed, or whether init_submodules() is called in different situations where it does work.  But this change works for me (the submodule is checked out correctly), so it may benefit someone else as well.

**Separate git submodule dir from `git describe` part when parsing**

**Ignore first character of `git submodule status` output**
The submodule may possibly already be initialized, thus lacking the
initially expected dash (`-`).
