### PR TITLE
sql: Generate models from postgresql

### DIFF
--- a/src/lib/Hydra/Schema/AggregateConstituents.pm
+++ b/src/lib/Hydra/Schema/AggregateConstituents.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<AggregateConstituents>
+=head1 TABLE: C<aggregateconstituents>
 
 =cut
 
-__PACKAGE__->table("AggregateConstituents");
+__PACKAGE__->table("aggregateconstituents");
 
 =head1 ACCESSORS
 
@@ -103,8 +103,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-08-15 00:20:01
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:TLNenyPLIWw2gWsOVhplZw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:bQfQoSstlaFy7zw8i1R+ow
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/BuildInputs.pm
+++ b/src/lib/Hydra/Schema/BuildInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<BuildInputs>
+=head1 TABLE: C<buildinputs>
 
 =cut
 
-__PACKAGE__->table("BuildInputs");
+__PACKAGE__->table("buildinputs");
 
 =head1 ACCESSORS
 
@@ -40,6 +40,7 @@ __PACKAGE__->table("BuildInputs");
   data_type: 'integer'
   is_auto_increment: 1
   is_nullable: 0
+  sequence: 'buildinputs_id_seq'
 
 =head2 build
 
@@ -98,7 +99,12 @@ __PACKAGE__->table("BuildInputs");
 
 __PACKAGE__->add_columns(
   "id",
-  { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "buildinputs_id_seq",
+  },
   "build",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "name",
@@ -176,8 +182,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-10-08 13:08:15
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OaJPzRM+8XGsu3eIkqeYEw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:/Fwb8emBsvwrZlEab2X+gQ
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/Schema/BuildMetrics.pm
+++ b/src/lib/Hydra/Schema/BuildMetrics.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<BuildMetrics>
+=head1 TABLE: C<buildmetrics>
 
 =cut
 
-__PACKAGE__->table("BuildMetrics");
+__PACKAGE__->table("buildmetrics");
 
 =head1 ACCESSORS
 
@@ -177,8 +177,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-07-30 16:52:20
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qoPm5/le+sVHigW4Dmum2Q
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Roy7h/K9u7DQOzet4B1sbA
 
 sub json_hint {
     return { columns => ['value', 'unit'] };

--- a/src/lib/Hydra/Schema/BuildOutputs.pm
+++ b/src/lib/Hydra/Schema/BuildOutputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<BuildOutputs>
+=head1 TABLE: C<buildoutputs>
 
 =cut
 
-__PACKAGE__->table("BuildOutputs");
+__PACKAGE__->table("buildoutputs");
 
 =head1 ACCESSORS
 
@@ -94,8 +94,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:V8MbzKvZNEaeHBJV67+ZMQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:71R9clwAP6vzDh10EukTaw
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/Schema/BuildProducts.pm
+++ b/src/lib/Hydra/Schema/BuildProducts.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<BuildProducts>
+=head1 TABLE: C<buildproducts>
 
 =cut
 
-__PACKAGE__->table("BuildProducts");
+__PACKAGE__->table("buildproducts");
 
 =head1 ACCESSORS
 
@@ -143,8 +143,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-04-13 14:49:33
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:kONECZn56f7sqfrLviiUOQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:iI0gmKqQxiPBTy5QsM6tpQ
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/Schema/BuildStepOutputs.pm
+++ b/src/lib/Hydra/Schema/BuildStepOutputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<BuildStepOutputs>
+=head1 TABLE: C<buildstepoutputs>
 
 =cut
 
-__PACKAGE__->table("BuildStepOutputs");
+__PACKAGE__->table("buildstepoutputs");
 
 =head1 ACCESSORS
 
@@ -119,8 +119,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:A/4v3ugXYbuYoKPlOvC6mg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Y6DpbTM6z4cOGoYIhD3i1A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/BuildSteps.pm
+++ b/src/lib/Hydra/Schema/BuildSteps.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<BuildSteps>
+=head1 TABLE: C<buildsteps>
 
 =cut
 
-__PACKAGE__->table("BuildSteps");
+__PACKAGE__->table("buildsteps");
 
 =head1 ACCESSORS
 
@@ -215,8 +215,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2016-12-07 13:48:19
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3FYkqSUfgWmiqZzmX8J4TA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:AMjHq4g/fSUv/lZuZOljYg
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/Schema/Builds.pm
+++ b/src/lib/Hydra/Schema/Builds.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<Builds>
+=head1 TABLE: C<builds>
 
 =cut
 
-__PACKAGE__->table("Builds");
+__PACKAGE__->table("builds");
 
 =head1 ACCESSORS
 
@@ -40,6 +40,7 @@ __PACKAGE__->table("Builds");
   data_type: 'integer'
   is_auto_increment: 1
   is_nullable: 0
+  sequence: 'builds_id_seq'
 
 =head2 finished
 
@@ -200,7 +201,12 @@ __PACKAGE__->table("Builds");
 
 __PACKAGE__->add_columns(
   "id",
-  { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "builds_id_seq",
+  },
   "finished",
   { data_type => "integer", is_nullable => 0 },
   "timestamp",
@@ -544,8 +550,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-19 16:12:37
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VjYbAQwv4THW2VfWQ5ajYQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:H3hs+zEywsUmwTWKfSE8wQ
 
 __PACKAGE__->has_many(
   "dependents",

--- a/src/lib/Hydra/Schema/CachedBazaarInputs.pm
+++ b/src/lib/Hydra/Schema/CachedBazaarInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<CachedBazaarInputs>
+=head1 TABLE: C<cachedbazaarinputs>
 
 =cut
 
-__PACKAGE__->table("CachedBazaarInputs");
+__PACKAGE__->table("cachedbazaarinputs");
 
 =head1 ACCESSORS
 
@@ -83,8 +83,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "revision");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zvun8uhxwrr7B8EsqBoCjA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:X8L4C57lMOctdqOKSmfA/g
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/CachedCVSInputs.pm
+++ b/src/lib/Hydra/Schema/CachedCVSInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<CachedCVSInputs>
+=head1 TABLE: C<cachedcvsinputs>
 
 =cut
 
-__PACKAGE__->table("CachedCVSInputs");
+__PACKAGE__->table("cachedcvsinputs");
 
 =head1 ACCESSORS
 
@@ -99,8 +99,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "module", "sha256hash");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Vi1qzjW52Lnsl0JSmGzy0w
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:6eQ+i/th+oVZNRiDPd2luA
 
 # You can replace this text with custom content, and it will be preserved on regeneration
 1;

--- a/src/lib/Hydra/Schema/CachedDarcsInputs.pm
+++ b/src/lib/Hydra/Schema/CachedDarcsInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<CachedDarcsInputs>
+=head1 TABLE: C<cacheddarcsinputs>
 
 =cut
 
-__PACKAGE__->table("CachedDarcsInputs");
+__PACKAGE__->table("cacheddarcsinputs");
 
 =head1 ACCESSORS
 
@@ -90,8 +90,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "revision");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-09-20 11:08:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Yl1slt3SAizijgu0KUTn0A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Buwq42sBXQVfYUy01WMyYw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/CachedGitInputs.pm
+++ b/src/lib/Hydra/Schema/CachedGitInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<CachedGitInputs>
+=head1 TABLE: C<cachedgitinputs>
 
 =cut
 
-__PACKAGE__->table("CachedGitInputs");
+__PACKAGE__->table("cachedgitinputs");
 
 =head1 ACCESSORS
 
@@ -92,7 +92,7 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "branch", "revision");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:I4hI02FKRMkw76WV/KBocA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0sdK9uQZpx869oqS5thRLw
 
 1;

--- a/src/lib/Hydra/Schema/CachedHgInputs.pm
+++ b/src/lib/Hydra/Schema/CachedHgInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<CachedHgInputs>
+=head1 TABLE: C<cachedhginputs>
 
 =cut
 
-__PACKAGE__->table("CachedHgInputs");
+__PACKAGE__->table("cachedhginputs");
 
 =head1 ACCESSORS
 
@@ -92,8 +92,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "branch", "revision");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qS/eiiZXmpc7KpTHdtaT7g
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:dYfjQ0SJG/mBrsZemAW3zw
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/CachedPathInputs.pm
+++ b/src/lib/Hydra/Schema/CachedPathInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<CachedPathInputs>
+=head1 TABLE: C<cachedpathinputs>
 
 =cut
 
-__PACKAGE__->table("CachedPathInputs");
+__PACKAGE__->table("cachedpathinputs");
 
 =head1 ACCESSORS
 
@@ -90,7 +90,7 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("srcpath", "sha256hash");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:28rja0vR1glJJ15hzVfjsQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:oV7tbWLNEMC8byKf9UnAlw
 
 1;

--- a/src/lib/Hydra/Schema/CachedSubversionInputs.pm
+++ b/src/lib/Hydra/Schema/CachedSubversionInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<CachedSubversionInputs>
+=head1 TABLE: C<cachedsubversioninputs>
 
 =cut
 
-__PACKAGE__->table("CachedSubversionInputs");
+__PACKAGE__->table("cachedsubversioninputs");
 
 =head1 ACCESSORS
 
@@ -83,7 +83,7 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("uri", "revision");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3qXfnvkOVj25W94bfhQ65w
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VGt/0HG84eNZr9OIA8jzow
 
 1;

--- a/src/lib/Hydra/Schema/FailedPaths.pm
+++ b/src/lib/Hydra/Schema/FailedPaths.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<FailedPaths>
+=head1 TABLE: C<failedpaths>
 
 =cut
 
-__PACKAGE__->table("FailedPaths");
+__PACKAGE__->table("failedpaths");
 
 =head1 ACCESSORS
 
@@ -57,8 +57,8 @@ __PACKAGE__->add_columns("path", { data_type => "text", is_nullable => 0 });
 __PACKAGE__->set_primary_key("path");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2015-06-10 14:48:16
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:WFgjfjH+szE6Ntcicmaflw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:jr3XiGO4lWAzqfATbsMwFw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/Jobs.pm
+++ b/src/lib/Hydra/Schema/Jobs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<Jobs>
+=head1 TABLE: C<jobs>
 
 =cut
 
-__PACKAGE__->table("Jobs");
+__PACKAGE__->table("jobs");
 
 =head1 ACCESSORS
 
@@ -169,7 +169,7 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-07-30 16:52:20
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:vDAo9bzLca+QWfhOb9OLMg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:sYa6dZNK+stMAnTH0Tmn8A
 
 1;

--- a/src/lib/Hydra/Schema/JobsetEvalInputs.pm
+++ b/src/lib/Hydra/Schema/JobsetEvalInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<JobsetEvalInputs>
+=head1 TABLE: C<jobsetevalinputs>
 
 =cut
 
-__PACKAGE__->table("JobsetEvalInputs");
+__PACKAGE__->table("jobsetevalinputs");
 
 =head1 ACCESSORS
 
@@ -166,8 +166,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1Dp8B58leBLh4GK0GPw2zg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:/cFQGBLhvpmBO1UJztgIAg
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/Schema/JobsetEvalMembers.pm
+++ b/src/lib/Hydra/Schema/JobsetEvalMembers.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<JobsetEvalMembers>
+=head1 TABLE: C<jobsetevalmembers>
 
 =cut
 
-__PACKAGE__->table("JobsetEvalMembers");
+__PACKAGE__->table("jobsetevalmembers");
 
 =head1 ACCESSORS
 
@@ -110,8 +110,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ccPNQe/QnSjTAC3uGWe8Ng
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:T+dJFh/sDO8WsasqYVLRSQ
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/JobsetEvals.pm
+++ b/src/lib/Hydra/Schema/JobsetEvals.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<JobsetEvals>
+=head1 TABLE: C<jobsetevals>
 
 =cut
 
-__PACKAGE__->table("JobsetEvals");
+__PACKAGE__->table("jobsetevals");
 
 =head1 ACCESSORS
 
@@ -40,6 +40,7 @@ __PACKAGE__->table("JobsetEvals");
   data_type: 'integer'
   is_auto_increment: 1
   is_nullable: 0
+  sequence: 'jobsetevals_id_seq'
 
 =head2 project
 
@@ -92,7 +93,12 @@ __PACKAGE__->table("JobsetEvals");
 
 __PACKAGE__->add_columns(
   "id",
-  { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "jobsetevals_id_seq",
+  },
   "project",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "jobset",
@@ -188,8 +194,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SlEiF8oN6FBK262uSiMKiw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4ZaT8Z1tmCCt6k4ein0MNg
 
 __PACKAGE__->has_many(
   "buildIds",

--- a/src/lib/Hydra/Schema/JobsetInputAlts.pm
+++ b/src/lib/Hydra/Schema/JobsetInputAlts.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<JobsetInputAlts>
+=head1 TABLE: C<jobsetinputalts>
 
 =cut
 
-__PACKAGE__->table("JobsetInputAlts");
+__PACKAGE__->table("jobsetinputalts");
 
 =head1 ACCESSORS
 
@@ -121,7 +121,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UUO37lIuEYm0GiR92m/fyA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:nh8dQDL9FtgzXcwjDufDMQ
 
 1;

--- a/src/lib/Hydra/Schema/JobsetInputs.pm
+++ b/src/lib/Hydra/Schema/JobsetInputs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<JobsetInputs>
+=head1 TABLE: C<jobsetinputs>
 
 =cut
 
-__PACKAGE__->table("JobsetInputs");
+__PACKAGE__->table("jobsetinputs");
 
 =head1 ACCESSORS
 
@@ -130,28 +130,9 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 jobsets
 
-Type: has_many
-
-Related object: L<Hydra::Schema::Jobsets>
-
-=cut
-
-__PACKAGE__->has_many(
-  "jobsets",
-  "Hydra::Schema::Jobsets",
-  {
-    "foreign.name"         => "self.jobset",
-    "foreign.nixexprinput" => "self.name",
-    "foreign.project"      => "self.project",
-  },
-  undef,
-);
-
-
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-10-08 13:06:15
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+mZZqLjQNwblb/EWW1alLQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5uKwEhDXso4IR1TFmwRxiA
 
 my %hint = (
     relations => {

--- a/src/lib/Hydra/Schema/JobsetRenames.pm
+++ b/src/lib/Hydra/Schema/JobsetRenames.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<JobsetRenames>
+=head1 TABLE: C<jobsetrenames>
 
 =cut
 
-__PACKAGE__->table("JobsetRenames");
+__PACKAGE__->table("jobsetrenames");
 
 =head1 ACCESSORS
 
@@ -110,8 +110,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2014-04-23 23:13:51
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SBpKWF9swFc9T1Uc0VFlgA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eOQbJ2O/p0G1317m3IC/KA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -27,18 +27,17 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<Jobsets>
+=head1 TABLE: C<jobsets>
 
 =cut
 
-__PACKAGE__->table("Jobsets");
+__PACKAGE__->table("jobsets");
 
 =head1 ACCESSORS
 
 =head2 name
 
   data_type: 'text'
-  is_foreign_key: 1
   is_nullable: 0
 
 =head2 project
@@ -55,7 +54,6 @@ __PACKAGE__->table("Jobsets");
 =head2 nixexprinput
 
   data_type: 'text'
-  is_foreign_key: 1
   is_nullable: 0
 
 =head2 nixexprpath
@@ -143,13 +141,13 @@ __PACKAGE__->table("Jobsets");
 
 __PACKAGE__->add_columns(
   "name",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  { data_type => "text", is_nullable => 0 },
   "project",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "description",
   { data_type => "text", is_nullable => 1 },
   "nixexprinput",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  { data_type => "text", is_nullable => 0 },
   "nixexprpath",
   { data_type => "text", is_nullable => 0 },
   "errormsg",
@@ -270,21 +268,6 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 jobsetinput
-
-Type: belongs_to
-
-Related object: L<Hydra::Schema::JobsetInputs>
-
-=cut
-
-__PACKAGE__->belongs_to(
-  "jobsetinput",
-  "Hydra::Schema::JobsetInputs",
-  { jobset => "name", name => "nixexprinput", project => "project" },
-  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
-);
-
 =head2 jobsetinputs
 
 Type: has_many
@@ -352,8 +335,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-09 13:03:05
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ivYvsUyhEeaeI4EmRQ0/QQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:fYKx6VRlNG5XiDZ73Qr6Rw
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/Schema/NewsItems.pm
+++ b/src/lib/Hydra/Schema/NewsItems.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<NewsItems>
+=head1 TABLE: C<newsitems>
 
 =cut
 
-__PACKAGE__->table("NewsItems");
+__PACKAGE__->table("newsitems");
 
 =head1 ACCESSORS
 
@@ -40,6 +40,7 @@ __PACKAGE__->table("NewsItems");
   data_type: 'integer'
   is_auto_increment: 1
   is_nullable: 0
+  sequence: 'newsitems_id_seq'
 
 =head2 contents
 
@@ -61,7 +62,12 @@ __PACKAGE__->table("NewsItems");
 
 __PACKAGE__->add_columns(
   "id",
-  { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "newsitems_id_seq",
+  },
   "contents",
   { data_type => "text", is_nullable => 0 },
   "createtime",
@@ -100,7 +106,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3CRNsvd+YnZp9c80tuZREQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:r6vX8VG/+NQraIVKFgHzxQ
 
 1;

--- a/src/lib/Hydra/Schema/NrBuilds.pm
+++ b/src/lib/Hydra/Schema/NrBuilds.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<NrBuilds>
+=head1 TABLE: C<nrbuilds>
 
 =cut
 
-__PACKAGE__->table("NrBuilds");
+__PACKAGE__->table("nrbuilds");
 
 =head1 ACCESSORS
 
@@ -67,8 +67,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("what");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-08-12 17:59:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CK8eJGC803nGj0wnete9xg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qv1I8Wu7KXHAs+pyBn2ofA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/ProjectMembers.pm
+++ b/src/lib/Hydra/Schema/ProjectMembers.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<ProjectMembers>
+=head1 TABLE: C<projectmembers>
 
 =cut
 
-__PACKAGE__->table("ProjectMembers");
+__PACKAGE__->table("projectmembers");
 
 =head1 ACCESSORS
 
@@ -103,8 +103,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:imPoiaitrTbX0vVNlF6dPA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:e/hYmoNmcEUoGhRqtwdyQw
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/Projects.pm
+++ b/src/lib/Hydra/Schema/Projects.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<Projects>
+=head1 TABLE: C<projects>
 
 =cut
 
-__PACKAGE__->table("Projects");
+__PACKAGE__->table("projects");
 
 =head1 ACCESSORS
 
@@ -303,8 +303,8 @@ Composing rels: L</projectmembers> -> username
 __PACKAGE__->many_to_many("usernames", "projectmembers", "username");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-03-11 10:39:17
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1ats3brIVhRTWLToIYSoaQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:pcF/8351zyo9VL6N5eimdQ
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/Schema/ReleaseMembers.pm
+++ b/src/lib/Hydra/Schema/ReleaseMembers.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<ReleaseMembers>
+=head1 TABLE: C<releasemembers>
 
 =cut
 
-__PACKAGE__->table("ReleaseMembers");
+__PACKAGE__->table("releasemembers");
 
 =head1 ACCESSORS
 
@@ -135,7 +135,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:7M7WPlGQT6rNHKJ+82/KSA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:k4z2YeB4gRAeAP6hmR93sQ
 
 1;

--- a/src/lib/Hydra/Schema/Releases.pm
+++ b/src/lib/Hydra/Schema/Releases.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<Releases>
+=head1 TABLE: C<releases>
 
 =cut
 
-__PACKAGE__->table("Releases");
+__PACKAGE__->table("releases");
 
 =head1 ACCESSORS
 
@@ -119,7 +119,7 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qISBiwvboB8dIdinaE45mg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:b4M/tHOhsy234tgTf+wqjQ
 
 1;

--- a/src/lib/Hydra/Schema/SchemaVersion.pm
+++ b/src/lib/Hydra/Schema/SchemaVersion.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<SchemaVersion>
+=head1 TABLE: C<schemaversion>
 
 =cut
 
-__PACKAGE__->table("SchemaVersion");
+__PACKAGE__->table("schemaversion");
 
 =head1 ACCESSORS
 
@@ -45,8 +45,8 @@ __PACKAGE__->table("SchemaVersion");
 __PACKAGE__->add_columns("version", { data_type => "integer", is_nullable => 0 });
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:08/7gbEQp1TqBiWFJXVY0w
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:2wy4FsRYVVo2RTCWXcmgvg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/StarredJobs.pm
+++ b/src/lib/Hydra/Schema/StarredJobs.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<StarredJobs>
+=head1 TABLE: C<starredjobs>
 
 =cut
 
-__PACKAGE__->table("StarredJobs");
+__PACKAGE__->table("starredjobs");
 
 =head1 ACCESSORS
 
@@ -153,8 +153,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-10-14 15:46:29
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:naj5aKWuw8hLE6klmvW9Eg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:fw4FfzmOhzDk0ZoSuNr2ww
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/SystemStatus.pm
+++ b/src/lib/Hydra/Schema/SystemStatus.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<SystemStatus>
+=head1 TABLE: C<systemstatus>
 
 =cut
 
-__PACKAGE__->table("SystemStatus");
+__PACKAGE__->table("systemstatus");
 
 =head1 ACCESSORS
 
@@ -67,8 +67,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("what");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-07-30 16:01:22
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:JCYi4+HwM22iucdFkhBjMg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:GeXpTVktMXjHENa/P3qOxw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/SystemTypes.pm
+++ b/src/lib/Hydra/Schema/SystemTypes.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<SystemTypes>
+=head1 TABLE: C<systemtypes>
 
 =cut
 
-__PACKAGE__->table("SystemTypes");
+__PACKAGE__->table("systemtypes");
 
 =head1 ACCESSORS
 
@@ -68,7 +68,7 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("system");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:8cC34cEw9T3+x+7uRs4KHQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:fYeKQQSS5J8rjO3t+Hbz0g
 
 1;

--- a/src/lib/Hydra/Schema/UriRevMapper.pm
+++ b/src/lib/Hydra/Schema/UriRevMapper.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<UriRevMapper>
+=head1 TABLE: C<urirevmapper>
 
 =cut
 
-__PACKAGE__->table("UriRevMapper");
+__PACKAGE__->table("urirevmapper");
 
 =head1 ACCESSORS
 
@@ -67,8 +67,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("baseuri");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:G2GAF/Rb7cRkRegH94LwIA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:FOg2/BVJK3yg8MAYMrqZOQ
 
 
 # You can replace this text with custom content, and it will be preserved on regeneration

--- a/src/lib/Hydra/Schema/UserRoles.pm
+++ b/src/lib/Hydra/Schema/UserRoles.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<UserRoles>
+=head1 TABLE: C<userroles>
 
 =cut
 
-__PACKAGE__->table("UserRoles");
+__PACKAGE__->table("userroles");
 
 =head1 ACCESSORS
 
@@ -87,7 +87,7 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-06-13 01:54:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aS+ivlFpndqIv8U578zz9A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:LUw2PDFvUHs0E0UZ3oHFxw
 
 1;

--- a/src/lib/Hydra/Schema/Users.pm
+++ b/src/lib/Hydra/Schema/Users.pm
@@ -27,11 +27,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Hydra::Component::ToJSON");
 
-=head1 TABLE: C<Users>
+=head1 TABLE: C<users>
 
 =cut
 
-__PACKAGE__->table("Users");
+__PACKAGE__->table("users");
 
 =head1 ACCESSORS
 
@@ -192,8 +192,8 @@ Composing rels: L</projectmembers> -> project
 __PACKAGE__->many_to_many("projects", "projectmembers", "project");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-05-27 11:32:14
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Az1+V+ztJoWUt50NLQR3xg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-02-06 12:22:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4/WZ95asbnGmK+nEHb4sLQ
 
 my %hint = (
     columns => [

--- a/src/sql/Makefile.am
+++ b/src/sql/Makefile.am
@@ -2,7 +2,6 @@ sqldir = $(libexecdir)/hydra/sql
 nobase_dist_sql_DATA =				\
   hydra-postgresql.sql				\
   hydra.sql					\
-  hydra-sqlite.sql				\
   test.sql					\
   upgrade-*.sql					\
   update-dbix.pl
@@ -10,10 +9,5 @@ nobase_dist_sql_DATA =				\
 hydra-postgresql.sql: hydra.sql
 	cpp -P -E -traditional-cpp -DPOSTGRESQL hydra.sql > $@ || rm -f $@
 
-hydra-sqlite.sql: hydra.sql
-	cpp -P -E -traditional-cpp -DSQLITE hydra.sql > $@ || rm -f $@
-
-update-dbix: hydra-sqlite.sql
-	rm -f tmp.sqlite
-	sqlite3 tmp.sqlite < hydra-sqlite.sql
-	perl -I ../lib -MDBIx::Class::Schema::Loader=make_schema_at,dump_to_dir:../lib update-dbix.pl
+update-dbix: hydra-postgresql.sql
+	./update-dbix-harness.sh

--- a/src/sql/update-dbix-harness.sh
+++ b/src/sql/update-dbix-harness.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+readonly scratch=$(mktemp -d -t tmp.XXXXXXXXXX)
+
+readonly socket=$scratch/socket
+readonly data=$scratch/data
+readonly dbname=hydra-update-dbix
+
+function finish {
+    set +e
+    pg_ctl -D "$data" \
+           -o "-F -h '' -k \"$socket\"" \
+           -w stop -m immediate
+
+    if [ -f "$data/postmaster.pid" ]; then
+        pg_ctl -D "$data" \
+               -o "-F -h '' -k \"$socket\"" \
+               -w kill TERM "$(cat "$data/postmaster.pid")"
+    fi
+
+    rm -rf "$scratch"
+}
+trap finish EXIT
+
+set -e
+
+mkdir -p "$socket"
+initdb -D "$data"
+
+pg_ctl -D "$data" \
+       -o "-F -h '' -k \"${socket}\"" \
+       -w start
+
+createdb -h "$socket" "$dbname"
+
+psql -h "$socket" "$dbname" -f ./hydra-postgresql.sql
+
+perl -I ../lib \
+     -MDBIx::Class::Schema::Loader=make_schema_at,dump_to_dir:../lib \
+     update-dbix.pl "dbi:Pg:dbname=$dbname;host=$socket"

--- a/src/sql/update-dbix.pl
+++ b/src/sql/update-dbix.pl
@@ -1,8 +1,49 @@
+use Cwd;
+
+die "$0: dbi connection string required \n" if scalar @ARGV != 1;
+
 make_schema_at("Hydra::Schema", {
     naming => { ALL => "v5" },
     relationships => 1,
-    moniker_map => sub { return "$_"; },
+    moniker_map => {
+        "aggregateconstituents" => "AggregateConstituents",
+            "buildinputs" => "BuildInputs",
+            "buildmetrics" => "BuildMetrics",
+            "buildoutputs" => "BuildOutputs",
+            "buildproducts" => "BuildProducts",
+            "builds" => "Builds",
+            "buildstepoutputs" => "BuildStepOutputs",
+            "buildsteps" => "BuildSteps",
+            "cachedbazaarinputs" => "CachedBazaarInputs",
+            "cachedcvsinputs" => "CachedCVSInputs",
+            "cacheddarcsinputs" => "CachedDarcsInputs",
+            "cachedgitinputs" => "CachedGitInputs",
+            "cachedhginputs" => "CachedHgInputs",
+            "cachedpathinputs" => "CachedPathInputs",
+            "cachedsubversioninputs" => "CachedSubversionInputs",
+            "failedpaths" => "FailedPaths",
+            "jobs" => "Jobs",
+            "jobsetevalinputs" => "JobsetEvalInputs",
+            "jobsetevalmembers" => "JobsetEvalMembers",
+            "jobsetevals" => "JobsetEvals",
+            "jobsetinputalts" => "JobsetInputAlts",
+            "jobsetinputs" => "JobsetInputs",
+            "jobsetrenames" => "JobsetRenames",
+            "jobsets" => "Jobsets",
+            "newsitems" => "NewsItems",
+            "nrbuilds" => "NrBuilds",
+            "projectmembers" => "ProjectMembers",
+            "projects" => "Projects",
+            "releasemembers" => "ReleaseMembers",
+            "releases" => "Releases",
+            "schemaversion" => "SchemaVersion",
+            "starredjobs" => "StarredJobs",
+            "systemstatus" => "SystemStatus",
+            "systemtypes" => "SystemTypes",
+            "urirevmapper" => "UriRevMapper",
+            "userroles" => "UserRoles",
+            "users" => "Users",
+    } , #sub { return "$_"; },
     components => [ "+Hydra::Component::ToJSON" ],
     rel_name_map => { buildsteps_builds => "buildsteps" }
-}, ["dbi:SQLite:tmp.sqlite"]);
-
+}, [$ARGV[0]]);


### PR DESCRIPTION
Lowercasing is due to postgresql not having case-sensitive table names.
It always technically workde before, but those table names never
existed literally.

The switch to generating from postgresql is to handle an upcoming
addition of an auto-incrementign ID to the Jobset table. Sqlite doesn't
seem to be able to handle the table having an auto incrementing ID
field which isn't the primary key, but we can't change the primary
key trivially.

Since hydra doesn't support sqlite and hasn't for many year anyway,
it is easier to just generate from pgsql directly.