### PR TITLE
Fix printing aggregate status

### DIFF
--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -186,7 +186,7 @@ END;
                        IF b.finished && b.buildstatus != 0; nrFailedConstituents = nrFailedConstituents + 1; END;
                      END;
                 %];
-                  [%+ IF nrFinished == nrMembers && nrFailedConstituents == 0 %]
+                  [%+ IF nrFinished == nrConstituents && nrFailedConstituents == 0 %]
                     all [% nrConstituents %] constituent builds succeeded
                   [% ELSE %]
                     [% nrFailedConstituents %] out of [% nrConstituents %] constituent builds failed


### PR DESCRIPTION
`nrMembers` is undefined and it should have clearly be `nrConstituents` which is calculated just before.

Fixes #693.

CC @nmattia.