### PR TITLE
Handle case where jobset has no defined errormsg for api/jobsets

### DIFF
--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -88,7 +88,7 @@ sub jobsetToHash {
         triggertime => $jobset->triggertime,
         fetcherrormsg => $jobset->fetcherrormsg,
         errortime => $jobset->errortime,
-        haserrormsg => defined($jobset->errormsg) ? ($jobset->errormsg eq "" ? JSON::false : JSON::true) : JSON::false
+        haserrormsg => defined($jobset->errormsg) && $jobset->errormsg ne "" ? JSON::true : JSON::false
     };
 }
 

--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -88,7 +88,7 @@ sub jobsetToHash {
         triggertime => $jobset->triggertime,
         fetcherrormsg => $jobset->fetcherrormsg,
         errortime => $jobset->errortime,
-        haserrormsg => $jobset->errormsg eq "" ? JSON::false : JSON::true
+        haserrormsg => defined($jobset->errormsg) ? ($jobset->errormsg eq "" ? JSON::false : JSON::true) : JSON::false
     };
 }
 


### PR DESCRIPTION
Fixes logged messages:

    {date} {hostname} hydra-server[PID]: Use of uninitialized value in string eq at /nix/store/.../libexec/hydra/lib/Hydra/Controller/API.pm line 79 <$read> line 383.
