### PR TITLE
Get rid of dependency to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Makefile.in
 hydra-config.h
 hydra-config.h.in
 result
+tests/jobs/config.nix

--- a/doc/dev-notes.txt
+++ b/doc/dev-notes.txt
@@ -8,22 +8,23 @@
 
 * Setting the maximum number of concurrent builds per system type:
 
-  $ sqlite3 hydra.sqlite "insert into SystemTypes(system, maxConcurrent) values('i686-linux', 3);"
+  $ psql -d hydra <<< "insert into SystemTypes(system, maxConcurrent) values('i686-linux', 3);"
 
 * Creating a user:
 
-  $ sqlite3 hydra.sqlite "insert into Users(userName, emailAddress, password) values('root', 'e.dolstra@tudelft.nl', '$(echo -n foobar | sha1sum | cut -c1-40)');"
+  $ hydra-create-user root --email-address 'e.dolstra@tudelft.nl' \
+      --password-hash "$(echo -n foobar | sha1sum | cut -c1-40)"
 
   (Replace "foobar" with the desired password.)
 
   To make the user an admin:
 
-  $ sqlite3 hydra.sqlite "insert into UserRoles(userName, role) values('root', 'admin');"
+  $ hydra-create-user root --role admin
 
   To enable a non-admin user to create projects:
-  
-  $ sqlite3 hydra.sqlite "insert into UserRoles(userName, role) values('alice', 'create-projects');"
-  
+
+  $ hydra-create-user root --role create-projects
+
 * Creating a release set:
 
   insert into ReleaseSets(project, name) values('patchelf', 'unstable');

--- a/doc/manual/projects.xml
+++ b/doc/manual/projects.xml
@@ -43,16 +43,11 @@ Identifier: patchelf
       The identifier should be a unique name (it is the primary
       database key for the project table in the database). If you try
       to create a project with an already existing identifier you'd
-      get an error message such as:
+      get an error message from the database.
 
-<screen>
-I'm very sorry, but an error occurred:
-DBIx::Class::ResultSet::create(): DBI Exception: DBD::SQLite::st execute failed: column name is not unique(19) at dbdimp.c line 402
-</screen>
-
-       So try to create the project after entering just the general
-       information to figure out if you have chosen a unique name.
-       Job sets can be added once the project has been created.
+      So try to create the project after entering just the general
+      information to figure out if you have chosen a unique name.
+      Job sets can be added once the project has been created.
 
 <screen>
 Display name: Patchelf

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
                 CatalystXRoleApplicator
                 CryptRandPasswd
                 DBDPg
+                DBDSQLite
                 DataDump
                 DateTime
                 DigestSHA1

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,6 @@
                 CatalystXRoleApplicator
                 CryptRandPasswd
                 DBDPg
-                DBDSQLite
                 DataDump
                 DateTime
                 DigestSHA1
@@ -103,7 +102,7 @@
           src = self;
 
           buildInputs =
-            [ makeWrapper autoconf automake libtool unzip nukeReferences pkgconfig sqlite libpqxx
+            [ makeWrapper autoconf automake libtool unzip nukeReferences pkgconfig libpqxx
               gitAndTools.topGit mercurial darcs subversion bazaar openssl bzip2 libxslt
               perlDeps perl final.nix
               postgresql95 # for running the tests
@@ -114,7 +113,7 @@
             ];
 
           hydraPath = lib.makeBinPath (
-            [ sqlite subversion openssh final.nix coreutils findutils pixz
+            [ subversion openssh final.nix coreutils findutils pixz
               gzip bzip2 lzma gnutar unzip git gitAndTools.topGit mercurial darcs gnused bazaar
             ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
 

--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -214,7 +214,7 @@ sub scmdiff : Path('/api/scmdiff') Args(0) {
 sub triggerJobset {
     my ($self, $c, $jobset, $force) = @_;
     print STDERR "triggering jobset ", $jobset->get_column('project') . ":" . $jobset->name, "\n";
-    txn_do($c->model('DB')->schema, sub {
+    $c->model('DB')->schema->txn_do(sub {
         $jobset->update({ triggertime => time });
         $jobset->update({ forceeval => 1 }) if $force;
     });

--- a/src/lib/Hydra/Controller/Admin.pm
+++ b/src/lib/Hydra/Controller/Admin.pm
@@ -90,7 +90,7 @@ sub news_submit : Chained('admin') PathPart('news/submit') Args(0) {
 sub news_delete : Chained('admin') PathPart('news/delete') Args(1) {
     my ($self, $c, $id) = @_;
 
-    txn_do($c->model('DB')->schema, sub {
+    $c->model('DB')->schema->txn_do(sub {
         my $newsItem = $c->model('DB::NewsItems')->find($id)
           or notFound($c, "Newsitem with id $id doesn't exist.");
         $newsItem->delete;

--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -526,7 +526,7 @@ sub keep : Chained('buildChain') PathPart Args(1) {
         registerRoot $_->path foreach $build->buildoutputs;
     }
 
-    txn_do($c->model('DB')->schema, sub {
+    $c->model('DB')->schema->txn_do(sub {
         $build->update({keep => $keep});
     });
 

--- a/src/lib/Hydra/Controller/Jobset.pm
+++ b/src/lib/Hydra/Controller/Jobset.pm
@@ -62,7 +62,7 @@ sub jobset_PUT {
     }
 
     if (defined $c->stash->{jobset}) {
-        txn_do($c->model('DB')->schema, sub {
+        $c->model('DB')->schema->txn_do(sub {
             updateJobset($c, $c->stash->{jobset});
         });
 
@@ -74,7 +74,7 @@ sub jobset_PUT {
 
     else {
         my $jobset;
-        txn_do($c->model('DB')->schema, sub {
+        $c->model('DB')->schema->txn_do(sub {
             # Note: $jobsetName is validated in updateProject, which will
             # abort the transaction if the name isn't valid.
             $jobset = $c->stash->{project}->jobsets->create(
@@ -100,7 +100,7 @@ sub jobset_DELETE {
         error($c, "can't modify jobset of declarative project", 403);
     }
 
-    txn_do($c->model('DB')->schema, sub {
+    $c->model('DB')->schema->txn_do(sub {
         $c->stash->{jobset}->jobsetevals->delete;
         $c->stash->{jobset}->builds->delete;
         $c->stash->{jobset}->delete;

--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -146,7 +146,7 @@ sub release : Chained('evalChain') PathPart('release') Args(0) {
 
     my $release;
 
-    txn_do($c->model('DB')->schema, sub {
+    $c->model('DB')->schema->txn_do(sub {
 
         $release = $c->stash->{project}->releases->create(
             { name => $releaseName

--- a/src/lib/Hydra/Controller/Project.pm
+++ b/src/lib/Hydra/Controller/Project.pm
@@ -41,7 +41,7 @@ sub project_PUT {
     if (defined $c->stash->{project}) {
         requireProjectOwner($c, $c->stash->{project});
 
-        txn_do($c->model('DB')->schema, sub {
+        $c->model('DB')->schema->txn_do(sub {
             updateProject($c, $c->stash->{project});
         });
 
@@ -55,7 +55,7 @@ sub project_PUT {
         requireMayCreateProjects($c);
 
         my $project;
-        txn_do($c->model('DB')->schema, sub {
+        $c->model('DB')->schema->txn_do(sub {
             # Note: $projectName is validated in updateProject,
             # which will abort the transaction if the name isn't
             # valid.  Idem for the owner.
@@ -77,7 +77,7 @@ sub project_DELETE {
 
     requireProjectOwner($c, $c->stash->{project});
 
-    txn_do($c->model('DB')->schema, sub {
+    $c->model('DB')->schema->txn_do(sub {
         $c->stash->{project}->jobsetevals->delete;
         $c->stash->{project}->builds->delete;
         $c->stash->{project}->delete;
@@ -198,7 +198,7 @@ sub create_release_submit : Chained('projectChain') PathPart('create-release/sub
     my $releaseName = $c->request->params->{name};
 
     my $release;
-    txn_do($c->model('DB')->schema, sub {
+    $c->model('DB')->schema->txn_do(sub {
         # Note: $releaseName is validated in updateRelease, which will
         # abort the transaction if the name isn't valid.
         $release = $c->stash->{project}->releases->create(

--- a/src/lib/Hydra/Controller/Release.pm
+++ b/src/lib/Hydra/Controller/Release.pm
@@ -63,13 +63,13 @@ sub submit : Chained('release') PathPart('submit') Args(0) {
     requireProjectOwner($c, $c->stash->{project});
 
     if (($c->request->params->{action} || "") eq "delete") {
-        txn_do($c->model('DB')->schema, sub {
+        $c->model('DB')->schema->txn_do(sub {
             $c->stash->{release}->delete;
         });
         $c->res->redirect($c->uri_for($c->controller('Project')->action_for('project'),
             [$c->stash->{project}->name]));
     } else {
-        txn_do($c->model('DB')->schema, sub {
+        $c->model('DB')->schema->txn_do(sub {
             updateRelease($c, $c->stash->{release});
         });
         $c->res->redirect($c->uri_for($self->action_for("view"),

--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -163,7 +163,7 @@ sub register :Local Args(0) {
     error($c, "Your user name is already taken.")
         if $c->find_user({ username => $userName });
 
-    txn_do($c->model('DB')->schema, sub {
+    $c->model('DB')->schema->txn_do(sub {
         my $user = $c->model('DB::Users')->create(
             { username => $userName
             , password => "!"
@@ -261,7 +261,7 @@ sub edit_PUT {
         return;
     }
 
-    txn_do($c->model('DB')->schema, sub {
+    $c->model('Db')->schema->txn_do(sub {
         updatePreferences($c, $user);
     });
 

--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -46,7 +46,7 @@ sub updateDeclarativeJobset {
         $update{$key} = $declSpec->{$key};
         delete $declSpec->{$key};
     }
-    txn_do($db, sub {
+    $db->txn_do(sub {
         my $jobset = $project->jobsets->update_or_create(\%update);
         $jobset->jobsetinputs->delete;
         while ((my $name, my $data) = each %{$declSpec->{"inputs"}}) {
@@ -79,7 +79,7 @@ sub handleDeclarativeJobsetBuild {
         }
 
         my $declSpec = decode_json($declText);
-        txn_do($db, sub {
+        $db->txn_do(sub {
             my @kept = keys %$declSpec;
             push @kept, ".jobsets";
             $project->jobsets->search({ name => { "not in" => \@kept } })->update({ enabled => 0, hidden => 1 });

--- a/src/lib/Hydra/Model/DB.pm
+++ b/src/lib/Hydra/Model/DB.pm
@@ -10,11 +10,7 @@ sub getHydraPath {
 }
 
 sub getHydraDBPath {
-    my $db = $ENV{"HYDRA_DBI"};
-    return $db if defined $db;
-    my $path = getHydraPath . '/hydra.sqlite';
-    #warn "The Hydra database ($path) does not exist!\n" unless -f $path;
-    return "dbi:SQLite:$path";
+    return $ENV{"HYDRA_DBI"} || "dbi:Pg:dbname=hydra;";
 }
 
 __PACKAGE__->config(

--- a/src/lib/Hydra/Plugin/BazaarInput.pm
+++ b/src/lib/Hydra/Plugin/BazaarInput.pm
@@ -58,7 +58,7 @@ sub fetchInput {
         # FIXME: time window between nix-prefetch-bzr and addTempRoot.
         addTempRoot($storePath);
 
-        txn_do($self->{db}, sub {
+        $self->{db}->txn_do(sub {
             $self->{db}->resultset('CachedBazaarInputs')->create(
                 { uri => $uri
                 , revision => $revision

--- a/src/lib/Hydra/Plugin/DarcsInput.pm
+++ b/src/lib/Hydra/Plugin/DarcsInput.pm
@@ -77,7 +77,7 @@ sub fetchInput {
         $sha256 = queryPathHash($storePath);
         $sha256 =~ s/sha256://;
 
-        txn_do($self->{db}, sub {
+        $self->{db}->txn_do(sub {
             $self->{db}->resultset('CachedDarcsInputs')->update_or_create(
                 { uri => $uri
                 , revision => $revision

--- a/src/lib/Hydra/Plugin/GitInput.pm
+++ b/src/lib/Hydra/Plugin/GitInput.pm
@@ -218,7 +218,7 @@ sub fetchInput {
         # FIXME: time window between nix-prefetch-git and addTempRoot.
         addTempRoot($storePath);
 
-        txn_do($self->{db}, sub {
+        $self->{db}->txn_do(sub {
             $self->{db}->resultset('CachedGitInputs')->update_or_create(
                 { uri => $uri
                 , branch => $branch

--- a/src/lib/Hydra/Plugin/MercurialInput.pm
+++ b/src/lib/Hydra/Plugin/MercurialInput.pm
@@ -85,7 +85,7 @@ sub fetchInput {
         # FIXME: time window between nix-prefetch-hg and addTempRoot.
         addTempRoot($storePath);
 
-        txn_do($self->{db}, sub {
+        $self->{db}->txn_do(sub {
             $self->{db}->resultset('CachedHgInputs')->update_or_create(
                 { uri => $uri
                 , branch => $branch

--- a/src/lib/Hydra/Plugin/PathInput.pm
+++ b/src/lib/Hydra/Plugin/PathInput.pm
@@ -54,7 +54,7 @@ sub fetchInput {
         # changes, we get a new "revision", but if it doesn't change
         # (or changes back), we don't get a new "revision".
         if (!defined $cachedInput) {
-            txn_do($self->{db}, sub {
+            $self->{db}->txn_do(sub {
                 $self->{db}->resultset('CachedPathInputs')->update_or_create(
                     { srcpath => $uri
                     , timestamp => $timestamp
@@ -65,7 +65,7 @@ sub fetchInput {
                 });
         } else {
             $timestamp = $cachedInput->timestamp;
-            txn_do($self->{db}, sub {
+            $self->{db}->txn_do(sub {
                 $cachedInput->update({lastseen => time});
             });
         }

--- a/src/lib/Hydra/Plugin/SubversionInput.pm
+++ b/src/lib/Hydra/Plugin/SubversionInput.pm
@@ -71,7 +71,7 @@ sub fetchInput {
 
         $sha256 = queryPathHash($storePath); $sha256 =~ s/sha256://;
 
-        txn_do($self->{db}, sub {
+        $self->{db}->txn_do(sub {
             $self->{db}->resultset('CachedSubversionInputs')->update_or_create(
                 { uri => $uri
                 , revision => $revision

--- a/src/script/hydra-create-user
+++ b/src/script/hydra-create-user
@@ -54,7 +54,7 @@ die "$0: type must be `hydra' or `google'\n"
 
 my $db = Hydra::Model::DB->new();
 
-txn_do($db, sub {
+$db->txn_do(sub {
     my $user = $db->resultset('Users')->find({ username => $renameFrom // $userName });
     if ($renameFrom) {
         die "$0: user `$renameFrom' does not exist\n" unless $user;

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -399,7 +399,7 @@ sub checkBuild {
 
     my $build;
 
-    txn_do($db, sub {
+    $db->txn_do(sub {
         my $job = $jobset->jobs->update_or_create({
             name => $jobName,
             jobset_id => $jobset->id,
@@ -501,7 +501,7 @@ sub setJobsetError {
     my $prevError = $jobset->errormsg;
 
     eval {
-        txn_do($db, sub {
+        $db->txn_do(sub {
             $jobset->update({ errormsg => $errorMsg, errortime => time, fetcherrormsg => undef });
         });
     };
@@ -603,7 +603,7 @@ sub checkJobsetWrapped {
     if ($fetchError) {
         Net::Statsd::increment("hydra.evaluator.failed_checkouts");
         print STDERR $fetchError;
-        txn_do($db, sub {
+        $db->txn_do(sub {
             $jobset->update({ lastcheckedtime => time, fetcherrormsg => $fetchError }) if !$dryRun;
             $db->storage->dbh->do("notify eval_failed, ?", undef, join('\t', $tmpId));
         });
@@ -619,7 +619,7 @@ sub checkJobsetWrapped {
     if (defined $prevEval && $prevEval->hash eq $argsHash && !$dryRun && !$jobset->forceeval && $prevEval->flake eq $flakeRef) {
         print STDERR "  jobset is unchanged, skipping\n";
         Net::Statsd::increment("hydra.evaluator.unchanged_checkouts");
-        txn_do($db, sub {
+        $db->txn_do(sub {
             $jobset->update({ lastcheckedtime => time, fetcherrormsg => undef });
             $db->storage->dbh->do("notify eval_cached, ?", undef, join('\t', $tmpId));
         });
@@ -660,7 +660,7 @@ sub checkJobsetWrapped {
     my $dbStart = clock_gettime(CLOCK_MONOTONIC);
 
     my %buildMap;
-    txn_do($db, sub {
+    $db->txn_do(sub {
 
         my $prevEval = getPrevJobsetEval($db, $jobset, 1);
 
@@ -806,7 +806,7 @@ sub checkJobset {
     my $failed = 0;
     if ($checkError) {
         print STDERR $checkError;
-        txn_do($db, sub {
+        $db->txn_do(sub {
             $jobset->update({lastcheckedtime => time});
             setJobsetError($jobset, $checkError);
             $db->storage->dbh->do("notify eval_failed, ?", undef, join('\t', $tmpId));

--- a/src/script/hydra-init
+++ b/src/script/hydra-init
@@ -25,9 +25,8 @@ my @tables = $dbh->tables;
 if (! grep { /SchemaVersion/i } @tables) {
     print STDERR "initialising the Hydra database schema...\n";
     my $schema = read_file(
-        $dbh->{Driver}->{Name} eq 'SQLite' ? "$home/sql/hydra-sqlite.sql" :
         $dbh->{Driver}->{Name} eq 'Pg' ? "$home/sql/hydra-postgresql.sql" :
-        die "unsupported database type\n");
+        die "unsupported database type $dbh->{Driver}->{Name}\n");
     my @statements = $sql_splitter->split($schema);
     eval {
         $dbh->begin_work;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -31,9 +31,6 @@ TESTS = \
 
 check_SCRIPTS = repos
 
-db.sqlite: $(top_srcdir)/src/sql/hydra-sqlite.sql
-	$(TESTS_ENVIRONMENT) $(top_srcdir)/src/script/hydra-init
-
 repos: dirs
 
 dirs:


### PR DESCRIPTION
SQLite isn't officially supported for a while. Since it's still used by default, it can lead to confusion by end-users.