### PR TITLE
Don't distribute localhost builds to other builders

### DIFF
--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -50,7 +50,7 @@ static void openConnection(Machine::ptr machine, Path tmpDir, int stderrFD, Chil
         Strings argv;
         if (machine->isLocalhost()) {
             pgmName = "nix-store";
-            argv = {"nix-store", "--serve", "--write"};
+            argv = {"nix-store", "--builders", "", "--serve", "--write"};
         }
         else {
             pgmName = "ssh";


### PR DESCRIPTION
Since the recent Hydra upgrade in nixpkgs, I have noticed that builds that are supposed to be running on localhost are actually getting distributed to other machines configured in `/etc/nix/machines`. If the build fails on the remote machine, it is marked as aborted.

I suspect this is caused by a change in Nix, rather than in Hydra, but I couldn't identify a commit that is to blame. It does not seem to happen for builds that Hydra intentionally runs on remote machines, even if those remote machines have builders configured in `/etc/nix/machines`. This may be due to implementation differences between the `cmdBuildPaths` `nix-store --serve` command (used for localhost builds) and the `cmdBuildDerivation` command (used for remote builds).

Note that I am still running `hydra-migration` because I was unable to get the migration to complete successfully.

This PR passes `--builders ''` to `nix-store` to prevent it from using Nix's remote building system.