### PR TITLE
tests: change postgresql socket dir to /tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Makefile.in
 /inst
 hydra-config.h
 hydra-config.h.in
+result

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,7 @@ TESTS_ENVIRONMENT = \
   NIX_STORE_DIR="$(abs_builddir)/nix/store"			\
   NIX_LOG_DIR="$(abs_builddir)/nix/var/log/nix"		\
   NIX_BUILD_HOOK=					\
+  PGHOST=/tmp	\
   PERL5LIB="$(srcdir):$(abs_top_srcdir)/src/lib:$$PERL5LIB"	\
   PATH=$(abs_top_srcdir)/src/hydra-evaluator:$(abs_top_srcdir)/src/script:$(abs_top_srcdir)/src/hydra-eval-jobs:$(abs_top_srcdir)/src/hydra-queue-runner:$$PATH \
   perl -w

--- a/tests/set-up.pl
+++ b/tests/set-up.pl
@@ -1,5 +1,5 @@
 use strict;
 system("initdb -D postgres") == 0 or die;
-system("pg_ctl -D postgres -o \"-F -p 6433 -h ''\" -w start") == 0 or die;
+system("pg_ctl -D postgres -o \"-F -p 6433 -h '' -k /tmp \" -w start") == 0 or die;
 system("createdb -p 6433 hydra-test-suite") == 0 or die;
 system("hydra-init") == 0 or die;


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/pull/57677 default postgresql socket directory was changed
to `/run/postgresql`, which doesn't exist (and can't be created) in
Nix build environment. We'll use /tmp as socket dir explicitly then.

Fixes build failure https://hydra.nixos.org/build/91221682

Cc @aszlig @edolstra