### PR TITLE
 hydra-evaluator: add a 'ONE_AT_A_TIME' evaluator style

### DIFF
--- a/src/lib/Hydra/Controller/Jobset.pm
+++ b/src/lib/Hydra/Controller/Jobset.pm
@@ -226,7 +226,7 @@ sub updateJobset {
     my ($nixExprPath, $nixExprInput) = nixExprPathFromParams $c;
 
     my $enabled = int($c->stash->{params}->{enabled});
-    die if $enabled < 0 || $enabled > 2;
+    die if $enabled < 0 || $enabled > 3;
 
     my $shares = int($c->stash->{params}->{schedulingshares} // 1);
     error($c, "The number of scheduling shares must be positive.") if $shares <= 0;

--- a/src/root/edit-jobset.tt
+++ b/src/root/edit-jobset.tt
@@ -68,6 +68,7 @@
           <input type="hidden" name="enabled" value="[% jobset.enabled %]" />
           <button type="button" class="btn" value="1">Enabled</button>
           <button type="button" class="btn" value="2">One-shot</button>
+          <button type="button" class="btn" value="3">One-at-a-time</button>
           <button type="button" class="btn" value="0">Disabled</button>
         </div>
       </div>

--- a/src/root/jobset.tt
+++ b/src/root/jobset.tt
@@ -129,7 +129,7 @@
     <table class="info-table">
       <tr>
         <th>State:</th>
-        <td>[% IF jobset.enabled == 0; "Disabled"; ELSIF jobset.enabled == 1; "Enabled"; ELSIF jobset.enabled == 2; "One-shot"; END %]</td>
+        <td>[% IF jobset.enabled == 0; "Disabled"; ELSIF jobset.enabled == 1; "Enabled"; ELSIF jobset.enabled == 2; "One-shot"; ELSIF jobset.enabled == 3; "One-at-a-time"; END %]</td>
       </tr>
       <tr>
         <th>Description:</th>

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -61,7 +61,7 @@ create table Jobsets (
     errorTime     integer, -- timestamp associated with errorMsg
     lastCheckedTime integer, -- last time the evaluator looked at this jobset
     triggerTime   integer, -- set if we were triggered by a push event
-    enabled       integer not null default 1, -- 0 = disabled, 1 = enabled, 2 = one-shot
+    enabled       integer not null default 1, -- 0 = disabled, 1 = enabled, 2 = one-shot, 3 = one-at-a-time
     enableEmail   integer not null default 1,
     hidden        integer not null default 0,
     emailOverride text not null,


### PR DESCRIPTION
In the past, jobsets which are automatically evaluated are evaluated
regularly, on a schedule. This schedule means a new evaluation is
created every checkInterval seconds (assuming something changed.)

This model works well for architectures where our build farm can
easily keep up with demand.

This commit adds a new type of evaluation, called ONE_AT_A_TIME, which
only schedules a new evaluation if the previous evaluation of the
jobset has no unfinished builds.

This model of evaluation lets us have 'low-tier' architectures.

For example, we could now have a jobset for ARMv7l builds, where
the buildfarm only has a single, underpowered ARMv7l builder.
Configuring that jobset as ONE_AT_A_TIME will create an evaluation
and then won't schedule another evaluation until every job of
the existing evaluation is complete.

This way, the cache will have a complete collection of pre-built
software for some commits, but the underpowered architecture will
never become backlogged in ancient revisions.