### PR TITLE
Improve dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ hydra-config.h
 hydra-config.h.in
 result
 tests/jobs/config.nix
+.hydra-data
+src/hydra-queue-runner/hydra-queue-runner
+config/
+src/hydra-evaluator/hydra-evaluator
+stamp-h1

--- a/doc/manual/hacking.xml
+++ b/doc/manual/hacking.xml
@@ -32,7 +32,18 @@ To build Hydra, you should then do:
 </screen>
 You can run the Hydra web server in your source tree as follows:
 <screen>
+$ ./src/script/hydra-init
+$ ./src/script/hydra-create-user dev --role admin --password notthatsafe
 $ ./src/script/hydra-server
+</screen>
+</para>
+
+<para>To evaluate a jobset locally and to build the queued jobs,
+the corresponding tools can be called directly from <literal>nix-shell</literal>
+if everything was built before:
+<screen>
+[nix-shell]$ ./src/hydra-evaluator/hydra-evaluator # Ctrl-C as soon as your evaluation finished
+[nix-shell]$ ./src/hydra-queue-runner/hydra-queue-runner
 </screen>
 </para>
 

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,19 @@
           shellHook = ''
             PATH=$(pwd)/src/hydra-evaluator:$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$PATH
             PERL5LIB=$(pwd)/src/lib:$PERL5LIB
+
+            export HYDRA_HOME="src/"
+            if [ ! -d .hydra-data ]; then
+              mkdir .hydra-data
+            fi
+            export HYDRA_DATA="$(pwd)/.hydra-data"
+            export HYDRA_DBI='dbi:Pg:dbname=hydra;host=10.242.1.2;user=hydra;'
+            if ! nc -z 10.242.1.2 5432 -w1 2>/dev/null; then
+              echo "If a PostgreSQL instance for testing purposes is needed,"
+              echo "you can set HYDRA_DBI to '$HYDRA_DBI'. The corresponding test container"
+              echo "can be started by running the following command:"
+              echo 'nixos-container create hydradb --nixos-path "<nixpkgs/nixos>" --local-address 10.242.1.2 --host-address 10.242.1.1 --config-file test-database.nix'
+            fi
           '';
 
           preConfigure = "autoreconf -vfi";

--- a/test-database.nix
+++ b/test-database.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+{
+  services.postgresql = {
+    enable = true;
+    ensureDatabases = [ "hydra" ];
+    ensureUsers = [
+      { name = "hydra";
+        ensurePermissions."DATABASE hydra" = "ALL PRIVILEGES";
+      }
+    ];
+    authentication = ''
+      host all all all trust
+    '';
+    enableTCPIP = true;
+  };
+
+  networking.firewall.allowedTCPPorts = [ 5432 ];
+}


### PR DESCRIPTION
This PR contains two commits with the attempt to make bootstrapping and hacking on Hydra easier. Until now it missed to mention hydra-init and setting the env vars accordingly.

Please note that this PR is highly opinionated and it probably shouldn't merged as-is to master. However it may help other folks to get started with contributing to Hydra even faster.

-----
**Update** from *2019-11-02* (after adding postgresql support):

This is basically stuff I found out during several times I contributed
minor things to Hydra. This patch adds several files to `.gitignore` to
ensure that one doesn't add random stuff accidentally to their commit.

Also improved the shellHook to set all required environment variables
and to check if there's a postgresql available (optionally one can start
a simple instance in a nixos-container using `test-database.nix`).