### PR TITLE
Remove the "log diff" buttons

### DIFF
--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -292,11 +292,9 @@ END;
             <th>Last successful build [% INCLUDE renderDateTime timestamp = prevSuccessfulBuild.timestamp %]</th>
             [% IF prevSuccessfulBuild && firstBrokenBuild && firstBrokenBuild.id != build.id %]
               <th>First broken build [% INCLUDE renderDateTime timestamp = firstBrokenBuild.timestamp %]
-                <a class="btn btn-mini" href="[% c.uri_for(c.controller('API').action_for('logdiff') prevSuccessfulBuild.id firstBrokenBuild.id ) %]">log diff</a>
               </th>
             [% END %]
             <th>This build [% INCLUDE renderDateTime timestamp = build.timestamp %]
-              <a class="btn btn-mini" href="[% c.uri_for(c.controller('API').action_for('logdiff') prevSuccessfulBuild.id build.id) %]">log diff</a>
             </th>
           </thead>
           <tr>


### PR DESCRIPTION
Remove the "log diff" buttons because they're referencing the removed `logdiff` API.

This API was removed in 4d1816b1529e4877f9527f039facbe9953c187bd.

Fixes #409.