### PR TITLE
Fix constraint violation in Jobset update

### DIFF
--- a/src/lib/Hydra/Controller/Jobset.pm
+++ b/src/lib/Hydra/Controller/Jobset.pm
@@ -276,7 +276,7 @@ sub updateJobset {
             });
 
         $value = checkInputValue($c, $name, $type, $value);
-        $input->jobsetinputalts->create({altnr => 0, value => $value});
+        $input->jobsetinputalts->update_or_create({altnr => 0, value => $value});
     }
 }
 


### PR DESCRIPTION
Until now I usually get an error like this when I try to update a jobset
configuration which contains several inputs:

```
DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception:
DBD::SQLite::st execute failed: UNIQUE constraint failed:
JobsetInputAlts.project, JobsetInputAlts.jobset, JobsetInputAlts.input, JobsetInputAlts.altnr
[for Statement "INSERT INTO JobsetInputAlts ( altnr, input, jobset, project, value) VALUES ( ?, ?, ?, ?, ? )"
with ParamValues: 1=0, 2='github', 3='baumal', 4='alarm', 5='https://github.com/nixos/nixpkgs']
at /home/ma27/Projects/hydra/src/script/../lib/Hydra/Controller/Jobset.pm line 279
```

This happens to occur since the table `JobsetInputAlts` contains a
primary key over the fields `project`, `jobset`, `input, `altnr`. When I
alter another value (e.g. switching the state from "Enabled" to
"Disabled") the controller tries to create a new input which collides
the the primary key declaration.

To work around this, the database should check first if the input
already exists by using `update_or_create`.