### PR TITLE
Consumable system features

### DIFF
--- a/src/hydra-queue-runner/dispatcher.cc
+++ b/src/hydra-queue-runner/dispatcher.cc
@@ -340,6 +340,9 @@ State::MachineReservation::MachineReservation(State & state, Step::ptr step, Mac
 {
     machine->state->currentJobs++;
 
+    for (auto & f : step->requiredSystemFeatures)
+        machine->state->featuresConsumption[f.first] += f.second;
+
     {
         auto machineTypes_(state.machineTypes.lock());
         (*machineTypes_)[step->systemType].running++;
@@ -353,6 +356,9 @@ State::MachineReservation::~MachineReservation()
     assert(prev);
     if (prev == 1)
         machine->state->idleSince = time(0);
+
+    for (auto & f : step->requiredSystemFeatures)
+        machine->state->featuresConsumption[f.first] -= f.second;
 
     {
         auto machineTypes_(state.machineTypes.lock());

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <thread>
+#include <climits>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -109,12 +110,30 @@ void State::parseMachines(const std::string & contents)
         else
             machine->maxJobs = 1;
         machine->speedFactor = atof(tokens[4].c_str());
+
         if (tokens[5] == "-") tokens[5] = "";
-        machine->supportedFeatures = tokenizeString<StringSet>(tokens[5], ",");
+        for (auto & rf : tokenizeString<StringSet>(tokens[5], ",")) {
+            auto ft = tokenizeString<std::list<std::string>>(rf, ":");
+            unsigned int amount = UINT_MAX;
+            if (ft.size() == 2) // consumable info provided
+                amount = std::stoul(ft.back());
+            if (amount == 0)
+                amount = UINT_MAX;
+            machine->supportedFeatures[ft.front()] = amount;
+        }
+
         if (tokens[6] == "-") tokens[6] = "";
-        machine->mandatoryFeatures = tokenizeString<StringSet>(tokens[6], ",");
-        for (auto & f : machine->mandatoryFeatures)
-            machine->supportedFeatures.insert(f);
+        for (auto & rf : tokenizeString<StringSet>(tokens[6], ",")) {
+            auto ft = tokenizeString<std::list<std::string>>(rf, ":");
+            unsigned int amount = UINT_MAX;
+            if (ft.size() == 2) // consumable info provided
+                amount = std::stoul(ft.back());
+            if (amount == 0)
+                amount = UINT_MAX;
+            machine->mandatoryFeatures[ft.front()] = amount;
+            machine->supportedFeatures[ft.front()] = amount;
+        }
+
         if (tokens[7] != "" && tokens[7] != "-")
             machine->sshPublicHostKey = base64Decode(tokens[7]);
 


### PR DESCRIPTION
Adds support for consumable system features.

Remote build machines can specify a supported or mandatory feature as
consumable with a "feature:n" notation, where n is the quantity of the
feature that the machine provides.  "feature:0" and "feature" are both
interpreted as a non-consumable (infinite) feature.

Derivations can specify how much of a feature they consume with a
similar "feature:n" notation, where n is the quantity of the feature
that the derivation consumes.  "feature" is interpreted as "feature:1"
(i.e., consumes one of the feature), and "feature:0" is interpreted as
still requiring the feature but not consuming any of it.

Closes #585

I tested this locally with a variety of different feature combinations and it behaves correctly.

Also, I am not a C++ programmer. A lot of this may very well be written in a non-optimal or non-idiomatic way. If there's a better way to write any of the code I've got here, please let me know.

Design notes are at https://github.com/NixOS/nix/issues/2307, feedback / discussion on the design should happen there.

There's an obvious corresponding implementation in NixOS/nix, but that will probably have to be authored by someone who's more familiar with the codebase than I am.