### PR TITLE
Add CI badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Hydra
 
-Hydra is a [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) service for [Nix](https://nixos.org/nix) based projects. 
+[![CI](https://github.com/NixOS/hydra/workflows/Test/badge.svg)](https://github.com/NixOS/hydra/actions)
+
+Hydra is a [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) service for [Nix](https://nixos.org/nix) based projects.
 
 ## Installation And Setup
 


### PR DESCRIPTION
Since we do have GitHub actions based CI activated we might as well display a
badge at the top of the README. Does no harm and maybe instills some
additional confidence :)