### PR TITLE
allow using a shorter context and increase hydra-notify debug

### DIFF
--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -487,6 +487,7 @@ void State::notificationSender()
                         argv = {"hydra-notify", "step-finished", std::to_string(item.id), std::to_string(item.stepNr), item.logPath};
                         break;
                 };
+                printMsg(lvlChatty, "Executing hydra-notify " + concatStringsSep(" ", argv));
                 execvp("hydra-notify", (char * *) stringsToCharPtrs(argv).data()); // FIXME: remove cast
                 throw SysError("cannot start hydra-notify");
             });


### PR DESCRIPTION
(cherry picked from commit 1c76ad393669af2f728fd519a050f417319412a6)

This PR adds `useShortContext = 1` as an option to github status that does two things:

1. rename continuous-integration/hydra to ci/hydra
2. remove the PR suffix from the name.

We use this primarily to be able to see full path in github for long job names as well as set protected branches requiring a hydra notification to be present.

It also adds additional debug we found useful to develop this feature.