### PR TITLE
Fix darcs input to use darcs-specific SCM cache dir.

### DIFF
--- a/src/lib/Hydra/Plugin/DarcsInput.pm
+++ b/src/lib/Hydra/Plugin/DarcsInput.pm
@@ -22,7 +22,7 @@ sub fetchInput {
     my $storePath;
     my $revCount;
 
-    my $cacheDir = getSCMCacheDir . "/git";
+    my $cacheDir = getSCMCacheDir . "/darcs";
     mkpath($cacheDir);
     my $clonePath = $cacheDir . "/" . sha256_hex($uri);
     $uri =~ s|^file://||; # darcs wants paths, not file:// uris


### PR DESCRIPTION
Currently re-using the git cache dir which could cause overlap problems.