### PR TITLE
Add JSON to hydra-perl-deps

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -75,6 +75,7 @@ rec {
             FileSlurp
             IOCompress
             IPCRun
+            JSON
             JSONXS
             LWP
             LWPProtocolHttps


### PR DESCRIPTION
This fixes test failures on 18.09 ("Can't locate JSON.pm in @INC").

Example snippet:
```
initialising the Hydra database schema...
PASS: set-up.pl
1..76
STDERR: Can't locate JSON.pm in @INC (you may need to install the JSON module) (@INC contains: . /build/source/src/lib /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl/5.28.0 /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0 /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl/5.28.0 /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0 /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0 /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/5.28.0/x86_64-linux-thread-multi /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/5.28.0) at /build/source/src/lib/Hydra/Helper/AddBuilds.pm line 6.
BEGIN failed--compilation aborted at /build/source/src/lib/Hydra/Helper/AddBuilds.pm line 6.
Compilation failed in require at /build/source/src/script/hydra-eval-jobset line 10.
BEGIN failed--compilation aborted at /build/source/src/script/hydra-eval-jobset line 10.
not ok 1 - Evaluating jobs/basic.nix should exit with return code 0
#   Failed test 'Evaluating jobs/basic.nix should exit with return code 0'
#   at ./evaluation-tests.pl line 24.
not ok 2 - Evaluating jobs/basic.nix should result in 3 builds
#   Failed test 'Evaluating jobs/basic.nix should result in 3 builds'
#   at ./evaluation-tests.pl line 25.
STDERR: Can't locate JSON.pm in @INC (you may need to install the JSON module) (@INC contains: . /build/source/src/lib /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl/5.28.0 /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0 /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl/5.28.0 /nix/store/j4wi2q8npcfv84vcwrmf35rwfcqd0yxj-hydra-perl-deps/lib/perl5/site_perl /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0 /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0/x86_64-linux-thread-multi /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/site_perl/5.28.0 /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/5.28.0/x86_64-linux-thread-multi /nix/store/q9ajsngf2w3r10dg7b1148wzq1avp4gj-perl-5.28.0/lib/perl5/5.28.0) at /build/source/src/lib/Hydra/Helper/AddBuilds.pm line 6.
BEGIN failed--compilation aborted at /build/source/src/lib/Hydra/Helper/AddBuilds.pm line 6.
Compilation failed in require at /build/source/src/script/hydra-eval-jobset line 10.
BEGIN failed--compilation aborted at /build/source/src/script/hydra-eval-jobset line 10.
```