### PR TITLE
Fix build against nix master

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,5 @@
 { hydraSrc ? builtins.fetchGit ./.
-, nixpkgs ? builtins.fetchTarball https://github.com/NixOS/nixpkgs/archive/release-19.09.tar.gz
+, nixpkgs ? builtins.fetchTarball https://github.com/NixOS/nixpkgs/archive/release-20.03.tar.gz
 , officialRelease ? false
 , shell ? false
 }:
@@ -63,7 +63,7 @@ rec {
 
       perlDeps = buildEnv {
         name = "hydra-perl-deps";
-        paths = with perlPackages;
+        paths = with perlPackages; lib.closePropagation
           [ ModulePluggable
             CatalystActionREST
             CatalystAuthenticationStoreDBIxClass
@@ -132,7 +132,7 @@ rec {
           perlDeps perl nix
           postgresql95 # for running the tests
           boost
-          (nlohmann_json.override { multipleHeaders = true; })
+          nlohmann_json
         ];
 
       hydraPath = lib.makeBinPath (

--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -109,7 +109,7 @@ static void worker(
         nlohmann::json reply;
 
         try {
-            auto vTmp = findAlongAttrPath(state, attrPath, autoArgs, *vRoot);
+            auto vTmp = findAlongAttrPath(state, attrPath, autoArgs, *vRoot).first;
 
             auto v = state.allocValue();
             state.autoCallFunction(autoArgs, *vTmp, *v);
@@ -139,23 +139,23 @@ static void worker(
 
                 /* If this is an aggregate, then get its constituents. */
                 auto a = v->attrs->get(state.symbols.create("_hydraAggregate"));
-                if (a && state.forceBool(*(*a)->value, *(*a)->pos)) {
+                if (a && state.forceBool(*a->value, *a->pos)) {
                     auto a = v->attrs->get(state.symbols.create("constituents"));
                     if (!a)
                         throw EvalError("derivation must have a ‘constituents’ attribute");
 
 
                     PathSet context;
-                    state.coerceToString(*(*a)->pos, *(*a)->value, context, true, false);
+                    state.coerceToString(*a->pos, *a->value, context, true, false);
                     for (auto & i : context)
                         if (i.at(0) == '!') {
                             size_t index = i.find("!", 1);
                             job["constituents"].push_back(string(i, index + 1));
                         }
 
-                    state.forceList(*(*a)->value, *(*a)->pos);
-                    for (unsigned int n = 0; n < (*a)->value->listSize(); ++n) {
-                        auto v = (*a)->value->listElems()[n];
+                    state.forceList(*a->value, *a->pos);
+                    for (unsigned int n = 0; n < a->value->listSize(); ++n) {
+                        auto v = a->value->listElems()[n];
                         state.forceValue(*v);
                         if (v->type == tString)
                             job["namedConstituents"].push_back(state.forceStringNoCtx(*v));

--- a/src/hydra-queue-runner/builder.cc
+++ b/src/hydra-queue-runner/builder.cc
@@ -466,7 +466,7 @@ void State::failStep(
             /* Remember failed paths in the database so that they
                won't be built again. */
             if (result.stepStatus != bsCachedFailure && result.canCache)
-                for (auto & path : step->drv.outputPaths())
+                for (auto & path : step->drv->outputPaths())
                     txn.exec_params0("insert into FailedPaths values ($1)", localStore->printStorePath(path));
 
             txn.commit();

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -258,7 +258,7 @@ unsigned int State::createBuildStep(pqxx::work & txn, time_t startTime, BuildID 
          localStore->printStorePath(step->drvPath),
          status == bsBusy ? 1 : 0,
          startTime != 0 ? std::make_optional(startTime) : std::nullopt,
-         step->drv.platform,
+         step->drv->platform,
          status != bsBusy ? std::make_optional((int) status) : std::nullopt,
          propagatedFrom != 0 ? std::make_optional(propagatedFrom) : std::nullopt, // internal::params
          errorMsg != "" ? std::make_optional(errorMsg) : std::nullopt,
@@ -267,7 +267,7 @@ unsigned int State::createBuildStep(pqxx::work & txn, time_t startTime, BuildID 
 
     if (r.affected_rows() == 0) goto restart;
 
-    for (auto & output : step->drv.outputs)
+    for (auto & output : step->drv->outputs)
         txn.exec_params0
             ("insert into BuildStepOutputs (build, stepnr, name, path) values ($1, $2, $3, $4)",
              buildId, stepNr, output.first, localStore->printStorePath(output.second.path));
@@ -452,7 +452,7 @@ void State::markSucceededBuild(pqxx::work & txn, Build::ptr build,
 bool State::checkCachedFailure(Step::ptr step, Connection & conn)
 {
     pqxx::work txn(conn);
-    for (auto & path : step->drv.outputPaths())
+    for (auto & path : step->drv->outputPaths())
         if (!txn.exec_params("select 1 from FailedPaths where path = $1", localStore->printStorePath(path)).empty())
             return true;
     return false;

--- a/src/hydra-queue-runner/queue-monitor.cc
+++ b/src/hydra-queue-runner/queue-monitor.cc
@@ -172,11 +172,11 @@ bool State::getQueuedBuilds(Connection & conn,
 
                 auto res = txn.exec_params1
                     ("select max(build) from BuildSteps where drvPath = $1 and startTime != 0 and stopTime != 0 and status = 1",
-                     localStore->printStorePathh(ex.step->drvPath));
+                     localStore->printStorePath(ex.step->drvPath));
                 if (!res[0].is_null()) propagatedFrom = res[0].as<BuildID>();
 
                 if (!propagatedFrom) {
-                    for (auto & output : ex.step->drv.outputs) {
+                    for (auto & output : ex.step->drv->outputs) {
                         auto res = txn.exec_params
                             ("select max(s.build) from BuildSteps s join BuildStepOutputs o on s.build = o.build where path = $1 and startTime != 0 and stopTime != 0 and status = 1",
                              localStore->printStorePath(output.second.path));


### PR DESCRIPTION
The current Hydra master was broken when building against
`pkgs.nixUnstable` from NixOS 20.03 (5e7ccdc9).

Please note that the nix-shell breaks due to the switch to 20.03 with
the following error:

    bash: src: unbound variable
    build time elapsed:  0m2.172s 0m0.261s 0m0.089s 0m0.026s
    bash: succeedOnFailure: unbound variable

---

`nix-build release.nix -A build` is building.
cc @edolstra @kquick 