### PR TITLE
Allow to search builds by hash

### DIFF
--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -422,11 +422,11 @@ sub search :Local Args(0) {
 
     # Perform build search in separate queries to prevent seq scan on buildoutputs table.
     $c->stash->{builds} = [ $c->model('DB::Builds')->search(
-        { "buildoutputs.path" => trim($query) },
+        { "buildoutputs.path" => { ilike => "%$query%" } },
         { order_by => ["id desc"], join => ["buildoutputs"] } ) ];
 
     $c->stash->{buildsdrv} = [ $c->model('DB::Builds')->search(
-        { "drvpath" => trim($query) },
+        { "drvpath" => { ilike => "%$query%" } },
         { order_by => ["id desc"] } ) ];
 
     $c->stash->{resource} = { projects => $c->stash->{projects},

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -688,3 +688,9 @@ create index IndexBuildsOnKeep on Builds(keep) where keep = 1;
 create index IndexJobsetEvalsOnJobsetId on JobsetEvals(project, jobset, id desc) where hasNewBuilds = 1;
 
 create index IndexBuildsOnNotificationPendingSince on Builds(notificationPendingSince) where notificationPendingSince is not null;
+
+#ifdef POSTGRESQL
+-- Provide an index used by LIKE operator on builds.drvpath (search query)
+CREATE EXTENSION pg_trgm;
+CREATE INDEX IndexTrgmBuildsOnDrvpath ON builds USING gin (drvpath gin_trgm_ops);
+#endif

--- a/src/sql/upgrade-57.sql
+++ b/src/sql/upgrade-57.sql
@@ -1,0 +1,2 @@
+CREATE EXTENSION pg_trgm;
+CREATE INDEX IndexTrgmBuildsOnDrvpath ON builds USING gin (drvpath gin_trgm_ops);


### PR DESCRIPTION
Currently, a full store path has to be provided to search in
builds. This patch permits to search jobs with a output path or
derivation hash.

Usecase: we are building Docker images with Hydra. The tag of the
Docker image is the hash of the image output path. This patch would
allow us to find back the build job from the tag of a running
container image.