### PR TITLE
GitInput: only convert integer option values to int

### DIFF
--- a/src/lib/Hydra/Plugin/GitInput.pm
+++ b/src/lib/Hydra/Plugin/GitInput.pm
@@ -118,7 +118,7 @@ sub fetchInput {
                             $name);
     # give preference to the options from the input value
     while (my ($opt_name, $opt_value) = each %{$options}) {
-        if ($opt_value =~ /\d+/) {
+        if ($opt_value =~ /^[+-]?\d+\z/) {
             $opt_value = int($opt_value);
         }
         $cfg->{$opt_name} = $opt_value;


### PR DESCRIPTION
The previous code converted option values to ints when the value contained a digit somewhere. This is too eager since it also converts strings like `release-0.2` to an int which should not happen.

We now only convert to int when the value is an integer.