### PR TITLE
Stops the pager from blocking at configurePhase

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ then
     NIX_STATE_DIR="$TMPDIR"
     export NIX_STATE_DIR
 fi
-if NIX_REMOTE=daemon "$NIX_STORE_PROGRAM" --timeout 123 -q; then 
+if NIX_REMOTE=daemon PAGER=cat "$NIX_STORE_PROGRAM" --timeout 123 -q; then 
     AC_MSG_RESULT([yes])
 else
     AC_MSG_RESULT([no])


### PR DESCRIPTION
This is caused by the autoconf check for `nix-store` which is equivalent
to running this:

```
$ nix-store --timeout 123 -q
```

This would open the pager on a 2.1.1 version of nix.

```
$ nix-store --version
nix-store (Nix) 2.1.1
```

Setting `PAGER` to `cat` ensures the pager doesn't block the
configurePhase.

```
$ PAGER=cat nix-store --timeout 123 -q
```