### PR TITLE
Fix declarative jobset missing type value

### DIFF
--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -43,6 +43,8 @@ sub updateDeclarativeJobset {
     );
     my %update = ( name => $jobsetName );
     foreach my $key (@allowed_keys) {
+        # do not pass missing data to let psql assign the default value
+        next unless defined $declSpec->{$key};
         $update{$key} = $declSpec->{$key};
         delete $declSpec->{$key};
     }

--- a/src/sql/upgrade-66.sql
+++ b/src/sql/upgrade-66.sql
@@ -1,0 +1,2 @@
+update Jobsets set type = 0 where type is null;
+alter table Jobsets alter column type set not null;


### PR DESCRIPTION
The current implementation will pass all values to `create_or_update` method. The
missing values will end up as `undef` (or `NULL`) when assigned to `%update`.
Thus, for columns that are NOT NULL, when, for example, flakes are not used,
will result in a horrible:

    DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::Pg::st execute failed:
    ERROR:  null value in column "type" violates not-null constraint

    DETAIL:  Failing row contains (.jobsets, 118, hydra, hydra jobsets, src, hydra/jobsets.nix, null,
    null, null, 1589536378, 1, 0, 0, , 3, 30, 100, null, null, 1589536379, null, null). [for Statement
    "UPDATE jobsets SET checkinterval = ?, description = ?, enableemail = ?, nixexprinput = ?,
    nixexprpath = ?, type = ? WHERE ( ( name = ? AND project = ? ) )" with ParamValues: 1='30',
    2='hydra jobsets', 3='0', 4='src', 5='hydra/jobsets.nix', 6=undef, 7='.jobsets', 8='hydra'] at
    /nix/store/lsf81ip9ybxihk5praf2n0nh14a6i9j0-hydra-0.1.19700101.DIRTY/libexec/hydra/lib/Hydra/Helper/AddBuilds.pm line 50

This change just omits adding such values to `%update`, which results in
PostgreSQL assigning the default values.

In addition, `type` column in `Jobsets` is defined as NOT NULL. However, the original upgrade
script adding this column ommited the constraint. This change adds the upgrade script.

Fixes #761 
