### PR TITLE
Adds error messages to lazy tabs

### DIFF
--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -237,7 +237,13 @@ sub end : ActionClass('RenderView') {
 
     elsif (scalar @{$c->error}) {
         $c->stash->{resource} = { error => join "\n", @{$c->error} };
-        $c->stash->{template} = 'error.tt';
+        if ($c->stash->{lazy}) {
+            $c->response->headers->header('X-Hydra-Lazy', 'Yes');
+            $c->stash->{template} = 'lazy_error.tt';
+        }
+        else {
+            $c->stash->{template} = 'error.tt';
+        }
         $c->stash->{errors} = $c->error;
         $c->response->status(500) if $c->response->status == 200;
         if ($c->response->status >= 300) {

--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -349,9 +349,10 @@ sub dashboard :Chained('dashboard_base') :PathPart('') :Args(0) {
 
 sub my_jobs_tab :Chained('dashboard_base') :PathPart('my-jobs-tab') :Args(0) {
     my ($self, $c) = @_;
+    $c->stash->{lazy} = 1;
     $c->stash->{template} = 'dashboard-my-jobs-tab.tt';
 
-    die unless $c->stash->{user}->emailaddress;
+    error($c, "No email address is set for this user.") unless $c->stash->{user}->emailaddress;
 
     # Get all current builds of which this user is a maintainer.
     $c->stash->{builds} = [$c->model('DB::Builds')->search(

--- a/src/root/lazy_error.tt
+++ b/src/root/lazy_error.tt
@@ -1,0 +1,5 @@
+[% PROCESS common.tt %]
+
+[% FOREACH error IN errors %]
+   <div class="alert alert-error">[% HTML.escape(error).replace('\n', '<br/>') %]</div>
+[% END %]

--- a/src/root/static/js/common.js
+++ b/src/root/static/js/common.js
@@ -108,8 +108,12 @@ function makeLazyTab(tabName, uri) {
         if (id == '#' + tabName && !tabsLoaded[id]) {
           tabsLoaded[id] = 1;
           $('#' + tabName).load(uri, function(response, status, xhr) {
-            if (status == "error") {
+            var lazy = xhr.getResponseHeader("X-Hydra-Lazy") === "Yes";
+            if (status == "error" && !lazy) {
               $('#' + tabName).html("<div class='alert alert-error'>Error loading tab: " + xhr.status + " " + xhr.statusText + "</div>");
+            }
+            else {
+              $('#' + tabName).html(response);
             }
           });
         }


### PR DESCRIPTION
On a fresh hydra development instance, I'm getting this unhelpful error message on *My jobs*.

![image](https://user-images.githubusercontent.com/132835/49331796-c54b7880-f570-11e8-9ffe-a01e7a787f28.png)

This PR adds the ability for lazy tabs to show the `error()` given.

![image](https://user-images.githubusercontent.com/132835/49331808-e44a0a80-f570-11e8-83c2-605561f53c17.png)

* * *

I am taking my first steps into the world of Perl, so this is possibly a bad implementation of a good idea. I am open to critique and to suggestion to make this better.

These are also my first steps in Hydra and its internals, which means the same, it might be unoptimally implemented. The idea here is to touch the smaller amount of things to implement this.

The way it is implemented, this allows `error()` in a "lazy" route to implicitly use a partial view for the error messages, and to document the fact that this is *still* to be rendered as-is using the custom header as the side-channel.

Ideally, I would like to instead use an attribute `:Lazy` on the route's method, but I have no idea how it works, if it's possible or if it's a good idea. Adding this attribute could also allow other automatisms, like using the full URL for the resource, with a special header (e.g. `X-Hydra-Wants-Lazy`), and render only the tab with the header, and the full layout with pre-baked tab on a normal navigation to the route. (Using HTML5 history navigation would allow us to change the URL when loading the tab via ajax.)