### PR TITLE
Show evaluation errors

### DIFF
--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -341,10 +341,20 @@ sub evals :Local Args(0) {
 
     my $evals = $c->model('DB::JobsetEvals');
 
+    my @failEvals = [$c->model('DB::Jobsets')
+                       ->search({ "me.enabled" => 1, "me.hidden" => 0,
+				  "project.enabled" => 1, "project.hidden" => 0 })
+		       ->search({ -or => [ errormsg => { '!=' => '' },
+					   fetcherrormsg => { '!=' => '' }
+				      ]},
+				{ order_by => ["project", "name"], join=>["project"] }
+		     )];
+
     $c->stash->{page} = $page;
     $c->stash->{resultsPerPage} = $resultsPerPage;
     $c->stash->{total} = $evals->search({hasnewbuilds => 1})->count;
-    $c->stash->{evals} = getEvals($self, $c, $evals, ($page - 1) * $resultsPerPage, $resultsPerPage)
+    $c->stash->{evals} = getEvals($self, $c, $evals, ($page - 1) * $resultsPerPage, $resultsPerPage);
+    $c->stash->{evalfailJobsets} = $_ foreach @failEvals;
 }
 
 

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -529,7 +529,11 @@ BLOCK renderJobsetOverview %]
         </td>
         <td><span class="[% IF !j.enabled %]disabled-jobset[% END %] [%+ IF j.hidden %]hidden-jobset[% END %]">[% IF showProject; INCLUDE renderFullJobsetName project=j.get_column('project') jobset=j.name inRow=1; ELSE; INCLUDE renderJobsetName project=j.get_column('project') jobset=j.name inRow=1; END %]</span></td>
         <td>[% HTML.escape(j.description) %]</td>
-        <td>[% IF j.lastcheckedtime; INCLUDE renderDateTime timestamp = j.lastcheckedtime; ELSE; "-"; END %]</td>
+        <td>[% IF j.lastcheckedtime;
+	         INCLUDE renderDateTime timestamp = j.lastcheckedtime;
+		 IF j.errormsg || j.fetcherrormsg; %]&nbsp;<span class = 'label label-warning'>Error</span>[% END;
+		 ELSE; "-";
+	       END %]</td>
         [% IF j.get_column('nrtotal') > 0 %]
           [% successrate = ( j.get_column('nrsucceeded') / j.get_column('nrtotal') )*100 %]
           [% IF j.get_column('nrscheduled') > 0 %]

--- a/src/root/evals.tt
+++ b/src/root/evals.tt
@@ -4,6 +4,17 @@
      "Latest evaluations") %]
 [% PROCESS common.tt %]
 
+[% IF evalfailJobsets && evalfailJobsets.size > 0 %]
+<p class='warning'>Jobsets currently failing evaluation ([% evalfailJobsets.size %]):</p>
+<ul>
+  [% FOREACH job IN evalfailJobsets %]
+    <li>Jobset [% INCLUDE renderFullJobsetName project=job.get_column('project') jobset=job.name inRow=1 %]
+  [% END %]
+</ul>
+
+<hr>
+[% END %]
+
 <p>Showing evaluations [% (page - 1) * resultsPerPage + 1 %] - [%
 (page - 1) * resultsPerPage + evals.size %] out of [% total %].</p>
 


### PR DESCRIPTION
Display evaluation errors on the project summary page and also on the Status:Latest Evaluations page.

In the original form, processing of a jobset can be affected by evaluation errors, but there is no indication of an evaluation error unless you visit the specific jobset page.  This modification makes these evaluation errors visible on top-level summaries (in the same places that build failures are shown) so that there is visible indication of a problem that should be fixed.

If there are no errors, there should be no difference in the display from the current output.  This only shows additional information when there are evaluation errors.
