### PR TITLE
 Abort unsupported build steps

### DIFF
--- a/src/hydra-queue-runner/dispatcher.cc
+++ b/src/hydra-queue-runner/dispatcher.cc
@@ -328,6 +328,8 @@ void State::abortUnsupported()
 
     std::unordered_set<Step::ptr> aborted;
 
+    size_t count = 0;
+
     for (auto & wstep : runnable2) {
         auto step(wstep.lock());
         if (!step) continue;
@@ -340,6 +342,9 @@ void State::abortUnsupported()
                 break;
             }
         }
+
+        if (!supported)
+            count++;
 
         if (!supported
             && std::chrono::duration_cast<std::chrono::seconds>(now - step->state.lock()->lastSupported).count() >= maxUnsupportedTime)
@@ -396,6 +401,8 @@ void State::abortUnsupported()
                 ++i;
         }
     }
+
+    nrUnsupportedSteps = count;
 }
 
 

--- a/src/hydra-queue-runner/dispatcher.cc
+++ b/src/hydra-queue-runner/dispatcher.cc
@@ -300,6 +300,8 @@ system_time State::doDispatch()
 
     } while (keepGoing);
 
+    abortUnsupported();
+
     return sleepUntil;
 }
 
@@ -311,6 +313,89 @@ void State::wakeDispatcher()
         *dispatcherWakeup_ = true;
     }
     dispatcherWakeupCV.notify_one();
+}
+
+
+void State::abortUnsupported()
+{
+    /* Make a copy of 'runnable' and 'machines' so we don't block them
+       very long. */
+    auto runnable2 = *runnable.lock();
+    auto machines2 = *machines.lock();
+
+    system_time now = std::chrono::system_clock::now();
+    auto now2 = time(0);
+
+    std::unordered_set<Step::ptr> aborted;
+
+    for (auto & wstep : runnable2) {
+        auto step(wstep.lock());
+        if (!step) continue;
+
+        bool supported = false;
+        for (auto & machine : machines2) {
+            if (machine.second->supportsStep(step)) {
+                step->state.lock()->lastSupported = now;
+                supported = true;
+                break;
+            }
+        }
+
+        if (!supported
+            && std::chrono::duration_cast<std::chrono::seconds>(now - step->state.lock()->lastSupported).count() >= maxUnsupportedTime)
+        {
+            printError("aborting unsupported build step '%s' (type '%s')",
+                localStore->printStorePath(step->drvPath),
+                step->systemType);
+
+            aborted.insert(step);
+
+            auto conn(dbPool.get());
+
+            std::set<Build::ptr> dependents;
+            std::set<Step::ptr> steps;
+            getDependents(step, dependents, steps);
+
+            /* Maybe the step got cancelled. */
+            if (dependents.empty()) continue;
+
+            /* Find the build that has this step as the top-level (if
+               any). */
+            Build::ptr build;
+            for (auto build2 : dependents) {
+                if (build2->drvPath == step->drvPath)
+                    build = build2;
+            }
+            if (!build) build = *dependents.begin();
+
+            bool stepFinished = false;
+            bool quit = false;
+
+            failStep(
+                *conn, step, build->id,
+                RemoteResult {
+                    .stepStatus = bsUnsupported,
+                    .errorMsg = fmt("unsupported system type '%s'",
+                        step->systemType),
+                    .startTime = now2,
+                    .stopTime = now2,
+                },
+                nullptr, stepFinished, quit);
+
+            if (quit) exit(1);
+        }
+    }
+
+    /* Clean up 'runnable'. */
+    {
+        auto runnable_(runnable.lock());
+        for (auto i = runnable_->begin(); i != runnable_->end(); ) {
+            if (aborted.count(i->lock()))
+                i = runnable_->erase(i);
+            else
+                ++i;
+        }
+    }
 }
 
 

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -523,6 +523,7 @@ void State::dumpStatus(Connection & conn, bool log)
         root.attr("nrStepsCopyingTo", nrStepsCopyingTo);
         root.attr("nrStepsCopyingFrom", nrStepsCopyingFrom);
         root.attr("nrStepsWaiting", nrStepsWaiting);
+        root.attr("nrUnsupportedSteps", nrUnsupportedSteps);
         root.attr("bytesSent", bytesSent);
         root.attr("bytesReceived", bytesReceived);
         root.attr("nrBuildsRead", nrBuildsRead);

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -46,6 +46,7 @@ std::string getEnvOrDie(const std::string & key)
 
 State::State()
     : config(std::make_unique<::Config>())
+    , maxUnsupportedTime(config->getIntOption("max_unsupported_time", 0))
     , dbPool(config->getIntOption("max_db_connections", 128))
     , memoryTokens(config->getIntOption("nar_buffer_size", getMemSize() / 2))
     , maxOutputSize(config->getIntOption("max_output_size", 2ULL << 30))

--- a/src/hydra-queue-runner/state.hh
+++ b/src/hydra-queue-runner/state.hh
@@ -355,6 +355,7 @@ private:
     counter nrStepsCopyingTo{0};
     counter nrStepsCopyingFrom{0};
     counter nrStepsWaiting{0};
+    counter nrUnsupportedSteps{0};
     counter nrRetries{0};
     counter maxNrRetries{0};
     counter totalStepTime{0}; // total time for steps, including closure copying

--- a/src/hydra-queue-runner/state.hh
+++ b/src/hydra-queue-runner/state.hh
@@ -420,9 +420,6 @@ private:
     size_t maxOutputSize;
     size_t maxLogSize;
 
-    time_t lastStatusLogged = 0;
-    const int statusLogInterval = 300;
-
     /* Steps that were busy while we encounted a PostgreSQL
        error. These need to be cleared at a later time to prevent them
        from showing up as busy until the queue runner is restarted. */
@@ -546,7 +543,7 @@ private:
        has it. */
     std::shared_ptr<nix::PathLocks> acquireGlobalLock();
 
-    void dumpStatus(Connection & conn, bool log);
+    void dumpStatus(Connection & conn);
 
     void addRoot(const nix::StorePath & storePath);
 

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -584,10 +584,10 @@ BLOCK renderJobsetOverview %]
         <td><span class="[% IF !j.enabled %]disabled-jobset[% END %] [%+ IF j.hidden %]hidden-jobset[% END %]">[% IF showProject; INCLUDE renderFullJobsetName project=j.get_column('project') jobset=j.name inRow=1; ELSE; INCLUDE renderJobsetName project=j.get_column('project') jobset=j.name inRow=1; END %]</span></td>
         <td>[% HTML.escape(j.description) %]</td>
         <td>[% IF j.lastcheckedtime;
-	         INCLUDE renderDateTime timestamp = j.lastcheckedtime;
-		 IF j.errormsg || j.fetcherrormsg; %]&nbsp;<span class = 'label label-warning'>Error</span>[% END;
-		 ELSE; "-";
-	       END %]</td>
+                 INCLUDE renderDateTime timestamp = j.lastcheckedtime;
+                 IF j.errormsg || j.fetcherrormsg; %]&nbsp;<span class = 'label label-warning'>Error</span>[% END;
+                 ELSE; "-";
+               END %]</td>
         [% IF j.get_column('nrtotal') > 0 %]
           [% successrate = ( j.get_column('nrsucceeded') / j.get_column('nrtotal') )*100 %]
           [% IF j.get_column('nrscheduled') > 0 %]

--- a/src/script/hydra-send-stats
+++ b/src/script/hydra-send-stats
@@ -34,6 +34,7 @@ sub sendQueueRunnerStats {
     gauge("hydra.queue.steps.unfinished", $json->{nrUnfinishedSteps});
     gauge("hydra.queue.steps.finished", $json->{nrStepsDone});
     gauge("hydra.queue.steps.retries", $json->{nrRetries});
+    gauge("hydra.queue.steps.unsupported", $json->{nrUnsupportedSteps});
     gauge("hydra.queue.steps.max_retries", $json->{maxNrRetries});
     if ($json->{nrStepsDone}) {
         gauge("hydra.queue.steps.avg_total_time", $json->{avgStepTime});


### PR DESCRIPTION
If we don't see machine that supports a build step for `max_unsupported_time` seconds, the step is aborted. The default is 0, which is appropriate for Hydra installations that don't provision missing machines dynamically.