### PR TITLE
improve the error messages when invalid declarative jobsets are defined

### DIFF
--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -76,7 +76,12 @@ sub handleDeclarativeJobsetBuild {
             push @kept, ".jobsets";
             $project->jobsets->search({ name => { "not in" => \@kept } })->update({ enabled => 0, hidden => 1 });
             while ((my $jobsetName, my $spec) = each %$declSpec) {
-                updateDeclarativeJobset($db, $project, $jobsetName, $spec);
+                eval {
+                    updateDeclarativeJobset($db, $project, $jobsetName, $spec);
+                };
+                if ($@) {
+                    print STDERR "ERROR: failed to process declarative jobset ", $project->name, ":${jobsetName}, ", $@, "\n";
+                }
             }
         });
     };


### PR DESCRIPTION
(cherry picked from commit 7568b89a1a9da3a58a0cdddc7b5bcea7bb6209d8)

This improves error messages when declarative jobsets are used.