### PR TITLE
Fix declarative jobsets due to `nix` command being hidden

### DIFF
--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -193,7 +193,8 @@ sub checkPath {
 sub serveFile {
     my ($c, $path) = @_;
 
-    my $res = run(cmd => ["nix", "ls-store", "--store", getStoreUri(), "--json", "$path"]);
+    my $res = run(cmd => ["nix", "--experimental-features", "nix-command",
+                          "ls-store", "--store", getStoreUri(), "--json", "$path"]);
 
     if ($res->{status}) {
         notFound($c, "File '$path' does not exist.") if $res->{stderr} =~ /does not exist/;
@@ -217,7 +218,8 @@ sub serveFile {
 
     elsif ($ls->{type} eq "regular") {
 
-        $c->stash->{'plain'} = { data => grab(cmd => ["nix", "cat-store", "--store", getStoreUri(), "$path"]) };
+        $c->stash->{'plain'} = { data => grab(cmd => ["nix", "--experimental-features", "nix-command",
+                                                      "cat-store", "--store", getStoreUri(), "$path"]) };
 
         # Detect MIME type. Borrowed from Catalyst::Plugin::Static::Simple.
         my $type = "text/plain";

--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -68,8 +68,14 @@ sub handleDeclarativeJobsetBuild {
         my $id = $build->id;
         die "Declarative jobset build $id failed" unless $build->buildstatus == 0;
         my $declPath = ($build->buildoutputs)[0]->path;
-        my $declText = readNixFile($declPath)
-            or die "Couldn't read declarative specification file $declPath: $!";
+        my $declText = eval {
+            readNixFile($declPath)
+        };
+        if ($@) {
+            print STDERR "ERROR: failed to readNixFile $declPath: ", $@, "\n";
+            die;
+        }
+
         my $declSpec = decode_json($declText);
         txn_do($db, sub {
             my @kept = keys %$declSpec;

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -509,7 +509,8 @@ sub getStoreUri {
 # Read a file from the (possibly remote) nix store
 sub readNixFile {
     my ($path) = @_;
-    return grab(cmd => ["nix", "cat-store", "--store", getStoreUri(), "$path"]);
+    return grab(cmd => ["nix", "--experimental-features", "nix-command",
+                        "cat-store", "--store", getStoreUri(), "$path"]);
 }
 
 

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -82,7 +82,7 @@ sub getPath {
 
     my $substituter = $config->{eval_substituter};
 
-    system("nix", "copy", "--from", $substituter, "--", $path)
+    system("nix", "--experimental-features", "nix-command", "copy", "--from", $substituter, "--", $path)
         if defined $substituter;
 
     return isValidPath($path);


### PR DESCRIPTION
I briefly looked for a Nix-1 interface to do this, but readNixFile has always been implemented using nix cat-file.