### PR TITLE
Extend the jobset API response

### DIFF
--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -81,7 +81,13 @@ sub jobsetToHash {
         nrscheduled => $jobset->get_column("nrscheduled"),
         nrsucceeded => $jobset->get_column("nrsucceeded"),
         nrfailed => $jobset->get_column("nrfailed"),
-        nrtotal => $jobset->get_column("nrtotal")
+        nrtotal => $jobset->get_column("nrtotal"),
+        lastcheckedtime => $jobset->lastcheckedtime,
+        starttime => $jobset->starttime,
+        checkinterval => $jobset->checkinterval,
+        triggertime => $jobset->triggertime,
+        fetcherrormsg => $jobset->fetcherrormsg,
+        errortime => $jobset->errortime
     };
 }
 


### PR DESCRIPTION
This adds the following (pre-existing) attributes to the jobset response:

- nrtotal
- lastcheckedtime
- starttime
- checkinterval
- triggertime
- fetcherrormsg
- errortime

Note that this is identical to #664 but omits `errormsg`. The error message could potentially become arbitrarily long so it is preferable to not deliver it by default.