### PR TITLE
hydra-eval-jobs: Warn and resets maxHeapSize on bad values

### DIFF
--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -234,6 +234,18 @@ int main(int argc, char * * argv)
         initNix();
         initGC();
 
+        /* Read the current heap size, which is the initial heap size. */
+        GC_prof_stats_s gc;
+        GC_get_prof_stats(&gc, sizeof(gc));
+        auto initialHeapSizeInt = gc.heapsize_full;
+
+        /* Then make sure the maximum heap size will be bigger than the initial heap size. */
+        if (initialHeapSizeInt > maxHeapSize) {
+            printInfo("warning: evaluator_initial_heap_size (%d) bigger than evaluator_max_heap_size (%d).", initialHeapSizeInt, maxHeapSize);
+            maxHeapSize = initialHeapSizeInt * 1.1;
+            printInfo("         evaluator_max_heap_size now set to %d.", maxHeapSize);
+        }
+
         Path releaseExpr;
 
         struct MyArgs : LegacyArgs, MixEvalArgs


### PR DESCRIPTION
This is because setting only the initial heap size to more than
the default value (or the configured value) will cause all initial evals
until maxHeapSize expands to the given value to abort.

The 1.1 multiplier comes from the the configured defaults on NixOS' hydra,
and from the previous multiplier used before
7876cf677ce086c22faf8909bcec7ac8811f1d39.

* * *

```
 $ export GC_INITIAL_HEAP_SIZE=40G
 $ .../result/bin/hydra-eval-jobs ...
warning: evaluator_initial_heap_size (42949672960) bigger than evaluator_max_heap_size (1073741824).
         evaluator_max_heap_size now set to 47244640256.
```