### PR TITLE
Allow channels to be usefully imported by other nix expressions.

### DIFF
--- a/src/lib/Hydra/View/NixExprs.pm
+++ b/src/lib/Hydra/View/NixExprs.pm
@@ -32,6 +32,10 @@ sub process {
 
 let
 
+  maybeStorePath = if builtins ? langVersion && builtins.lessThan 1 builtins.langVersion
+    then builtins.storePath
+    else x: x;
+
   mkFakeDerivation = attrs: outputs:
     let
       outputNames = builtins.attrNames outputs;
@@ -44,7 +48,7 @@ let
         { name = outputName;
           value = common // {
             inherit outputName;
-            outPath = builtins.getAttr outputName outputs;
+            outPath = maybeStorePath (builtins.getAttr outputName outputs);
           };
         };
       outputsList = map outputToAttrListElement outputNames;


### PR DESCRIPTION
> With this you can import a hydra-built channel in nix and use the packages there as build inputs etc., and they will be fetched from the cache as-needed. Before the channels were only usable with nix-env.

Re #141 
