### PR TITLE
job: create a prometheus endpoint

### DIFF
--- a/src/lib/Hydra/Controller/Job.pm
+++ b/src/lib/Hydra/Controller/Job.pm
@@ -6,7 +6,7 @@ use warnings;
 use base 'Hydra::Base::Controller::ListBuilds';
 use Hydra::Helper::Nix;
 use Hydra::Helper::CatalystUtils;
-
+use Net::Prometheus;
 
 sub job : Chained('/') PathPart('job') CaptureArgs(3) {
     my ($self, $c, $projectName, $jobsetName, $jobName) = @_;
@@ -29,6 +29,41 @@ sub job : Chained('/') PathPart('job') CaptureArgs(3) {
     $c->stash->{project} = $c->stash->{job}->project;
 }
 
+sub prometheus : Chained('job') PathPart('prometheus') Args(0) {
+    my ($self, $c) = @_;
+    my $job = $c->stash->{job};
+    my $prometheus = Net::Prometheus->new;
+
+    my $lastBuild = $job->builds->find(
+        { finished => 1 },
+        { order_by => 'id DESC', rows => 1, columns => [@buildListColumns] }
+    );
+
+    $prometheus->new_counter(
+        name => "hydra_job_completion_time",
+        help => "The most recent job's completion time",
+        labels => [ "project", "jobset", "job", "nixname" ]
+    )->labels(
+        $c->stash->{project}->name,
+        $c->stash->{jobset}->name,
+        $c->stash->{job}->name,
+        $lastBuild->nixname,
+    )->inc($lastBuild->stoptime);
+
+    $prometheus->new_gauge(
+        name => "hydra_job_failed",
+        help => "Record if the most recent version of this job failed (1 means failed)",
+        labels => [ "project", "jobset", "job", "nixname" ]
+    )->labels(
+        $c->stash->{project}->name,
+        $c->stash->{jobset}->name,
+        $c->stash->{job}->name,
+        $lastBuild->nixname,
+    )->inc($lastBuild->stoptime >= 0);
+
+    $c->stash->{'plain'} = { data => $prometheus->render };
+    $c->forward('Hydra::View::Plain');
+}
 
 sub overview : Chained('job') PathPart('') Args(0) {
     my ($self, $c) = @_;


### PR DESCRIPTION
Export the most recent stop time and exit status in
a prometheus-friendly format.

```
# HELP hydra_job_completion_time The most recent job's completion time
# TYPE hydra_job_completion_time counter
hydra_job_completion_time{project="nixpkgs",jobset="trunk",job="unstable",nixname="nixpkgs-20.03pre206075.d68c70f1bbb"} 1576853952
# HELP hydra_job_failed Record if the most recent version of this job failed (1 means failed)
# TYPE hydra_job_failed gauge
hydra_job_failed{project="nixpkgs",jobset="trunk",job="unstable",nixname="nixpkgs-20.03pre206075.d68c70f1bbb"} 1
```

http://147.75.75.222:3000/job/nixpkgs/trunk/unstable/prometheus