### PR TITLE
Fix broken build.x86_64-linux job

### DIFF
--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -275,7 +275,7 @@ int main(int argc, char * * argv)
 
                 /* Prevent access to paths outside of the Nix search path and
                    to the environment. */
-                evalSettings.restrictEval = true;
+                settings.restrictEval = true;
 
                 if (releaseExpr == "") throw UsageError("no expression specified");
 


### PR DESCRIPTION
The job has been failing since https://hydra.nixos.org/eval/1461286
with the following error:

    hydra-eval-jobs.cc:278:17: error: 'evalSettings' was not declared in this scope
                     evalSettings.restrictEval = true;
                     ^~~~~~~~~~~~

This is likely due to a typo in 0882519 where that line and the
corresponding comment were moved, and `settings` was changed in that
one place to `evalSettings`.

I reproduced the error by running `nix-build release.nix -A
build.x86_64-linux` on my machine, and this small change makes it build.