### PR TITLE
Fixes for macOS

### DIFF
--- a/src/hydra-evaluator/hydra-evaluator.cc
+++ b/src/hydra-evaluator/hydra-evaluator.cc
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <thread>
 #include <cstring>
-#include <experimental/optional>
+#include <optional>
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -31,7 +31,7 @@ struct Evaluator
 
     typedef std::map<JobsetName, Jobset> Jobsets;
 
-    std::experimental::optional<JobsetName> evalOne;
+    std::optional<JobsetName> evalOne;
 
     const size_t maxEvals;
 

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -23,6 +23,7 @@ namespace nix {
 
 template<> void toJSON<std::atomic<long>>(std::ostream & str, const std::atomic<long> & n) { str << n; }
 template<> void toJSON<std::atomic<unsigned long>>(std::ostream & str, const std::atomic<unsigned long> & n) { str << n; }
+template<> void toJSON<std::atomic<unsigned long long>>(std::ostream & str, const std::atomic<unsigned long long> & n) { str << n; }
 template<> void toJSON<double>(std::ostream & str, const double & n) { str << n; }
 
 }

--- a/src/libhydra/db.hh
+++ b/src/libhydra/db.hh
@@ -23,7 +23,7 @@ struct Connection : pqxx::connection
 
 class receiver : public pqxx::notification_receiver
 {
-    std::experimental::optional<std::string> status;
+    std::optional<std::string> status;
 
 public:
 
@@ -35,9 +35,9 @@ public:
         status = payload;
     };
 
-    std::experimental::optional<std::string> get() {
+    std::optional<std::string> get() {
         auto s = status;
-        status = std::experimental::nullopt;
+        status = std::nullopt;
         return s;
     }
 };


### PR DESCRIPTION
Building on macOS with the latest nixpkgs master and NixOS/nixpkgs#77147
fails.  It seems some `std::experimental` (optional for instance) are
not available as `experimental`, but are in `std`.  Also `toJSON` is
missing for `atomic< unsigned long long >`.