### PR TITLE
Add `cancel-build` & `bump-to-front` roles

### DIFF
--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -540,7 +540,7 @@ sub bump : Chained('buildChain') PathPart('bump') {
 
     my $build = $c->stash->{build};
 
-    requireProjectOwner($c, $build->project); # FIXME: require admin?
+    requireBumpPrivileges($c, $build->project);
 
     $c->model('DB')->schema->txn_do(sub {
         $build->update({globalpriority => time()});

--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -504,7 +504,7 @@ sub restart : Chained('buildChain') PathPart Args(0) {
 sub cancel : Chained('buildChain') PathPart Args(0) {
     my ($self, $c) = @_;
     my $build = $c->stash->{build};
-    requireProjectOwner($c, $build->project);
+    requireCancelBuildPrivileges($c, $build->project);
     my $n = cancelBuilds($c->model('DB')->schema, $c->model('DB::Builds')->search({ id => $build->id }));
     error($c, "This build cannot be cancelled.") if $n != 1;
     $c->flash->{successMsg} = "Build has been cancelled.";

--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -210,7 +210,7 @@ sub restart_failed : Chained('evalChain') PathPart('restart-failed') Args(0) {
 
 sub bump : Chained('evalChain') PathPart('bump') Args(0) {
     my ($self, $c) = @_;
-    requireProjectOwner($c, $c->stash->{eval}->project); # FIXME: require admin?
+    requireBumpPrivileges($c, $c->stash->{eval}->project); # FIXME: require admin?
     my $builds = $c->stash->{eval}->builds->search({ finished => 0 });
     my $n = $builds->count();
     $c->model('DB')->schema->txn_do(sub {

--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -179,7 +179,7 @@ sub create_jobset : Chained('evalChain') PathPart('create-jobset') Args(0) {
 
 sub cancel : Chained('evalChain') PathPart('cancel') Args(0) {
     my ($self, $c) = @_;
-    requireProjectOwner($c, $c->stash->{eval}->project);
+    requireCancelBuildPrivileges($c, $c->stash->{eval}->project);
     my $n = cancelBuilds($c->model('DB')->schema, $c->stash->{eval}->builds);
     $c->flash->{successMsg} = "$n builds have been cancelled.";
     $c->res->redirect($c->uri_for($c->controller('JobsetEval')->action_for('view'), $c->req->captures));

--- a/src/lib/Hydra/Helper/CatalystUtils.pm
+++ b/src/lib/Hydra/Helper/CatalystUtils.pm
@@ -14,6 +14,7 @@ our @EXPORT = qw(
     error notFound gone accessDenied
     forceLogin requireUser requireProjectOwner requireRestartPrivileges requireAdmin requirePost isAdmin isProjectOwner
     requireBumpPrivileges
+    requireCancelBuildPrivileges
     trim
     getLatestFinishedEval getFirstEval
     paramToList
@@ -180,6 +181,27 @@ sub isProjectOwner {
         (isAdmin($c) ||
          $c->user->username eq $project->owner->username ||
          defined $c->model('DB::ProjectMembers')->find({ project => $project, userName => $c->user->username }));
+}
+
+sub hasCancelBuildRole {
+    my ($c) = @_;
+    return $c->user_exists && $c->check_user_roles('cancel-build');
+}
+
+sub mayCancelBuild {
+    my ($c, $project) = @_;
+    return
+        $c->user_exists &&
+        (isAdmin($c) ||
+         hasCancelBuildRole($c) ||
+         isProjectOwner($c, $project));
+}
+
+sub requireCancelBuildPrivileges {
+    my ($c, $project) = @_;
+    requireUser($c);
+    accessDenied($c, "Only the project members, administrators, and accounts with cancel-build privileges can perform this operation.")
+        unless mayCancelBuild($c, $project);
 }
 
 sub hasBumpJobsRole {

--- a/src/root/user.tt
+++ b/src/root/user.tt
@@ -81,6 +81,7 @@
             [% INCLUDE roleoption role="admin" %]
             [% INCLUDE roleoption role="create-projects" %]
             [% INCLUDE roleoption role="restart-jobs" %]
+            [% INCLUDE roleoption role="bump-to-front" %]
           </select>
         </div>
       </div>

--- a/src/root/user.tt
+++ b/src/root/user.tt
@@ -82,6 +82,7 @@
             [% INCLUDE roleoption role="create-projects" %]
             [% INCLUDE roleoption role="restart-jobs" %]
             [% INCLUDE roleoption role="bump-to-front" %]
+            [% INCLUDE roleoption role="cancel-build" %]
           </select>
         </div>
       </div>


### PR DESCRIPTION
This adds the `cancel-build` & `bump-to-front` roles. The idea is to provide more granular access to hydra.nixos.org.

I tested both on a local hydra instance and so far it works as expected.


cc @grahamc 