### PR TITLE
redo the notify events between eval and queue-runner

### DIFF
--- a/src/hydra-queue-runner/state.hh
+++ b/src/hydra-queue-runner/state.hh
@@ -493,6 +493,9 @@ private:
     /* Check the queue for new builds. */
     bool getQueuedBuilds(Connection & conn,
         nix::ref<nix::Store> destStore, unsigned int & lastBuildId);
+    bool getQueuedBuildsInEval(Connection & conn,
+        nix::ref<nix::Store> destStore, unsigned int evalId);
+    bool finishQueuedBuilds(Connection & conn, nix::ref<nix::Store> destStore, unsigned int & lastBuildId, unsigned int newLastBuildId, std::vector<BuildID> newIDs, std::map<BuildID, Build::ptr> newBuildsByID, std::multimap<nix::Path, BuildID> newBuildsByPath);
 
     /* Handle cancellation, deletion and priority bumps. */
     void processQueueChange(Connection & conn);

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -25,7 +25,7 @@ STDERR->autoflush(1);
 binmode STDERR, ":encoding(utf8)";
 
 my $db = Hydra::Model::DB->new();
-my $notifyAdded = $db->storage->dbh->prepare("notify builds_added, ?");
+my $notifyAdded = $db->storage->dbh->prepare("notify eval_added, ?");
 
 my $config = getHydraConfig();
 
@@ -744,11 +744,7 @@ sub checkJobsetWrapped {
             $ev->builds->update({iscurrent => 1});
 
             # Wake up hydra-queue-runner.
-            my $lowestId;
-            while (my ($id, $x) = each %buildMap) {
-                $lowestId = $id if $x->{new} && (!defined $lowestId || $id < $lowestId);
-            }
-            $notifyAdded->execute($lowestId) if defined $lowestId;
+            $notifyAdded->execute($ev->id);
 
         } else {
             print STDERR "  created cached eval ", $ev->id, "\n";


### PR DESCRIPTION
(cherry picked from commit 73ca325d1c0f7914640a63764c9a6d448fde5bd0)

We did this at IOHK to improve some performance problems with notifications. It's still not perfect, and there may be a good reason to not do it this way, but creating a PR for the community to discuss whether this is worthwhile, and if so if it needs improvements to get in.