### PR TITLE
schema/Builds: use jobset_id instead of jobset name matches

### DIFF
--- a/src/lib/Hydra/Controller/Job.pm
+++ b/src/lib/Hydra/Controller/Job.pm
@@ -172,7 +172,7 @@ sub get_builds : Chained('job') PathPart('') CaptureArgs(0) {
     my ($self, $c) = @_;
     $c->stash->{allBuilds} = $c->stash->{job}->builds;
     $c->stash->{latestSucceeded} = $c->model('DB')->resultset('LatestSucceededForJob')
-        ->search({}, {bind => [$c->stash->{jobset}->name, $c->stash->{job}->name]});
+        ->search({}, {bind => [$c->stash->{jobset}->id, $c->stash->{job}->name]});
     $c->stash->{channelBaseName} =
         $c->stash->{project}->name . "-" . $c->stash->{jobset}->name . "-" . $c->stash->{job}->name;
 }

--- a/src/lib/Hydra/Controller/Jobset.pm
+++ b/src/lib/Hydra/Controller/Jobset.pm
@@ -162,7 +162,7 @@ sub get_builds : Chained('jobsetChain') PathPart('') CaptureArgs(0) {
     my ($self, $c) = @_;
     $c->stash->{allBuilds} = $c->stash->{jobset}->builds;
     $c->stash->{latestSucceeded} = $c->model('DB')->resultset('LatestSucceededForJobset')
-        ->search({}, {bind => [$c->stash->{jobset}->name]});
+        ->search({}, {bind => [$c->stash->{jobset}->id]});
     $c->stash->{channelBaseName} =
         $c->stash->{project}->name . "-" . $c->stash->{jobset}->name;
 }

--- a/src/lib/Hydra/Schema/Builds.pm
+++ b/src/lib/Hydra/Schema/Builds.pm
@@ -622,8 +622,8 @@ QUERY
 
 makeQueries('', "");
 makeQueries('ForProject', "and project = ?");
-makeQueries('ForJobset', "and jobset_id = (select id from jobsets j where j.name = ?)");
-makeQueries('ForJob', "and jobset_id = (select id from jobsets j where j.name = ?) and job = ?");
+makeQueries('ForJobset', "and jobset_id = ?");
+makeQueries('ForJob', "and jobset_id = ? and job = ?");
 
 
 my %hint = (


### PR DESCRIPTION
This was clearly an error in the original part-2 of the diff, and
specifically breaks when two projects have a jobset of the same name.