### PR TITLE
Implement maintainer search

### DIFF
--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -33,6 +33,9 @@ sub view_GET {
     $c->stash->{filter} = $c->request->params->{filter} // "";
     my $filter = $c->stash->{filter} eq "" ? {} : { job => { ilike => "%" . $c->stash->{filter} . "%" } };
 
+    $c->stash->{maintainers} = $c->request->params->{maintainers} // "";
+    $filter->{maintainers_github} = { ilike => "%" . $c->stash->{maintainers} . "%" };
+
     my $compare = $c->req->params->{compare};
     my $eval2;
 

--- a/src/lib/Hydra/Helper/CatalystUtils.pm
+++ b/src/lib/Hydra/Helper/CatalystUtils.pm
@@ -33,7 +33,7 @@ our @EXPORT = qw(
 
 
 # Columns from the Builds table needed to render build lists.
-Readonly our @buildListColumns => ('id', 'finished', 'timestamp', 'stoptime', 'project', 'jobset', 'job', 'nixname', 'system', 'buildstatus', 'releasename');
+Readonly our @buildListColumns => ('id', 'finished', 'timestamp', 'stoptime', 'project', 'jobset', 'job', 'nixname', 'system', 'buildstatus', 'releasename', 'maintainers_github');
 
 
 sub getBuild {

--- a/src/lib/Hydra/Schema/Builds.pm
+++ b/src/lib/Hydra/Schema/Builds.pm
@@ -239,6 +239,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "maintainers",
   { data_type => "text", is_nullable => 1 },
+  "maintainers_github",
+  { data_type => "text", is_nullable => 1 },
   "maxsilent",
   { data_type => "integer", default_value => 3600, is_nullable => 1 },
   "timeout",

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -109,6 +109,7 @@ BLOCK renderBuildListHeader %]
         <th>[% IF showSchedulingInfo %]Queued at[% ELSE %]Finished at[% END %]</th>
         <th>Package/release name</th>
         <th>System</th>
+        <th>Maintainers</th>
         [% IF showDescription %]
           <th>Description</th>
         [% END %]
@@ -131,11 +132,12 @@ BLOCK renderBuildListBody;
       [% END %]
       <td><a class="row-link" href="[% link %]">[% build.id %]</a></td>
       [% IF !hideJobName %]
-        <td><a href="[%link%]">[% IF !hideJobsetName %][%build.get_column("project")%]:[%build.get_column("jobset")%]:[% END %][%build.get_column("job")%]</td>
+        <td><a href="[%link%]">[% IF !hideJobsetName %][%build.get_column("project")%]:[%build.get_column("jobset")%]:[% END %][%build.get_column("job")%]</a></td>
       [% END %]
       <td class="nowrap">[% t = showSchedulingInfo ? build.timestamp : build.stoptime; IF t; INCLUDE renderRelativeDate timestamp=(showSchedulingInfo ? build.timestamp : build.stoptime); ELSE; "-"; END %]</td>
       <td>[% !showSchedulingInfo and build.get_column('releasename') ? build.get_column('releasename') : build.nixname %]</td>
       <td class="nowrap"><tt>[% build.system %]</tt></td>
+      <td class="nowrap"><tt>[% build.maintainers_github %]</tt></td>
       [% IF showDescription %]
         <td>[% build.description %]</td>
       [% END %]

--- a/src/root/jobset-eval.tt
+++ b/src/root/jobset-eval.tt
@@ -37,6 +37,11 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
   <input name="full" type="hidden" [% HTML.attributes(value => full) %]/>
 </form>
 
+<form class="form-search">
+  <input name="maintainers" type="text" class="input-large search-query" placeholder="Search jobs by maintainers..." />
+  <input type="hidden" name="full" [% HTML.attributes(value => full) %] />
+</form>
+
 <ul class="nav nav-tabs">
   [% IF c.user_exists %]
     <li class="dropdown">

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -461,6 +461,7 @@ sub checkBuild {
             , finished => 0
             , iscurrent => 1
             , ischannel => $buildInfo->{isChannel}
+            , maintainers_github => null($buildInfo->{maintainers_github})
             });
 
         $build->buildoutputs->create({ name => $_, path => $buildInfo->{outputs}->{$_} })

--- a/src/sql/upgrade-66.sql
+++ b/src/sql/upgrade-66.sql
@@ -1,0 +1,1 @@
+alter table Builds add maintainers_github text;


### PR DESCRIPTION
As proposed during the release managers' talk on last NixCon, Hydra
should provide a feature to search for maintainers. I wanted to have
something like this for a long time as well and decided to give it a
try.

This change adds a second search field to the jobset-eval view that can
be used to search for maintainer's github names. Please note that I
intentionally didn't merge this together with the `Search by name`-form
since this form is only used to compare the builds against another eval.

By default Hydra now searches for github handles of maintainers (IMHO this
is more convenient than email addresses), however emails are
used fallbacks as the github handle isn't mandatory for a package
maintainer. The new values are stored in the `Builds` table at the new
column `maintainers_github`.