### PR TITLE
Add comment about edolstra/flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,6 @@
+# The `default.nix` in flake-compat reads `flake.nix` and `flake.lock` from `src` and
+# returns an attribute set of the shape `{ defaultNix, shellNix }`
+
 (import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
   src = builtins.fetchGit ./.;
 }).defaultNix

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,6 @@
+# The `default.nix` in flake-compat reads `flake.nix` and `flake.lock` from `src` and
+# returns an attribute set of the shape `{ defaultNix, shellNix }`
+
 (import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
   src = builtins.fetchGit ./.;
 }).shellNix


### PR DESCRIPTION
Add a comment to default.nix and shell.nix briefly outlining what
flake-compat/default.nix does.

Since i haven't dealt much with flakes before i wasn't aware of the flake-compat repository and what it does and that might be the case for others as well. Doesn't hurt to add a little comment :)