### PR TITLE
Add hydra-notify to devshell

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 hydra-server: ./foreman/start-hydra.sh
 hydra-queue-runner: ./foreman/start-queue-runner.sh
 hydra-evaluator: ./foreman/start-evaluator.sh
+hydra-notify: ./foreman/start-notify.sh
 postgres: ./foreman/start-postgres.sh

--- a/foreman/start-notify.sh
+++ b/foreman/start-notify.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# wait for hydra-server to listen
+while ! nc -z localhost 63333; do sleep 1; done
+
+touch .hydra-data/hydra.conf
+HYDRA_CONFIG=$(pwd)/.hydra-data/hydra.conf exec hydra-notify


### PR DESCRIPTION
I came across https://github.com/NixOS/hydra/issues/751 and realized
that hydra-notify is responsible for creating the additional jobsets in
a declarative file. My declarative testing works in dev now.