### PR TITLE
allow users with 'restart-jobs' role to restart individual builds

### DIFF
--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -493,7 +493,7 @@ sub nix : Chained('buildChain') PathPart('nix') CaptureArgs(0) {
 sub restart : Chained('buildChain') PathPart Args(0) {
     my ($self, $c) = @_;
     my $build = $c->stash->{build};
-    requireProjectOwner($c, $build->project);
+    requireRestartPrivileges($c, $build->project);
     my $n = restartBuilds($c->model('DB')->schema, $c->model('DB::Builds')->search({ id => $build->id }));
     error($c, "This build cannot be restarted.") if $n != 1;
     $c->flash->{successMsg} = "Build has been restarted.";


### PR DESCRIPTION
Sometimes there is just that one failing build that you want to restart. With the current permission model uses that have the `restart-jobs` permission can only restart all failed builds of an evaluation.

This change should make it possible to additionally restart individual builds.


The change is fairly trivial and I wasn't able to test that yet since I do not run my own hydra (yet).