### PR TITLE
Fix Linux build on Darwin

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -37,8 +37,9 @@ in
 rec {
 
   build = genAttrs' (system:
+    let pkgs = import nixpkgs { inherit system; }; in
 
-    with import nixpkgs { inherit system; };
+    with pkgs;
 
     let
 


### PR DESCRIPTION
This is a fix for https://discourse.nixos.org/t/why-do-darwin-build-derivations-end-up-on-a-nixos-system/2416/2.

Without this patch running the following on MacOS:

```
nix-build release.nix -A build.x86_64-linux
```

results in the following error during the configuration phase (note that Nix should be configured with a x86_64-linux build machine):

```
building '/nix/store/jb6ca1gmplyb69ayd43z7fb0y9npxd53-hydra-0.1.2581.8b5948f4cf12424c04df67a6eb136c9846fb2cfd.drv' on 'ssh://my-linux-build-machine'...
...
checking whether /nix/store/s6bhdppx66bkgf741vk4d29hgsj1h1zp-hydra-perl-deps/bin/nix-store is recent enough... ./configure: line 16254: /nix/store/s6bhdppx66bkgf741vk4d29hgsj1h1zp-hydra-perl-deps/bin/nix-store: cannot execute binary file: Exec format error
no
configure: error: `/nix/store/s6bhdppx66bkgf741vk4d29hgsj1h1zp-hydra-perl-deps/bin/nix-store' doesn't support `--timeout'; please use a newer version.
build time elapsed:  0m1.624s 0m1.774s 0m9.366s 0m6.110s
builder for '/nix/store/jb6ca1gmplyb69ayd43z7fb0y9npxd53-hydra-0.1.2581.8b5948f4cf12424c04df67a6eb136c9846fb2cfd.drv' failed with exit code 1
```

This problem is that the `nix` dependency of hydra is selected from a nixpkgs set configured with a default `system` parameter, i.e. `builtin.currentSystem`. This means that the hydra derivation which is
build for and on Linux depends on the nix derivation build for Darwin.

The fix is to select nix from the nixpkgs set configured with a system specified by the user.