### PR TITLE
Add Term::Size::Any

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -106,6 +106,7 @@ rec {
             SetScalar
             Starman
             SysHostnameLong
+            TermSizeAny
             TestMore
             TextDiff
             TextTable


### PR DESCRIPTION
This removes a supper annoying set of messages that polute the logs:

    Aug 30 09:00:30 xxx.compute.internal hydra-server[957]: Trouble trying to detect your terminal size, looking at $ENV{COLUMNS}
    Aug 30 09:00:30 xxx.compute.internal hydra-server[957]: Term::Size::Any is not installed, can't autodetect terminal column width