### PR TITLE
hydra-queue-runner: sleep 5s after handling an exception

### DIFF
--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -218,6 +218,7 @@ void State::monitorMachinesFile()
             sleep(30);
         } catch (std::exception & e) {
             printMsg(lvlError, format("reloading machines file: %1%") % e.what());
+            sleep(5);
         }
     }
 }


### PR DESCRIPTION
In `monitorMachinesFile` sleep 5s after handling an exception instead of immediately calling `readMachinesFiles` again which could immediately throw another exception again.

