### PR TITLE
Revert "hydra-queue-runner: Support running in a NixOS container"

### DIFF
--- a/src/hydra-queue-runner/state.hh
+++ b/src/hydra-queue-runner/state.hh
@@ -284,11 +284,6 @@ struct Machine
 
         return true;
     }
-
-    bool isLocalhost()
-    {
-        return sshName == "localhost";
-    }
 };
 
 


### PR DESCRIPTION
This reverts commit d4b4255dd2aef51db916dfafd78891178534fd56 which caused builds on the localhost builder to build all dependencies of `preferLocalBuild` derivations as well. It was [suggested](https://github.com/NixOS/hydra/pull/749#issuecomment-626354485) by @AmineChikhaoui to revert that commit to fix this and I can confirm it indeed fixes it.

@edolstra I expect you to have a better solution for this but I didn't understand the code well enough to know what to revert and what to leave so I just reverted the whole of d4b425. See this more as a starting point of a conversation on how to properly fix this.