### PR TITLE
Add LDAP support

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -112,6 +112,7 @@ rec {
             TextDiff
             TextTable
             XMLSimple
+            YAML
             nix
             nix.perl-bindings
             git

--- a/src/lib/Hydra.pm
+++ b/src/lib/Hydra.pm
@@ -20,7 +20,8 @@ use Catalyst qw/ConfigLoader
                 Captcha/,
                 '-Log=warn,fatal,error';
 use CatalystX::RoleApplicator;
-
+use YAML qw(LoadFile);
+use Path::Class 'file';
 
 our $VERSION = '0.01';
 
@@ -44,6 +45,9 @@ __PACKAGE__->config(
                     role_field => "role",
                 },
             },
+            ldap => LoadFile(
+		file($ENV{'HYDRA_LDAP_CONFIG'})
+	    )
         },
     },
     'Plugin::Static::Simple' => {

--- a/src/lib/Hydra.pm
+++ b/src/lib/Hydra.pm
@@ -45,9 +45,9 @@ __PACKAGE__->config(
                     role_field => "role",
                 },
             },
-            ldap => LoadFile(
-		file($ENV{'HYDRA_LDAP_CONFIG'})
-	    )
+            ldap => $ENV{'HYDRA_LDAP_CONFIG'} ? LoadFile(
+                file($ENV{'HYDRA_LDAP_CONFIG'})
+            ) : undef
         },
     },
     'Plugin::Static::Simple' => {


### PR DESCRIPTION
This closes #53.

The two main things that need fixing before this is ready are:

- The config parsing
  - ~Assuming a separate config file is fine, I could not manage to figure out how to load and apply it conditionally.~
  - Assuming these options should be put into `HYDRA_CONFIG`, I failed at figuring that out as well.
- The LDAP to hydra group/role mapping
  - Right now, it literally checks if they start with hydra: [1](https://github.com/NixOS/hydra/compare/master...helsinki-systems:ldap?expand=1#diff-65565fb99ce7a7d5d4887473a43888b5R57)
  - and then strips the first 6 characters from the roles: [2](https://github.com/NixOS/hydra/compare/master...helsinki-systems:ldap?expand=1#diff-65565fb99ce7a7d5d4887473a43888b5R78).

Furthermore, this introduces a dependency on [Catalyst::Authentication::Store::LDAP](https://metacpan.org/release/Catalyst-Authentication-Store-LDAP), which is not part of nixpkgs right now.

cc @dasJ @edef1c