### PR TITLE
Add host tag to InfluxDB metrics

### DIFF
--- a/src/lib/Hydra/Plugin/InfluxDBNotification.pm
+++ b/src/lib/Hydra/Plugin/InfluxDBNotification.pm
@@ -3,9 +3,8 @@ package Hydra::Plugin::InfluxDBNotification;
 use strict;
 use parent 'Hydra::Plugin';
 use HTTP::Request;
-# use JSON;
 use LWP::UserAgent;
-# use Hydra::Helper::CatalystUtils;
+use Sys::Hostname::Long;
 
 sub isEnabled {
     my ($self) = @_;
@@ -67,6 +66,11 @@ sub toBuildStatusClass {
     }
 }
 
+# Get the hostname. If we can't, we swallow the exception from hostname.
+my $hostname = eval {
+    hostname_long;
+};
+
 # Syntax
 # build_status,job=my-job status=failed,result=dependency-failed duration=123i
 #   |    -------------------- --------------  |
@@ -81,6 +85,8 @@ sub createLine {
     foreach my $tag (sort keys %$tagSet) {
         push @tags, "$tag=$tagSet->{$tag}";
     }
+    # we add host tag to all outputs
+    push @tags, "host=$hostname" if defined $hostname;
     my @fields = ();
     foreach my $field (sort keys %$fieldSet) {
         push @fields, "$field=$fieldSet->{$field}";


### PR DESCRIPTION
This should help us discern machines in environments with multiple Hydra deployments.