### PR TITLE
GitInput: add merge-base support

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -283,6 +283,7 @@ sub buildInputToString {
         (defined $input->{version} ? "; version = \"" . $input->{version} . "\"" : "") .
         (defined $input->{outputName} ? "; outputName = \"" . $input->{outputName} . "\"" : "") .
         (defined $input->{drvPath} ? "; drvPath = builtins.storePath " . $input->{drvPath} . "" : "") .
+        (defined $input->{mergeBase} ? "; mergeBase = " . buildInputToString($input->{mergeBase}) . "" : "") .
         ";}";
 }
 
@@ -319,6 +320,11 @@ sub inputsToArgs {
             push @res, "--arg", $input, $s;
         }
         else {
+            # If defined, add the mergeBase input to the NIX_PATH
+            # otherwise it can't be imported in restricted eval mode.
+            push @res, "-I", "$input.mergeBase=$alt->{mergeBase}->{storePath}"
+                if (defined $alt->{mergeBase});
+
             push @res, "--arg", $input, buildInputToString($alt);
         }
     }


### PR DESCRIPTION
We have been using the following feature since a month at work and it's working well:

This allows fetching the merge-base revision between the specified branch and the specified base branch. This is useful for defining jobs that perform comparisons between the base and the PR.

To enable this specify the `base` option and point it to the base branch of the PR. For example:

```
git@github.com:me/my-repo.git my-pr-branch base=master
```

The plugin will calculate the merge-base revision between `my-pr-branch` and `master`, `nix-prefetch-git` that revision and make it available in the output under the `mergeBase` attribute like:

```
{
  outPath = builtins.storePath /nix/store/...-source;
  inputType = "git";
  uri = "git@github.com:me/my-repo.git";
  rev = "<revision of the PR branch>";
  revCount = ...;
  gitTag = "...";
  shortRev = "...";
  mergeBase = {
    outPath = builtins.storePath /nix/store/...-source;
    inputType = "git";
    uri = "git@github.com:me/my-repo.git";
    rev = "<revision of the merge-base of the PR branch and master>";
    revCount = ...;
    gitTag = "...";
    shortRev = "...";
  };
}
```