### PR TITLE
hydra-eval-jobs: Mirror eval errors in STDERR

### DIFF
--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -200,7 +200,12 @@ static void worker(
             else throw TypeError("attribute '%s' is %s, which is not supported", attrPath, showType(*v));
 
         } catch (EvalError & e) {
+            // Transmits the error we got from the previous evaluation
+            // in the JSON output.
             reply["error"] = filterANSIEscapes(e.msg(), true);
+            // Don't forget to print it into the STDERR log, this is
+            // what's shown in the Hydra UI.
+            printError("error: %s", reply["error"]);
         }
 
         writeLine(to.get(), reply.dump());
@@ -286,6 +291,9 @@ int main(int argc, char * * argv)
                                     nlohmann::json err;
                                     err["error"] = e.what();
                                     writeLine(to->get(), err.dump());
+                                    // Don't forget to print it into the STDERR log, this is
+                                    // what's shown in the Hydra UI.
+                                    printError("error: %s", err["error"]);
                                 }
                             },
                             ProcessOptions { .allowVfork = false });


### PR DESCRIPTION
Otherwise, errors will not be shown to end-users, which makes debugging
long evals pretty much impossible.

Fixes #728

* * *

**Note**: I'm still testing this change, but want to make it public ASAP so I can be told what I did wrong (and why).