### PR TITLE
Turn hydra-notify into a daemon

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -391,6 +391,8 @@ in
           { ExecStart = "@${cfg.package}/bin/hydra-notify hydra-notify";
             # FIXME: run this under a less privileged user?
             User = "hydra-queue-runner";
+            Restart = "always";
+            RestartSec = 5;
           };
       };
 

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -379,6 +379,21 @@ in
           };
       };
 
+    systemd.services.hydra-notify =
+      { wantedBy = [ "multi-user.target" ];
+        requires = [ "hydra-init.service" ];
+        after = [ "hydra-init.service" ];
+        restartTriggers = [ hydraConf ];
+        environment = env // {
+          PGPASSFILE = "${baseDir}/pgpass-queue-runner"; # grrr
+        };
+        serviceConfig =
+          { ExecStart = "@${cfg.package}/bin/hydra-notify hydra-notify";
+            # FIXME: run this under a less privileged user?
+            User = "hydra-queue-runner";
+          };
+      };
+
     # If there is less than a certain amount of free disk space, stop
     # the queue/evaluator to prevent builds from failing or aborting.
     systemd.services.hydra-check-space =

--- a/src/hydra-queue-runner/builder.cc
+++ b/src/hydra-queue-runner/builder.cc
@@ -99,6 +99,8 @@ State::StepResult State::doBuildStep(nix::ref<Store> destStore,
     unsigned int maxSilentTime, buildTimeout;
     unsigned int repeats = step->isDeterministic ? 1 : 0;
 
+    auto conn(dbPool.get());
+
     {
         std::set<Build::ptr> dependents;
         std::set<Step::ptr> steps;
@@ -122,8 +124,10 @@ State::StepResult State::doBuildStep(nix::ref<Store> destStore,
 
         for (auto build2 : dependents) {
             if (build2->drvPath == step->drvPath) {
-              build = build2;
-              enqueueNotificationItem({NotificationItem::Type::BuildStarted, build->id});
+                build = build2;
+                pqxx::work txn(*conn);
+                notifyBuildStarted(txn, build->id);
+                txn.commit();
             }
             {
                 auto i = jobsetRepeats.find(std::make_pair(build2->projectName, build2->jobsetName));
@@ -143,8 +147,6 @@ State::StepResult State::doBuildStep(nix::ref<Store> destStore,
     }
 
     bool quit = buildId == buildOne && step->drvPath == buildDrvPath;
-
-    auto conn(dbPool.get());
 
     RemoteResult result;
     BuildOutput res;
@@ -170,11 +172,6 @@ State::StepResult State::doBuildStep(nix::ref<Store> destStore,
             } catch (...) {
                 ignoreException();
             }
-
-            /* Asynchronously run plugins. FIXME: if we're killed,
-               plugin actions might not be run. Need to ensure
-               at-least-once semantics. */
-            enqueueNotificationItem({NotificationItem::Type::StepFinished, buildId, {}, stepNr, result.logFile});
         }
     });
 
@@ -342,8 +339,12 @@ State::StepResult State::doBuildStep(nix::ref<Store> destStore,
 
         /* Send notification about the builds that have this step as
            the top-level. */
-        for (auto id : buildIDs)
-            enqueueNotificationItem({NotificationItem::Type::BuildFinished, id});
+        {
+            pqxx::work txn(*conn);
+            for (auto id : buildIDs)
+                notifyBuildFinished(txn, id, {});
+            txn.commit();
+        }
 
         /* Wake up any dependent steps that have no other
            dependencies. */
@@ -462,11 +463,10 @@ State::StepResult State::doBuildStep(nix::ref<Store> destStore,
 
         /* Send notification about this build and its dependents. */
         {
-            auto notificationSenderQueue_(notificationSenderQueue.lock());
-            notificationSenderQueue_->push(NotificationItem{NotificationItem::Type::BuildFinished, buildId, dependentIDs});
+            pqxx::work txn(*conn);
+            notifyBuildFinished(txn, buildId, dependentIDs);
+            txn.commit();
         }
-        notificationSenderWakeup.notify_one();
-
     }
 
     // FIXME: keep stats about aborted steps?

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -299,6 +299,9 @@ void State::finishBuildStep(pqxx::work & txn, const RemoteResult & result,
         (result.timesBuilt, result.timesBuilt > 0)
         (result.isNonDeterministic, result.timesBuilt > 1)
         .exec();
+    assert(result.logFile.find('\'') == std::string::npos);
+    txn.exec(fmt("notify step_finished, '%d %d %s'", buildId, stepNr,
+            result.logFile.empty() ? "-" : result.logFile));
 }
 
 
@@ -450,74 +453,20 @@ bool State::checkCachedFailure(Step::ptr step, Connection & conn)
 }
 
 
-void State::notificationSender()
+void State::notifyBuildStarted(pqxx::work & txn, BuildID buildId)
 {
-    while (true) {
-        try {
+    txn.exec(fmt("notify build_started, '%s'", buildId));
+}
 
-            NotificationItem item;
-            {
-                auto notificationSenderQueue_(notificationSenderQueue.lock());
-                while (notificationSenderQueue_->empty())
-                    notificationSenderQueue_.wait(notificationSenderWakeup);
-                item = notificationSenderQueue_->front();
-                notificationSenderQueue_->pop();
-            }
 
-            MaintainCount<counter> mc(nrNotificationsInProgress);
-
-            printMsg(lvlChatty, format("sending notification about build %1%") % item.id);
-
-            auto now1 = std::chrono::steady_clock::now();
-
-            Pid pid = startProcess([&]() {
-                Strings argv;
-                switch (item.type) {
-                    case NotificationItem::Type::BuildStarted:
-                        argv = {"hydra-notify", "build-started", std::to_string(item.id)};
-                        for (auto id : item.dependentIds)
-                            argv.push_back(std::to_string(id));
-                        break;
-                    case NotificationItem::Type::BuildFinished:
-                        argv = {"hydra-notify", "build-finished", std::to_string(item.id)};
-                        for (auto id : item.dependentIds)
-                            argv.push_back(std::to_string(id));
-                        break;
-                    case NotificationItem::Type::StepFinished:
-                        argv = {"hydra-notify", "step-finished", std::to_string(item.id), std::to_string(item.stepNr), item.logPath};
-                        break;
-                };
-                printMsg(lvlChatty, "Executing hydra-notify " + concatStringsSep(" ", argv));
-                execvp("hydra-notify", (char * *) stringsToCharPtrs(argv).data()); // FIXME: remove cast
-                throw SysError("cannot start hydra-notify");
-            });
-
-            int res = pid.wait();
-
-            if (!statusOk(res))
-                throw Error("notification about build %d failed: %s", item.id, statusToString(res));
-
-            auto now2 = std::chrono::steady_clock::now();
-
-            if (item.type == NotificationItem::Type::BuildFinished) {
-                auto conn(dbPool.get());
-                pqxx::work txn(*conn);
-                txn.parameterized
-                    ("update Builds set notificationPendingSince = null where id = $1")
-                    (item.id)
-                    .exec();
-                txn.commit();
-            }
-
-            nrNotificationTimeMs += std::chrono::duration_cast<std::chrono::milliseconds>(now2 - now1).count();
-            nrNotificationsDone++;
-
-        } catch (std::exception & e) {
-            nrNotificationsFailed++;
-            printMsg(lvlError, format("notification sender: %1%") % e.what());
-            sleep(5);
-        }
-    }
+void State::notifyBuildFinished(pqxx::work & txn, BuildID buildId,
+    const std::vector<BuildID> & dependentIds)
+{
+    auto payload = fmt("%d ", buildId);
+    for (auto & d : dependentIds)
+        payload += fmt("%d ", d);
+    // FIXME: apparently parameterized() doesn't support NOTIFY.
+    txn.exec(fmt("notify build_finished, '%s'", payload));
 }
 
 
@@ -589,13 +538,6 @@ void State::dumpStatus(Connection & conn, bool log)
         root.attr("nrDbConnections", dbPool.count());
         root.attr("nrActiveDbUpdates", nrActiveDbUpdates);
         root.attr("memoryTokensInUse", memoryTokens.currentUse());
-        root.attr("nrNotificationsDone", nrNotificationsDone);
-        root.attr("nrNotificationsFailed", nrNotificationsFailed);
-        root.attr("nrNotificationsInProgress", nrNotificationsInProgress);
-        root.attr("nrNotificationsPending", notificationSenderQueue.lock()->size());
-        root.attr("nrNotificationTimeMs", nrNotificationTimeMs);
-        uint64_t nrNotificationsTotal = nrNotificationsDone + nrNotificationsFailed;
-        root.attr("nrNotificationTimeAvgMs", nrNotificationsTotal == 0 ? 0.0 : (float) nrNotificationTimeMs / nrNotificationsTotal);
 
         {
             auto nested = root.object("machines");
@@ -842,24 +784,6 @@ void State::run(BuildID buildOne)
     std::thread(&State::queueMonitor, this).detach();
 
     std::thread(&State::dispatcher, this).detach();
-
-    /* Idem for notification sending. */
-    auto maxConcurrentNotifications = config->getIntOption("max-concurrent-notifications", 2);
-    for (uint64_t i = 0; i < maxConcurrentNotifications; ++i)
-        std::thread(&State::notificationSender, this).detach();
-
-    /* Enqueue notification items for builds that were finished
-       previously, but for which we didn't manage to send
-       notifications. */
-    {
-        auto conn(dbPool.get());
-        pqxx::work txn(*conn);
-        auto res = txn.parameterized("select id from Builds where notificationPendingSince > 0").exec();
-        for (auto const & row : res) {
-            auto id = row["id"].as<BuildID>();
-            enqueueNotificationItem({NotificationItem::Type::BuildFinished, id});
-        }
-    }
 
     /* Periodically clean up orphaned busy steps in the database. */
     std::thread([&]() {

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -268,6 +268,9 @@ unsigned int State::createBuildStep(pqxx::work & txn, time_t startTime, BuildID 
             ("insert into BuildStepOutputs (build, stepnr, name, path) values ($1, $2, $3, $4)")
             (buildId)(stepNr)(output.first)(output.second.path).exec();
 
+    if (status == bsBusy)
+        txn.exec(fmt("notify step_started, '%d\t%d'", buildId, stepNr));
+
     return stepNr;
 }
 

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -299,9 +299,9 @@ void State::finishBuildStep(pqxx::work & txn, const RemoteResult & result,
         (result.timesBuilt, result.timesBuilt > 0)
         (result.isNonDeterministic, result.timesBuilt > 1)
         .exec();
-    assert(result.logFile.find('\'') == std::string::npos);
-    txn.exec(fmt("notify step_finished, '%d %d %s'", buildId, stepNr,
-            result.logFile.empty() ? "-" : result.logFile));
+    assert(result.logFile.find('\t') == std::string::npos);
+    txn.exec(fmt("notify step_finished, '%d\t%d\t%s'",
+            buildId, stepNr, result.logFile));
 }
 
 

--- a/src/hydra-queue-runner/queue-monitor.cc
+++ b/src/hydra-queue-runner/queue-monitor.cc
@@ -193,12 +193,11 @@ bool State::getQueuedBuilds(Connection & conn,
                     (build->id)
                     ((int) (ex.step->drvPath == build->drvPath ? bsFailed : bsDepFailed))
                     (time(0)).exec();
+                notifyBuildFinished(txn, build->id, {});
                 txn.commit();
                 build->finishedInDB = true;
                 nrBuildsDone++;
             }
-
-            enqueueNotificationItem({NotificationItem::Type::BuildFinished, build->id});
 
             return;
         }
@@ -230,12 +229,11 @@ bool State::getQueuedBuilds(Connection & conn,
             time_t now = time(0);
             printMsg(lvlInfo, format("marking build %1% as succeeded (cached)") % build->id);
             markSucceededBuild(txn, build, res, true, now, now);
+            notifyBuildFinished(txn, build->id, {});
             txn.commit();
             }
 
             build->finishedInDB = true;
-
-            enqueueNotificationItem({NotificationItem::Type::BuildFinished, build->id});
 
             return;
         }

--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -76,7 +76,7 @@ sub latestbuilds : Chained('api') PathPart('latestbuilds') Args(0) {
 sub jobsetToHash {
     my ($jobset) = @_;
     return {
-        project => $jobset->project->name,
+        project => $jobset->get_column('project'),
         name => $jobset->name,
         nrscheduled => $jobset->get_column("nrscheduled"),
         nrsucceeded => $jobset->get_column("nrsucceeded"),
@@ -206,12 +206,12 @@ sub scmdiff : Path('/api/scmdiff') Args(0) {
 
 sub triggerJobset {
     my ($self, $c, $jobset, $force) = @_;
-    print STDERR "triggering jobset ", $jobset->project->name . ":" . $jobset->name, "\n";
+    print STDERR "triggering jobset ", $jobset->get_column('project') . ":" . $jobset->name, "\n";
     txn_do($c->model('DB')->schema, sub {
         $jobset->update({ triggertime => time });
         $jobset->update({ forceeval => 1 }) if $force;
     });
-    push @{$c->{stash}->{json}->{jobsetsTriggered}}, $jobset->project->name . ":" . $jobset->name;
+    push @{$c->{stash}->{json}->{jobsetsTriggered}}, $jobset->get_column('project') . ":" . $jobset->name;
 }
 
 

--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -142,7 +142,7 @@ sub release : Chained('evalChain') PathPart('release') Args(0) {
     $releaseName ||= $_->releasename foreach @builds;
 
     # If no release name has been defined by any of the builds, compose one of the project name and evaluation id
-    $releaseName = $eval->project->name."-".$eval->id unless defined $releaseName;
+    $releaseName = $eval->get_column('project') . "-" . $eval->id unless defined $releaseName;
 
     my $release;
 

--- a/src/lib/Hydra/Helper/CatalystUtils.pm
+++ b/src/lib/Hydra/Helper/CatalystUtils.pm
@@ -60,9 +60,9 @@ sub getNextBuild {
     (my $nextBuild) = $c->model('DB::Builds')->search(
       { finished => 1
       , system => $build->system
-      , project => $build->project->name
-      , jobset => $build->jobset->name
-      , job => $build->job->name
+      , project => $build->get_column('project')
+      , jobset => $build->get_column('jobset')
+      , job => $build->get_column('job')
       , 'me.id' =>  { '>' => $build->id }
       }, {rows => 1, order_by => "me.id ASC"});
 
@@ -77,9 +77,9 @@ sub getPreviousSuccessfulBuild {
     (my $prevBuild) = $c->model('DB::Builds')->search(
       { finished => 1
       , system => $build->system
-      , project => $build->project->name
-      , jobset => $build->jobset->name
-      , job => $build->job->name
+      , project => $build->get_column('project')
+      , jobset => $build->get_column('jobset')
+      , job => $build->get_column('job')
       , buildstatus => 0
       , 'me.id' =>  { '<' => $build->id }
       }, {rows => 1, order_by => "me.id DESC"});
@@ -289,7 +289,7 @@ sub parseJobsetName {
 
 sub showJobName {
     my ($build) = @_;
-    return $build->project->name . ":" . $build->jobset->name . ":" . $build->job->name;
+    return $build->get_column('project') . ":" . $build->get_column('jobset') . ":" . $build->get_column('job');
 }
 
 

--- a/src/lib/Hydra/Plugin.pm
+++ b/src/lib/Hydra/Plugin.pm
@@ -12,11 +12,15 @@ sub new {
     return $self;
 }
 
+sub isEnabled {
+    return 1;
+}
+
 sub instantiate {
     my ($class, %args) = @_;
     my $plugins = [];
     $args{plugins} = $plugins;
-    push @$plugins, $class->plugins(%args);
+    push @$plugins, grep { $_->isEnabled } $class->plugins(%args);
     return @$plugins;
 }
 

--- a/src/lib/Hydra/Plugin/BitBucketStatus.pm
+++ b/src/lib/Hydra/Plugin/BitBucketStatus.pm
@@ -7,6 +7,11 @@ use JSON;
 use LWP::UserAgent;
 use Hydra::Helper::CatalystUtils;
 
+sub isEnabled {
+    my ($self) = @_;
+    return $self->{config}->{enable_bitbucket_status} == 1;
+}
+
 sub toBitBucketState {
     my ($buildStatus) = @_;
     if ($buildStatus == 0) {

--- a/src/lib/Hydra/Plugin/CircleCINotification.pm
+++ b/src/lib/Hydra/Plugin/CircleCINotification.pm
@@ -7,6 +7,11 @@ use LWP::UserAgent;
 use Hydra::Helper::CatalystUtils;
 use JSON;
 
+sub isEnabled {
+    my ($self) = @_;
+    return defined $self->{config}->{circleci};
+}
+
 sub buildFinished {
     my ($self, $build, $dependents) = @_;
     my $cfg = $self->{config}->{circleci};

--- a/src/lib/Hydra/Plugin/CoverityScan.pm
+++ b/src/lib/Hydra/Plugin/CoverityScan.pm
@@ -6,6 +6,11 @@ use File::Basename;
 use LWP::UserAgent;
 use Hydra::Helper::CatalystUtils;
 
+sub isEnabled {
+    my ($self) = @_;
+    return defined $self->{config}->{coverityscan};
+}
+
 sub buildFinished {
     my ($self, $b, $dependents) = @_;
 

--- a/src/lib/Hydra/Plugin/EmailNotification.pm
+++ b/src/lib/Hydra/Plugin/EmailNotification.pm
@@ -9,6 +9,10 @@ use Hydra::Helper::Nix;
 use Hydra::Helper::CatalystUtils;
 use Hydra::Helper::Email;
 
+sub isEnabled {
+    my ($self) = @_;
+    return $self->{config}->{email_notification} == 1;
+}
 
 my $template = <<EOF;
 Hi,
@@ -43,8 +47,6 @@ EOF
 
 sub buildFinished {
     my ($self, $build, $dependents) = @_;
-
-    return unless $self->{config}->{email_notification} // 0;
 
     die unless $build->finished;
 

--- a/src/lib/Hydra/Plugin/EmailNotification.pm
+++ b/src/lib/Hydra/Plugin/EmailNotification.pm
@@ -100,7 +100,7 @@ sub buildFinished {
             , dependents => [grep { $_->id != $build->id } @builds]
             , baseurl => getBaseUrl($self->{config})
             , showJobName => \&showJobName, showStatus => \&showStatus
-            , showSystem => index($build->job->name, $build->system) == -1
+            , showSystem => index($build->get_column('job'), $build->system) == -1
             , nrCommits => $nrCommits
             , authorList => $authorList
             };
@@ -119,9 +119,9 @@ sub buildFinished {
 
         sendEmail(
             $self->{config}, $to, $subject, $body,
-            [ 'X-Hydra-Project'  => $build->project->name,
-            , 'X-Hydra-Jobset'   => $build->jobset->name,
-            , 'X-Hydra-Job'      => $build->job->name,
+            [ 'X-Hydra-Project'  => $build->get_column('project'),
+            , 'X-Hydra-Jobset'   => $build->get_column('jobset'),
+            , 'X-Hydra-Job'      => $build->get_column('job'),
             , 'X-Hydra-System'   => $build->system
             ]);
     }

--- a/src/lib/Hydra/Plugin/GithubStatus.pm
+++ b/src/lib/Hydra/Plugin/GithubStatus.pm
@@ -8,6 +8,11 @@ use LWP::UserAgent;
 use Hydra::Helper::CatalystUtils;
 use List::Util qw(max);
 
+sub isEnabled {
+    my ($self) = @_;
+    return defined $self->{config}->{githubstatus};
+}
+
 sub toGithubState {
     my ($buildStatus) = @_;
     if ($buildStatus == 0) {

--- a/src/lib/Hydra/Plugin/GitlabStatus.pm
+++ b/src/lib/Hydra/Plugin/GitlabStatus.pm
@@ -55,7 +55,7 @@ sub common {
                 state => $state,
                 target_url => "$baseurl/build/" . $b->id,
                 description => "Hydra build #" . $b->id . " of $jobName",
-                name => "Hydra " . $b->job->name,
+                name => "Hydra " . $b->get_column('job'),
             });
         while (my $eval = $evals->next) {
             my $gitlabstatusInput = $eval->jobsetevalinputs->find({ name => "gitlab_status_repo" });

--- a/src/lib/Hydra/Plugin/GitlabStatus.pm
+++ b/src/lib/Hydra/Plugin/GitlabStatus.pm
@@ -16,6 +16,11 @@ use List::Util qw(max);
 #   - gitlab_project_id => ID of the project in Gitlab, i.e. in the above
 #     case the ID in gitlab of "nixexprs"
 
+sub isEnabled {
+    my ($self) = @_;
+    return defined $self->{config}->{gitlab_authorization};
+}
+
 sub toGitlabState {
     my ($status, $buildStatus) = @_;
     if ($status == 0) {

--- a/src/lib/Hydra/Plugin/HipChatNotification.pm
+++ b/src/lib/Hydra/Plugin/HipChatNotification.pm
@@ -5,6 +5,11 @@ use parent 'Hydra::Plugin';
 use LWP::UserAgent;
 use Hydra::Helper::CatalystUtils;
 
+sub isEnabled {
+    my ($self) = @_;
+    return defined $self->{config}->{hipchat};
+}
+
 sub buildFinished {
     my ($self, $build, $dependents) = @_;
 

--- a/src/lib/Hydra/Plugin/HipChatNotification.pm
+++ b/src/lib/Hydra/Plugin/HipChatNotification.pm
@@ -59,7 +59,7 @@ sub buildFinished {
 
         my $msg = "";
         $msg .= "<img src='$img'/> ";
-        $msg .= "Job <a href='$baseurl/job/${\$build->project->name}/${\$build->jobset->name}/${\$build->job->name}'>${\showJobName($build)}</a>";
+        $msg .= "Job <a href='$baseurl/job/${\$build->get_column('project')}/${\$build->get_column('jobset')}/${\$build->get_column('job')}'>${\showJobName($build)}</a>";
         $msg .= " (and ${\scalar @deps} others)" if scalar @deps > 0;
         $msg .= ": <a href='$baseurl/build/${\$build->id}'>" . showStatus($build) . "</a>";
 

--- a/src/lib/Hydra/Plugin/InfluxDBNotification.pm
+++ b/src/lib/Hydra/Plugin/InfluxDBNotification.pm
@@ -7,6 +7,11 @@ use HTTP::Request;
 use LWP::UserAgent;
 # use Hydra::Helper::CatalystUtils;
 
+sub isEnabled {
+    my ($self) = @_;
+    return defined $self->{config}->{influxdb};
+}
+
 sub toBuildStatusDetailed {
     my ($buildStatus) = @_;
     if ($buildStatus == 0) {

--- a/src/lib/Hydra/Plugin/InfluxDBNotification.pm
+++ b/src/lib/Hydra/Plugin/InfluxDBNotification.pm
@@ -104,10 +104,10 @@ sub buildFinished {
         my $tagSet = {
             status  => toBuildStatusClass($b->buildstatus),
             result  => toBuildStatusDetailed($b->buildstatus),
-            project => $b->project->name,
-            jobset  => $b->jobset->name,
-            repo    => ($b->jobset->name =~ /^(.*)\.pr-/) ? $1 : $b->jobset->name,
-            job     => $b->job->name,
+            project => $b->get_column('project'),
+            jobset  => $b->get_column('jobset'),
+            repo    => ($b->get_column('jobset') =~ /^(.*)\.pr-/) ? $1 : $b->get_column('jobset'),
+            job     => $b->get_column('job'),
             system  => $b->system,
             cached  => $b->iscachedbuild ? "true" : "false",
         };

--- a/src/lib/Hydra/Plugin/RunCommand.pm
+++ b/src/lib/Hydra/Plugin/RunCommand.pm
@@ -5,6 +5,11 @@ use parent 'Hydra::Plugin';
 use experimental 'smartmatch';
 use JSON;
 
+sub isEnabled {
+    my ($self) = @_;
+    return defined $self->{config}->{runcommand};
+}
+
 sub configSectionMatches {
     my ($name, $project, $jobset, $job) = @_;
 

--- a/src/lib/Hydra/Plugin/S3Backup.pm
+++ b/src/lib/Hydra/Plugin/S3Backup.pm
@@ -14,6 +14,11 @@ use Nix::Store;
 use Hydra::Model::DB;
 use Hydra::Helper::CatalystUtils;
 
+sub isEnabled {
+    my ($self) = @_;
+    return defined $self->{config}->{s3backup};
+}
+
 my $client;
 my %compressors = (
     xz => "| $Nix::Config::xz",

--- a/src/lib/Hydra/Plugin/SlackNotification.pm
+++ b/src/lib/Hydra/Plugin/SlackNotification.pm
@@ -7,6 +7,11 @@ use LWP::UserAgent;
 use Hydra::Helper::CatalystUtils;
 use JSON;
 
+sub isEnabled {
+    my ($self) = @_;
+    return defined $self->{config}->{slack};
+}
+
 sub renderDuration {
     my ($build) = @_;
     my $duration = $build->stoptime - $build->starttime;

--- a/src/lib/Hydra/Plugin/SlackNotification.pm
+++ b/src/lib/Hydra/Plugin/SlackNotification.pm
@@ -81,7 +81,7 @@ sub buildFinished {
             "danger";
 
         my $text = "";
-        $text .= "Job <$baseurl/job/${\$build->project->name}/${\$build->jobset->name}/${\$build->job->name}|${\showJobName($build)}>";
+        $text .= "Job <$baseurl/job/${\$build->get_column('project')}/${\$build->get_column('jobset')}/${\$build->get_column('job')}|${\showJobName($build)}>";
         $text .= " (and ${\scalar @deps} others)" if scalar @deps > 0;
         $text .= ": <$baseurl/build/${\$build->id}|" . showStatus($build) . ">". " in " . renderDuration($build);
 

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -568,7 +568,7 @@ sub permute {
 
 
 sub checkJobsetWrapped {
-    my ($jobset) = @_;
+    my ($jobset, $tmpId) = @_;
     my $project = $jobset->project;
     my $jobsetsJobset = length($project->declfile) && $jobset->name eq ".jobsets";
     my $inputInfo = {};
@@ -607,6 +607,7 @@ sub checkJobsetWrapped {
         print STDERR $fetchError;
         txn_do($db, sub {
             $jobset->update({ lastcheckedtime => time, fetcherrormsg => $fetchError }) if !$dryRun;
+            $db->storage->dbh->do("notify eval_failed, ?", undef, join('\t', $tmpId));
         });
         return;
     }
@@ -622,6 +623,7 @@ sub checkJobsetWrapped {
         Net::Statsd::increment("hydra.evaluator.unchanged_checkouts");
         txn_do($db, sub {
             $jobset->update({ lastcheckedtime => time, fetcherrormsg => undef });
+            $db->storage->dbh->do("notify eval_cached, ?", undef, join('\t', $tmpId));
         });
         return;
     }
@@ -689,6 +691,9 @@ sub checkJobsetWrapped {
             , hasnewbuilds => $jobsetChanged ? 1 : 0
             , nrbuilds => $jobsetChanged ? scalar(keys %buildMap) : undef
             });
+
+        $db->storage->dbh->do("notify eval_added, ?", undef,
+                              join('\t', $tmpId, $ev->id));
 
         if ($jobsetChanged) {
             # Create JobsetEvalMembers mappings.
@@ -767,10 +772,6 @@ sub checkJobsetWrapped {
     Net::Statsd::increment("hydra.evaluator.evals");
     Net::Statsd::increment("hydra.evaluator.cached_evals") unless $jobsetChanged;
 
-    #while (my ($id, $x) = each %buildMap) {
-    #    system("hydra-notify build-queued $id") if $x->{new};
-    #}
-
     # Store the error messages for jobs that failed to evaluate.
     my $msg = "";
     foreach my $job (values %{$jobs}) {
@@ -788,8 +789,15 @@ sub checkJobset {
 
     my $startTime = clock_gettime(CLOCK_MONOTONIC);
 
+    # Add an ID to eval_* notifications so receivers can correlate
+    # them.
+    my $tmpId = "${startTime}.$$";
+
+    $db->storage->dbh->do("notify eval_started, ?", undef,
+                          join('\t', $tmpId, $jobset->get_column('project'), $jobset->name));
+
     eval {
-        checkJobsetWrapped($jobset);
+        checkJobsetWrapped($jobset, $tmpId);
     };
     my $checkError = $@;
 
@@ -802,6 +810,7 @@ sub checkJobset {
         txn_do($db, sub {
             $jobset->update({lastcheckedtime => time});
             setJobsetError($jobset, $checkError);
+            $db->storage->dbh->do("notify eval_failed, ?", undef, join('\t', $tmpId));
         }) if !$dryRun;
         $failed = 1;
     }

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -438,7 +438,7 @@ sub checkBuild {
                 # semantically unnecessary (because they're implied by
                 # the eval), but they give a factor 1000 speedup on
                 # the Nixpkgs jobset with PostgreSQL.
-                { project => $jobset->project->name, jobset => $jobset->name, job => $jobName,
+                { project => $jobset->get_column('project'), jobset => $jobset->name, job => $jobName,
                   name => $firstOutputName, path => $firstOutputPath },
                 { rows => 1, columns => ['id'], join => ['buildoutputs'] });
             if (defined $prevBuild) {
@@ -489,7 +489,7 @@ sub checkBuild {
         $buildMap->{$build->id} = { id => $build->id, jobName => $jobName, new => 1, drvPath => $drvPath };
         $$jobOutPathMap{$jobName . "\t" . $firstOutputPath} = $build->id;
 
-        print STDERR "added build ${\$build->id} (${\$jobset->project->name}:${\$jobset->name}:$jobName)\n";
+        print STDERR "added build ${\$build->id} (${\$jobset->get_column('project')}:${\$jobset->name}:$jobName)\n";
     });
 
     return $build;
@@ -531,7 +531,7 @@ sub sendJobsetErrorNotification() {
     return if $jobset->project->owner->emailonerror == 0;
     return if $errorMsg eq "";
 
-    my $projectName = $jobset->project->name;
+    my $projectName = $jobset->get_column('project');
     my $jobsetName = $jobset->name;
     my $body = "Hi,\n"
         . "\n"

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -96,27 +96,28 @@ my $sel = IO::Select->new($fd);
 
 while (1) {
     $sel->can_read;
-    my $notify = $dbh->func("pg_notifies");
-    next if !$notify;
 
-    my ($channelName, $pid, $payload) = @$notify;
-    #print STDERR "got '$channelName' from $pid: $payload\n";
+    while (my $notify = $dbh->func("pg_notifies")) {
 
-    my @payload = split /\t/, $payload;
+        my ($channelName, $pid, $payload) = @$notify;
+        #print STDERR "got '$channelName' from $pid: $payload\n";
 
-    eval {
-        if ($channelName eq "build_started") {
-            buildStarted(int($payload[0]));
-        } elsif ($channelName eq "build_finished") {
-            my $buildId = int($payload[0]);
-            my $build = $db->resultset('Builds')->find($buildId)
-                or die "build $buildId does not exist\n";
-            buildFinished($build, @payload[1..$#payload]);
-        } elsif ($channelName eq "step_finished") {
-            stepFinished(int($payload[0]), int($payload[1]));
+        my @payload = split /\t/, $payload;
+
+        eval {
+            if ($channelName eq "build_started") {
+                buildStarted(int($payload[0]));
+            } elsif ($channelName eq "build_finished") {
+                my $buildId = int($payload[0]);
+                my $build = $db->resultset('Builds')->find($buildId)
+                    or die "build $buildId does not exist\n";
+                buildFinished($build, @payload[1..$#payload]);
+            } elsif ($channelName eq "step_finished") {
+                stepFinished(int($payload[0]), int($payload[1]));
+            }
+        };
+        if ($@) {
+            print STDERR "error processing message '$payload' on channel '$channelName': $@\n";
         }
-    };
-    if ($@) {
-        print STDERR "error processing message '$payload' on channel '$channelName': $@\n";
     }
 }

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -102,7 +102,7 @@ while (1) {
     my ($channelName, $pid, $payload) = @$notify;
     #print STDERR "got '$channelName' from $pid: $payload\n";
 
-    my @payload = split / /, $payload;
+    my @payload = split /\t/, $payload;
 
     eval {
         if ($channelName eq "build_started") {

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -5,6 +5,7 @@ use utf8;
 use Hydra::Plugin;
 use Hydra::Helper::Nix;
 use Hydra::Helper::AddBuilds;
+use IO::Select;
 
 STDERR->autoflush(1);
 binmode STDERR, ":encoding(utf8)";
@@ -15,20 +16,37 @@ my $db = Hydra::Model::DB->new();
 
 my @plugins = Hydra::Plugin->instantiate(db => $db, config => $config);
 
-my $cmd = shift @ARGV or die "Syntax: hydra-notify build-started BUILD | build-finished BUILD-ID [BUILD-IDs...] | step-finished BUILD-ID STEP-NR LOG-PATH\n";
+my $dbh = $db->storage->dbh;
 
-my $buildId = shift @ARGV or die;
-my $build = $db->resultset('Builds')->find($buildId)
-    or die "build $buildId does not exist\n";
+$dbh->do("listen build_started");
+$dbh->do("listen build_finished");
+$dbh->do("listen step_finished");
 
-if ($cmd eq "build-finished") {
+sub buildStarted {
+    my ($buildId) = @_;
+
+    my $build = $db->resultset('Builds')->find($buildId)
+        or die "build $buildId does not exist\n";
+
+    foreach my $plugin (@plugins) {
+        eval { $plugin->buildStarted($build); };
+        if ($@) {
+            print STDERR "$plugin->buildStarted: $@\n";
+        }
+    }
+}
+
+sub buildFinished {
+    my ($build, @deps) = @_;
+
     my $project = $build->project;
     my $jobset = $build->jobset;
     if (length($project->declfile) && $jobset->name eq ".jobsets" && $build->iscurrent) {
         handleDeclarativeJobsetBuild($db, $project, $build);
     }
+
     my @dependents;
-    foreach my $id (@ARGV) {
+    foreach my $id (@deps) {
         my $dep = $db->resultset('Builds')->find($id)
             or die "build $id does not exist\n";
         push @dependents, $dep;
@@ -40,33 +58,20 @@ if ($cmd eq "build-finished") {
             print STDERR "$plugin->buildFinished: $@\n";
         }
     }
+
+    $build->update({ notificationpendingsince => undef });
 }
 
-elsif ($cmd eq "build-queued") {
-    foreach my $plugin (@plugins) {
-        eval { $plugin->buildQueued($build); };
-        if ($@) {
-            print STDERR "$plugin->buildQueued: $@\n";
-        }
-    }
-}
+sub stepFinished {
+    my ($buildId, $stepNr, $logPath) = @_;
 
-elsif ($cmd eq "build-started") {
-    foreach my $plugin (@plugins) {
-        eval { $plugin->buildStarted($build); };
-        if ($@) {
-            print STDERR "$plugin->buildStarted: $@\n";
-        }
-    }
-}
+    my $build = $db->resultset('Builds')->find($buildId)
+        or die "build $buildId does not exist\n";
 
-elsif ($cmd eq "step-finished") {
-    die if scalar @ARGV < 2;
-    my $stepNr = shift @ARGV;
     my $step = $build->buildsteps->find({stepnr => $stepNr})
         or die "step $stepNr does not exist\n";
-    my $logPath = shift @ARGV;
-    $logPath = undef if $logPath eq "";
+
+    $logPath = undef if $logPath eq "-";
 
     foreach my $plugin (@plugins) {
         eval { $plugin->stepFinished($step, $logPath); };
@@ -76,6 +81,42 @@ elsif ($cmd eq "step-finished") {
     }
 }
 
-else {
-    die "unknown action ‘$cmd’";
+# Process builds that finished while hydra-notify wasn't running.
+for my $build ($db->resultset('Builds')->search(
+                   { notificationpendingsince => { '!=', undef } }))
+{
+    my $buildId = $build->id;
+    print STDERR "sending notifications for build ${\$buildId}...\n";
+    buildFinished($build);
+}
+
+# Process incoming notifications.
+my $fd = $dbh->func("getfd");
+my $sel = IO::Select->new($fd);
+
+while (1) {
+    $sel->can_read;
+    my $notify = $dbh->func("pg_notifies");
+    next if !$notify;
+
+    my ($channelName, $pid, $payload) = @$notify;
+    #print STDERR "got '$channelName' from $pid: $payload\n";
+
+    my @payload = split / /, $payload;
+
+    eval {
+        if ($channelName eq "build_started") {
+            buildStarted(int($payload[0]));
+        } elsif ($channelName eq "build_finished") {
+            my $buildId = int($payload[0]);
+            my $build = $db->resultset('Builds')->find($buildId)
+                or die "build $buildId does not exist\n";
+            buildFinished($build, @payload[1..$#payload]);
+        } elsif ($channelName eq "step_finished") {
+            stepFinished(int($payload[0]), int($payload[1]));
+        }
+    };
+    if ($@) {
+        print STDERR "error processing message '$payload' on channel '$channelName': $@\n";
+    }
 }

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -40,8 +40,8 @@ sub buildFinished {
     my ($build, @deps) = @_;
 
     my $project = $build->project;
-    my $jobset = $build->jobset;
-    if (length($project->declfile) && $jobset->name eq ".jobsets" && $build->iscurrent) {
+    my $jobsetName = $build->get_column('jobset');
+    if (length($project->declfile) && $jobsetName eq ".jobsets" && $build->iscurrent) {
         handleDeclarativeJobsetBuild($db, $project, $build);
     }
 


### PR DESCRIPTION
`hydra-notify` is now a daemon that receives events from `hydra-queue-runner` by listening to PostgreSQL notifications. This makes it a lot more efficient: not starting a `hydra-notify` process for each event avoids the ~1s startup time loading all the plugins. Also, it allows future plugins to be written in any language as long as they can listen to PostgreSQL notifications, and to run on different machines from the queue runner.

The PostgreSQL notifications are:

* `step_started`
* `step_finished`
* `build_started`
* `build_finished`
* `eval_started`
* `eval_failed`
* `eval_cached`
* `eval_added`