### PR TITLE
Add stale GitHub Action

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,28 @@
+name: "Close stale issues and pull requests"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: >
+          This issue has been open 180 days with no activity. Consequently, it
+          is being marked with the "stale" label. This means is that the issue will be
+          automatically closed in 30 days unless more comments are added or the "stale"
+          label is removed. Comments that provide new information on the issue are
+          especially welcome: is it still reproducible? did it appear in other contexts?
+          how critical is it?
+        stale-pr-message: >
+          This PR has been open 180 days with no activity. Consequently, it
+          is being marked with the "stale" label. This means is that the PR will be
+          automatically closed in 30 days unless more comments are added, code is updated,
+          or the "stale" label is removed.
+        days-before-stale: 180
+        days-before-close: 30
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'


### PR DESCRIPTION
This GitHub Action will mark and close all issues and PRs that are older
than 180 days.

The list of open PRs and issues is ever growing and the
old issues will probably not ever be looked again. To make it easier for
the maintainers and also to submitters, mark all stale issues/PRs as
such and delete them after 210 days of inactivity.