### PR TITLE
Added job/PROJECT/JOBSET/JOB/latest-outpath endpoint.

### DIFF
--- a/src/lib/Hydra/Base/Controller/ListBuilds.pm
+++ b/src/lib/Hydra/Base/Controller/ListBuilds.pm
@@ -58,6 +58,20 @@ sub latest : Chained('get_builds') PathPart('latest') {
 }
 
 
+# Redirect to the latest successful build's first output path (useful
+# if the output is HTML (e.g. haddock documentation).
+sub latest_outpath : Chained('get_builds') PathPart('latest-outpath') {
+    my ($self, $c, @rest) = @_;
+
+    my $latest = $c->stash->{allBuilds}->find(
+        { finished => 1, buildstatus => 0 }, { order_by => ["id DESC"], rows => 1 });
+
+    notFound($c, "There is no successful build to redirect to.") unless defined $latest;
+
+    $c->res->redirect(($latest->buildoutputs)[0]->path);
+}
+
+
 # Redirect to the latest successful build for a specific platform.
 sub latest_for : Chained('get_builds') PathPart('latest-for') {
     my ($self, $c, $system, @rest) = @_;


### PR DESCRIPTION
Returns a redirect to the first output path of the latest successful
build of the specified job. This can be useful when the output
provides HTML documentation (e.g. generated documentation for a build
such as Haskell haddock output).  By providing a "constant" redirect
link, the hydra machine can also serve the documentation it builds via
an href in a static page.