### PR TITLE
Update prompt for Local path input to indicate a URL is also valid.

### DIFF
--- a/src/lib/Hydra/Plugin/PathInput.pm
+++ b/src/lib/Hydra/Plugin/PathInput.pm
@@ -8,7 +8,7 @@ use Nix::Store;
 
 sub supportedInputTypes {
     my ($self, $inputTypes) = @_;
-    $inputTypes->{'path'} = 'Local path';
+    $inputTypes->{'path'} = 'Local path or URL';
 }
 
 sub fetchInput {


### PR DESCRIPTION
The PathInput input for local paths was previously enhanced to allow
URLs for which it would use a nix-prefetch-url operation.  This change
updates the prompt for the declarative input type to indicate this
capability.