### PR TITLE
Create `pg_trgm` extension in the NixOS module

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -273,6 +273,7 @@ in
               runuser -u ${config.services.postgresql.superUser} -- ${config.services.postgresql.package}/bin/createdb -O hydra hydra
               touch ${baseDir}/.db-created
             fi
+            echo "create extension if not exists pg_trgm" | runuser -u ${config.services.postgresql.superUser} -- ${config.services.postgresql.package}/bin/psql hydra
           ''}
 
           if [ ! -e ${cfg.gcRootsDir} ]; then
@@ -415,6 +416,8 @@ in
         hydra-users hydra-queue-runner hydra
         hydra-users hydra-www hydra
         hydra-users root hydra
+        # The postgres user is used to create the pg_trgm extension for the hydra database
+        hydra-users postgres postgres
       '';
 
     services.postgresql.authentication = optionalString haveLocalDB

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -690,7 +690,20 @@ create index IndexJobsetEvalsOnJobsetId on JobsetEvals(project, jobset, id desc)
 create index IndexBuildsOnNotificationPendingSince on Builds(notificationPendingSince) where notificationPendingSince is not null;
 
 #ifdef POSTGRESQL
--- Provide an index used by LIKE operator on builds.drvpath (search query)
-create extension pg_trgm;
-create index IndexTrgmBuildsOnDrvpath on builds using gin (drvpath gin_trgm_ops);
+-- The pg_trgm extension has to be created by a superuser. The NixOS
+-- module creates this extension in the systemd prestart script. We
+-- then ensure the extension has been created before creating the
+-- index. If it is not possible to create the extension, a warning
+-- message is emitted to inform the user the index creation is skipped
+-- (slower complex queries on builds.drvpath).
+do $$
+begin
+    create extension if not exists pg_trgm;
+    -- Provide an index used by LIKE operator on builds.drvpath (search query)
+    create index IndexTrgmBuildsOnDrvpath on builds using gin (drvpath gin_trgm_ops);
+exception when others then
+    raise warning 'Can not create extension pg_trgm: %', SQLERRM;
+    raise warning 'HINT: Temporary provide superuser role to your Hydra Postgresql user and run the script src/sql/upgrade-57.sql';
+    raise warning 'The pg_trgm index on builds.drvpath has been skipped (slower complex queries on builds.drvpath)';
+end$$;
 #endif

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -691,6 +691,6 @@ create index IndexBuildsOnNotificationPendingSince on Builds(notificationPending
 
 #ifdef POSTGRESQL
 -- Provide an index used by LIKE operator on builds.drvpath (search query)
-CREATE EXTENSION pg_trgm;
-CREATE INDEX IndexTrgmBuildsOnDrvpath ON builds USING gin (drvpath gin_trgm_ops);
+create extension pg_trgm;
+create index IndexTrgmBuildsOnDrvpath on builds using gin (drvpath gin_trgm_ops);
 #endif

--- a/src/sql/upgrade-57.sql
+++ b/src/sql/upgrade-57.sql
@@ -1,2 +1,16 @@
-create extension pg_trgm;
-create index IndexTrgmBuildsOnDrvpath on builds using gin (drvpath gin_trgm_ops);
+-- The pg_trgm extension has to be created by a superuser. The NixOS
+-- module creates this extension in the systemd prestart script. We
+-- then ensure the extension has been created before creating the
+-- index. If it is not possible to create the extension, a warning
+-- message is emitted to inform the user the index creation is skipped
+-- (slower complex queries on builds.drvpath).
+do $$
+begin
+    create extension if not exists pg_trgm;
+    -- Provide an index used by LIKE operator on builds.drvpath (search query)
+    create index IndexTrgmBuildsOnDrvpath on builds using gin (drvpath gin_trgm_ops);
+exception when others then
+    raise warning 'Can not create extension pg_trgm: %', SQLERRM;
+    raise warning 'HINT: Temporary provide superuser role to your Hydra Postgresql user and run the script src/sql/upgrade-57.sql';
+    raise warning 'The pg_trgm index on builds.drvpath has been skipped (slower complex queries on builds.drvpath)';
+end$$;

--- a/src/sql/upgrade-57.sql
+++ b/src/sql/upgrade-57.sql
@@ -1,2 +1,2 @@
-CREATE EXTENSION pg_trgm;
-CREATE INDEX IndexTrgmBuildsOnDrvpath ON builds USING gin (drvpath gin_trgm_ops);
+create extension pg_trgm;
+create index IndexTrgmBuildsOnDrvpath on builds using gin (drvpath gin_trgm_ops);


### PR DESCRIPTION
The creation of the `pg_trgm` extension needs superuser power. So,
this patch makes the extension creation in the Hydra NixOS module when
a local database is used.

If it is not possible to create this extension (remote database for
instance with nosuperuser), the creation of the `pg_trgm` index is
skipped (this index speedup queries on builds.drvpath) and warnings
are emitted:

    initialising the Hydra database schema...
    WARNING:  Can not create extension pg_trgm: permission denied to create extension "pg_trgm"
    WARNING:  HINT: Temporary provide superuser role to your Hydra Postgresql user and run the script src/sql/upgrade-57.sql
    WARNING:  The pg_trgm index on builds.drvpath has been skipped (slower complex queries on builds.drvpath)

This allows to keep smooth migrations: the migration process doesn't
require a manual step (but this manual step is recommended on big
remote databases).

@rbvermaa does it work for you?