### PR TITLE
tests: disable sandbox

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,5 +40,6 @@ dirs:
 	mkdir -p nix
 	mkdir -p nix/etc/nix
 	touch nix/etc/nix/nix.conf
+	echo "sandbox = false" >> nix/etc/nix/nix.conf
 	mkdir -p nix/store
 	mkdir -p nix/var


### PR DESCRIPTION
Hydra has not been deployable from bastion lately due to a build error.

Prior, tests would all fail to build, causing, roughly, the following
error (roughly, because I added some debug log messages :)):

    ok 68 - Evaluating jobs/build-products.nix should result in 2 builds
    Queue runner stderr: using 4185024512 bytes for the NAR buffer
    locking path '/build/source/tests/data/queue-runner/lock'
    lock acquired on '/build/source/tests/data/queue-runner/lock.lock'
    warning: unknown setting 'max-connection-age'
    warning: unknown setting 'max-connections'
    dispatcher woken up
    dispatcher woken up
    dispatcher sleeping for 7674380800s
    adding new machine ‘localhost’
    dispatcher woken up
    checking the queue for builds > 0...
    dispatcher sleeping for 7674380800s
    sending notification about build 1
    loading build 18 (tests:build-products:simple)
    considering derivation ‘/build/source/tests/nix/store/24h0i450d4k00a4jhhk6r7qpqdvzskw6-build-product-simple.drv’
    sending notification about build 2
    creating build step ‘/build/source/tests/nix/store/24h0i450d4k00a4jhhk6r7qpqdvzskw6-build-product-simple.drv’
    added build 18 (top-level step /build/source/tests/nix/store/24h0i450d4k00a4jhhk6r7qpqdvzskw6-build-product-simple.drv, 1 new steps)
    got 1 new runnable steps from 1 new builds
    step ‘/build/source/tests/nix/store/24h0i450d4k00a4jhhk6r7qpqdvzskw6-build-product-simple.drv’ is now runnable
    dispatcher woken up
    dispatcher sleeping for 7674380800s
    performing step ‘/build/source/tests/nix/store/24h0i450d4k00a4jhhk6r7qpqdvzskw6-build-product-simple.drv’ 1 times on ‘localhost’ (needed by build 18
    and 0 others)
    sending closure of ‘/build/source/tests/nix/store/24h0i450d4k00a4jhhk6r7qpqdvzskw6-build-product-simple.drv’ to ‘localhost’
    building ‘/build/source/tests/nix/store/24h0i450d4k00a4jhhk6r7qpqdvzskw6-build-product-simple.drv’ on ‘localhost’
    killing process 10462
    marking build 18 as failed
    finishing build step ‘/build/source/tests/nix/store/24h0i450d4k00a4jhhk6r7qpqdvzskw6-build-product-simple.drv’

    ok 69 - Build 'simple' from jobs/build-products.nix should exit with code 0
    ok 70 - newbuild->finished was '1' instead of 1
    not ok 71 - newbuild->buildstatus was '1' instead of 0
    not ok 72 - Build 'simple' from jobs/build-products.nix should have buildstatus 0
    Can't call method "name" on an undefined value at ./evaluation-tests.pl line 173.
    FAIL: evaluation-tests.pl