### PR TITLE
Add the project name to declarative inputs

### DIFF
--- a/doc/manual/src/projects.md
+++ b/doc/manual/src/projects.md
@@ -435,7 +435,8 @@ evaluated will go through the steps above in reverse order:
 2.  Hydra will use the configuration given in the declarative spec file
     as the jobset configuration for this evaluation. In addition to any
     inputs specified in the spec file, hydra will also pass the
-    `declInput` argument corresponding to the input fetched in step 1.
+    `declInput` argument corresponding to the input fetched in step 1 and
+    the `projectName` argument containing the project\'s name.
 
 3.  As normal, hydra will build the jobs specified in the jobset
     repository, which in this case is the single `jobsets` job. When

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -565,7 +565,7 @@ sub checkJobsetWrapped {
     if ($jobsetsJobset) {
         my @declInputs = fetchInput($plugins, $db, $project, $jobset, "decl", $project->decltype, $project->declvalue, 0);
         my $declInput = @declInputs[0] or die "cannot find the input containing the declarative project specification\n";
-        die "multiple alternatives for the input containing the declarative project specificaiton are not supported\n"
+        die "multiple alternatives for the input containing the declarative project specification are not supported\n"
             if scalar @declInputs != 1;
         my $declFile = $declInput->{storePath} . "/" . $project->declfile;
         my $declText = read_file($declFile)
@@ -599,6 +599,8 @@ sub checkJobsetWrapped {
                 updateDeclarativeJobset($db, $project, ".jobsets", $declSpec);
                 $jobset->discard_changes;
                 $inputInfo->{"declInput"} = [ $declInput ];
+                $inputInfo ->{"projectName"} = [ { "value" => $project->name, } ];
+
             }
         } else {
             die "Declarative specification file $declFile is not a dictionary"


### PR DESCRIPTION
This allows for more generic declarative configurations which can be
shared between projects.