### PR TITLE
Add hydra-dev-server which uses the classic Catalyst server

### DIFF
--- a/src/lib/Hydra/Script/DevServer.pm
+++ b/src/lib/Hydra/Script/DevServer.pm
@@ -1,0 +1,7 @@
+package Hydra::Script::DevServer;
+use Moose;
+use namespace::autoclean;
+
+extends 'Catalyst::Script::Server';
+
+1;

--- a/src/script/hydra-dev-server
+++ b/src/script/hydra-dev-server
@@ -1,0 +1,59 @@
+#! /usr/bin/env perl
+
+BEGIN {
+    $ENV{CATALYST_SCRIPT_GEN} = 40;
+}
+
+use Catalyst::ScriptRunner;
+Catalyst::ScriptRunner->run('Hydra', 'DevServer');
+
+1;
+
+=head1 NAME
+
+hydra_server.pl - Catalyst Test Server
+
+=head1 SYNOPSIS
+
+hydra_server.pl [options]
+
+   -d --debug           force debug mode
+   -f --fork            handle each request in a new process
+                        (defaults to false)
+   -? --help            display this help and exits
+   -h --host            host (defaults to all)
+   -p --port            port (defaults to 3000)
+   -k --keepalive       enable keep-alive connections
+   -r --restart         restart when files get modified
+                        (defaults to false)
+   -rd --restart_delay  delay between file checks
+                        (ignored if you have Linux::Inotify2 installed)
+   -rr --restart_regex  regex match files that trigger
+                        a restart when modified
+                        (defaults to '\.yml$|\.yaml$|\.conf|\.pm$')
+   --restart_directory  the directory to search for
+                        modified files, can be set multiple times
+                        (defaults to '[SCRIPT_DIR]/..')
+   --follow_symlinks    follow symlinks in search directories
+                        (defaults to false. this is a no-op on Win32)
+   --background         run the process in the background
+   --pidfile            specify filename for pid file
+
+ See also:
+   perldoc Catalyst::Manual
+   perldoc Catalyst::Manual::Intro
+
+=head1 DESCRIPTION
+
+Run a Catalyst Testserver for this application.
+
+=head1 AUTHORS
+
+Catalyst Contributors, see Catalyst.pm
+
+=head1 COPYRIGHT
+
+This library is free software. You can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut


### PR DESCRIPTION
This, in turns allows

 - Using --restart for reloading the perl code
 - Printing traces on error

* * *

I am invoking [Cunningham's Law](https://meta.wikimedia.org/wiki/Cunningham%27s_Law) here. Following the manual, Appendix A., I couldn't figure out how to make the server handle changes in code. 

With these changes, it becomes more trivial for developers to get in a quick hack/test loop.