### PR TITLE
hydra-server: jobsets api endpoint returns more elements

### DIFF
--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -81,7 +81,14 @@ sub jobsetToHash {
         nrscheduled => $jobset->get_column("nrscheduled"),
         nrsucceeded => $jobset->get_column("nrsucceeded"),
         nrfailed => $jobset->get_column("nrfailed"),
-        nrtotal => $jobset->get_column("nrtotal")
+        nrtotal => $jobset->get_column("nrtotal"),
+        lastcheckedtime => $jobset->lastcheckedtime,
+        starttime => $jobset->starttime,
+        checkinterval => $jobset->checkinterval,
+        triggertime => $jobset->triggertime,
+        errormsg => $jobset->errormsg,
+        fetcherrormsg => $jobset->fetcherrormsg,
+        errortime => $jobset->errortime
     };
 }
 


### PR DESCRIPTION
Improve the jobset API output by returning attributes related to
evaluations. These informations can be useful to know if a jobset has
been successfully evaluated.