### PR TITLE
Separate the build IDs in the build_finished payload with tabs

### DIFF
--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -468,9 +468,9 @@ void State::notifyBuildStarted(pqxx::work & txn, BuildID buildId)
 void State::notifyBuildFinished(pqxx::work & txn, BuildID buildId,
     const std::vector<BuildID> & dependentIds)
 {
-    auto payload = fmt("%d ", buildId);
+    auto payload = fmt("%d", buildId);
     for (auto & d : dependentIds)
-        payload += fmt("%d ", d);
+        payload += fmt("\t%d", d);
     // FIXME: apparently parameterized() doesn't support NOTIFY.
     txn.exec(fmt("notify build_finished, '%s'", payload));
 }


### PR DESCRIPTION
`hydra-notify` [splits the payload on tabs](https://github.com/NixOS/hydra/blob/4cabb37ebdeade1435ad8ebf1913cdd603b9c452/src/script/hydra-notify#L105) so we shouldn't separate the IDs with spaces.