### PR TITLE
Refactor/Split up flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       # - `hydra` via overalay
       pkgs = import nixpkgs {
         system = "x86_64-linux";
-        overlays = [ self.hydraOverlay nix.overlay ];
+        overlays = [ self.overlay nix.overlay ];
       };
 
 
@@ -28,7 +28,7 @@
         defaultPackage.x86_64-linux = pkgs.hydra;
 
         # A Nixpkgs overlay that provides a 'hydra' package.
-        hydraOverlay = final: prev: {
+        overlay = final: prev: {
           hydra = final.callPackage ./nix/hydra.nix {
             hydraSrc = self.outPath;
             system = "x86_64-linux";
@@ -53,7 +53,7 @@
           # The default hydra module
           hydra = {
             imports = [ ./hydra-module.nix ];
-            nixpkgs.overlays = [ hydraOverlay nix.overlay ];
+            nixpkgs.overlays = [ overlay nix.overlay ];
           };
 
           # Debug version of the hydra module

--- a/flake.nix
+++ b/flake.nix
@@ -38,9 +38,9 @@
 
         hydraJobs = import ./nix/hydra-jobs.nix {
           inherit (pkgs) hydra perlPackages runCommand;
-          inherit packages nixpkgs version;
           inherit (nixosModules) hydraTest hydraProxy;
           inherit (self) rev;
+          inherit nixpkgs version;
 
           system = "x86_64-linux";
         };

--- a/flake.nix
+++ b/flake.nix
@@ -3,358 +3,102 @@
 
   inputs.nixpkgs.url = "nixpkgs/nixos-20.03";
 
+  # self   : this flake
+  # nixpkgs: inputs.nixpkgs
+  # nix    : from the flake registry
   outputs = { self, nixpkgs, nix }:
     let
 
       version = "${builtins.readFile ./version}.${builtins.substring 0 8 self.lastModifiedDate}.${self.shortRev or "DIRTY"}";
 
+      # pkgs based on `inputs.nixpkgs` including
+      # - `inputs.nix` via overlay
+      # - `hydra` via overalay
       pkgs = import nixpkgs {
         system = "x86_64-linux";
-        overlays = [ self.overlay nix.overlay ];
+        overlays = [ self.hydraOverlay nix.overlay ];
       };
 
-      # NixOS configuration used for VM tests.
-      hydraServer =
-        { config, pkgs, ... }:
-        { imports = [ self.nixosModules.hydraTest ];
 
-          virtualisation.memorySize = 1024;
-          virtualisation.writableStore = true;
+    in
+      rec {
 
-          environment.systemPackages = [ pkgs.perlPackages.LWP pkgs.perlPackages.JSON ];
+        packages.x86_64-linux.hydra = pkgs.hydra;
 
-          nix = {
-            # Without this nix tries to fetch packages from the default
-            # cache.nixos.org which is not reachable from this sandboxed NixOS test.
-            binaryCaches = [];
+        defaultPackage.x86_64-linux = pkgs.hydra;
+
+        # A Nixpkgs overlay that provides a 'hydra' package.
+        hydraOverlay = final: prev: {
+          hydra = final.callPackage ./nix/hydra.nix {
+            hydraSrc = self.outPath;
+            system = "x86_64-linux";
+            inherit version;
           };
         };
 
-    in rec {
-
-      # A Nixpkgs overlay that provides a 'hydra' package.
-      overlay = final: prev: {
-
-        hydra = with final; let
-
-          perlDeps = buildEnv {
-            name = "hydra-perl-deps";
-            paths = with perlPackages; lib.closePropagation
-              [ ModulePluggable
-                CatalystActionREST
-                CatalystAuthenticationStoreDBIxClass
-                CatalystDevel
-                CatalystDispatchTypeRegex
-                CatalystPluginAccessLog
-                CatalystPluginAuthorizationRoles
-                CatalystPluginCaptcha
-                CatalystPluginSessionStateCookie
-                CatalystPluginSessionStoreFastMmap
-                CatalystPluginStackTrace
-                CatalystPluginUnicodeEncoding
-                CatalystTraitForRequestProxyBase
-                CatalystViewDownload
-                CatalystViewJSON
-                CatalystViewTT
-                CatalystXScriptServerStarman
-                CatalystXRoleApplicator
-                CryptRandPasswd
-                DBDPg
-                DBDSQLite
-                DataDump
-                DateTime
-                DigestSHA1
-                EmailMIME
-                EmailSender
-                FileSlurp
-                IOCompress
-                IPCRun
-                JSON
-                JSONAny
-                JSONXS
-                LWP
-                LWPProtocolHttps
-                NetAmazonS3
-                NetPrometheus
-                NetStatsd
-                PadWalker
-                Readonly
-                SQLSplitStatement
-                SetScalar
-                Starman
-                SysHostnameLong
-                TermSizeAny
-                TestMore
-                TextDiff
-                TextTable
-                XMLSimple
-                final.nix
-                final.nix.perl-bindings
-                git
-              ];
-          };
-
-        in stdenv.mkDerivation {
-
-          name = "hydra-${version}";
-
-          src = self;
-
-          buildInputs =
-            [ makeWrapper autoconf automake libtool unzip nukeReferences pkgconfig libpqxx
-              gitAndTools.topGit mercurial darcs subversion bazaar openssl bzip2 libxslt
-              perlDeps perl final.nix
-              boost
-              postgresql95
-              (if lib.versionAtLeast lib.version "20.03pre"
-               then nlohmann_json
-               else nlohmann_json.override { multipleHeaders = true; })
-            ];
-
-          checkInputs = [
-            foreman
-          ];
-
-          hydraPath = lib.makeBinPath (
-            [ subversion openssh final.nix coreutils findutils pixz
-              gzip bzip2 lzma gnutar unzip git gitAndTools.topGit mercurial darcs gnused bazaar
-            ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
-
-          configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
-
-          shellHook = ''
-            PATH=$(pwd)/src/hydra-evaluator:$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$PATH
-            PERL5LIB=$(pwd)/src/lib:$PERL5LIB
-            export HYDRA_HOME="src/"
-            mkdir -p .hydra-data
-            export HYDRA_DATA="$(pwd)/.hydra-data"
-            export HYDRA_DBI='dbi:Pg:dbname=hydra;host=localhost;port=64444'
-          '';
-
-          preConfigure = "autoreconf -vfi";
-
-          NIX_LDFLAGS = [ "-lpthread" ];
-
-          enableParallelBuilding = true;
-
-          doCheck = true;
-
-          preCheck = ''
-            patchShebangs .
-            export LOGNAME=''${LOGNAME:-foo}
-          '';
-
-          postInstall = ''
-            mkdir -p $out/nix-support
-
-            for i in $out/bin/*; do
-                read -n 4 chars < $i
-                if [[ $chars =~ ELF ]]; then continue; fi
-                wrapProgram $i \
-                    --prefix PERL5LIB ':' $out/libexec/hydra/lib:$PERL5LIB \
-                    --prefix PATH ':' $out/bin:$hydraPath \
-                    --set HYDRA_RELEASE ${version} \
-                    --set HYDRA_HOME $out/libexec/hydra \
-                    --set NIX_RELEASE ${final.nix.name or "unknown"}
-            done
-          '';
-
-          dontStrip = true;
-
-          meta.description = "Build of Hydra on ${system}";
-          passthru.perlDeps = perlDeps;
-        };
-      };
-
-      hydraJobs = {
-
-        build.x86_64-linux = packages.x86_64-linux.hydra;
-
-        manual =
-          pkgs.runCommand "hydra-manual-${version}" {}
-          ''
-            mkdir -p $out/share
-            cp -prvd ${pkgs.hydra}/share/doc $out/share/
-
-            mkdir $out/nix-support
-            echo "doc manual $out/share/doc/hydra" >> $out/nix-support/hydra-build-products
-          '';
-
-        tests.install.x86_64-linux =
-          with import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; };
-          simpleTest {
-            machine = hydraServer;
-            testScript =
-              ''
-                machine.wait_for_job("hydra-init")
-                machine.wait_for_job("hydra-server")
-                machine.wait_for_job("hydra-evaluator")
-                machine.wait_for_job("hydra-queue-runner")
-                machine.wait_for_open_port("3000")
-                machine.succeed("curl --fail http://localhost:3000/")
-              '';
-          };
-
-        tests.api.x86_64-linux =
-          with import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; };
-          simpleTest {
-            machine = hydraServer;
-            testScript =
-              let dbi = "dbi:Pg:dbname=hydra;user=root;"; in
-              ''
-                machine.wait_for_job("hydra-init")
-
-                # Create an admin account and some other state.
-                machine.succeed(
-                    """
-                        su - hydra -c "hydra-create-user root --email-address 'alice@example.org' --password foobar --role admin"
-                        mkdir /run/jobset /tmp/nix
-                        chmod 755 /run/jobset /tmp/nix
-                        cp ${./tests/api-test.nix} /run/jobset/default.nix
-                        chmod 644 /run/jobset/default.nix
-                        chown -R hydra /run/jobset /tmp/nix
-                """
-                )
-
-                machine.succeed("systemctl stop hydra-evaluator hydra-queue-runner")
-                machine.wait_for_job("hydra-server")
-                machine.wait_for_open_port("3000")
-
-                # Run the API tests.
-                machine.succeed(
-                    "su - hydra -c 'perl -I ${pkgs.hydra.perlDeps}/lib/perl5/site_perl ${./tests/api-test.pl}' >&2"
-                )
-              '';
+        hydraJobs = pkgs.callPackage ./nix/hydra-jobs.nix {
+          inherit packages nixpkgs version;
+          inherit (nixosModules) hydraTest hydraProxy;
+          inherit (self) rev;
         };
 
-        tests.notifications.x86_64-linux =
-          with import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; };
-          simpleTest {
-            machine = { pkgs, ... }: {
-              imports = [ hydraServer ];
-              services.hydra-dev.extraConfig = ''
-                <influxdb>
-                  url = http://127.0.0.1:8086
-                  db = hydra
-                </influxdb>
-              '';
-              services.influxdb.enable = true;
-            };
-            testScript = ''
-              machine.wait_for_job("hydra-init")
+        checks.x86_64-linux = {
+          build = hydraJobs.build.x86_64-linux;
+          install = hydraJobs.tests.install.x86_64-linux;
+        };
 
-              # Create an admin account and some other state.
-              machine.succeed(
-                  """
-                      su - hydra -c "hydra-create-user root --email-address 'alice@example.org' --password foobar --role admin"
-                      mkdir /run/jobset
-                      chmod 755 /run/jobset
-                      cp ${./tests/api-test.nix} /run/jobset/default.nix
-                      chmod 644 /run/jobset/default.nix
-                      chown -R hydra /run/jobset
-              """
-              )
 
-              # Wait until InfluxDB can receive web requests
-              machine.wait_for_job("influxdb")
-              machine.wait_for_open_port("8086")
+        nixosModules = {
 
-              # Create an InfluxDB database where hydra will write to
-              machine.succeed(
-                  "curl -XPOST 'http://127.0.0.1:8086/query' "
-                  + "--data-urlencode 'q=CREATE DATABASE hydra'"
-              )
+          # The default hydra module
+          hydra = {
+            imports = [ ./hydra-module.nix ];
+            nixpkgs.overlays = [ hydraOverlay nix.overlay ];
+          };
 
-              # Wait until hydra-server can receive HTTP requests
-              machine.wait_for_job("hydra-server")
-              machine.wait_for_open_port("3000")
+          # Debug version of the hydra module
+          hydraTest = {
+            imports = [ self.nixosModules.hydra ];
 
-              # Setup the project and jobset
-              machine.succeed(
-                  "su - hydra -c 'perl -I ${pkgs.hydra.perlDeps}/lib/perl5/site_perl ${./tests/setup-notifications-jobset.pl}' >&2"
-              )
+            services.hydra-dev.enable = true;
+            services.hydra-dev.hydraURL = "http://hydra.example.org";
+            services.hydra-dev.notificationSender = "admin@hydra.example.org";
 
-              # Wait until hydra has build the job and
-              # the InfluxDBNotification plugin uploaded its notification to InfluxDB
-              machine.wait_until_succeeds(
-                  "curl -s -H 'Accept: application/csv' "
-                  + "-G 'http://127.0.0.1:8086/query?db=hydra' "
-                  + "--data-urlencode 'q=SELECT * FROM hydra_build_status' | grep success"
-              )
+            systemd.services.hydra-send-stats.enable = false;
+
+            services.postgresql.enable = true;
+            services.postgresql.package = pkgs.postgresql95;
+
+            # The following is to work around the following error from hydra-server:
+            #   [error] Caught exception in engine "Cannot determine local time zone"
+            time.timeZone = "UTC";
+
+            nix.extraOptions = ''
+              allowed-uris = https://github.com/
             '';
-        };
+          };
 
-        container = nixosConfigurations.container.config.system.build.toplevel;
-      };
+          # Apache proxy for Hydra
+          hydraProxy = {
+            services.httpd = {
+              enable = true;
+              adminAddr = "hydra-admin@example.org";
+              extraConfig = ''
+                <Proxy *>
+                  Order deny,allow
+                  Allow from all
+                </Proxy>
 
-      checks.x86_64-linux.build = hydraJobs.build.x86_64-linux;
-      checks.x86_64-linux.install = hydraJobs.tests.install.x86_64-linux;
+                ProxyRequests     Off
+                ProxyPreserveHost On
+                ProxyPass         /apache-errors !
+                ErrorDocument 503 /apache-errors/503.html
+                ProxyPass         /       http://127.0.0.1:3000/ retry=5 disablereuse=on
+                ProxyPassReverse  /       http://127.0.0.1:3000/
+              '';
+            };
+          };
 
-      packages.x86_64-linux.hydra = pkgs.hydra;
-      defaultPackage.x86_64-linux = pkgs.hydra;
-
-      nixosModules.hydra = {
-        imports = [ ./hydra-module.nix ];
-        nixpkgs.overlays = [ self.overlay nix.overlay ];
-      };
-
-      nixosModules.hydraTest = {
-        imports = [ self.nixosModules.hydra ];
-
-        services.hydra-dev.enable = true;
-        services.hydra-dev.hydraURL = "http://hydra.example.org";
-        services.hydra-dev.notificationSender = "admin@hydra.example.org";
-
-        systemd.services.hydra-send-stats.enable = false;
-
-        services.postgresql.enable = true;
-        services.postgresql.package = pkgs.postgresql95;
-
-        # The following is to work around the following error from hydra-server:
-        #   [error] Caught exception in engine "Cannot determine local time zone"
-        time.timeZone = "UTC";
-
-        nix.extraOptions = ''
-          allowed-uris = https://github.com/
-        '';
-      };
-
-      nixosModules.hydraProxy = {
-        services.httpd = {
-          enable = true;
-          adminAddr = "hydra-admin@example.org";
-          extraConfig = ''
-            <Proxy *>
-              Order deny,allow
-              Allow from all
-            </Proxy>
-
-            ProxyRequests     Off
-            ProxyPreserveHost On
-            ProxyPass         /apache-errors !
-            ErrorDocument 503 /apache-errors/503.html
-            ProxyPass         /       http://127.0.0.1:3000/ retry=5 disablereuse=on
-            ProxyPassReverse  /       http://127.0.0.1:3000/
-          '';
         };
       };
-
-      nixosConfigurations.container = nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
-        modules =
-          [ self.nixosModules.hydraTest
-            self.nixosModules.hydraProxy
-            { system.configurationRevision = self.rev;
-
-              boot.isContainer = true;
-              networking.useDHCP = false;
-              networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.hostName = "hydra";
-
-              services.hydra-dev.useSubstitutes = true;
-            }
-          ];
-      };
-
-    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -36,17 +36,19 @@
           };
         };
 
-        hydraJobs = pkgs.callPackage ./nix/hydra-jobs.nix {
+        hydraJobs = import ./nix/hydra-jobs.nix {
+          inherit (pkgs) hydra perlPackages runCommand;
           inherit packages nixpkgs version;
           inherit (nixosModules) hydraTest hydraProxy;
           inherit (self) rev;
+
+          system = "x86_64-linux";
         };
 
         checks.x86_64-linux = {
           build = hydraJobs.build.x86_64-linux;
           install = hydraJobs.tests.install.x86_64-linux;
         };
-
 
         nixosModules = {
 

--- a/nix/hydra-jobs.nix
+++ b/nix/hydra-jobs.nix
@@ -1,0 +1,163 @@
+{ pkgs, nixpkgs, packages, version, hydraTest, hydraProxy, rev }:
+
+let
+
+  nixosConfigurations.container = nixpkgs.lib.nixosSystem {
+    system = "x86_64-linux";
+    modules =
+      [
+        hydraTest
+        hydraProxy
+        {
+          system.configurationRevision = rev;
+
+          boot.isContainer = true;
+          networking.useDHCP = false;
+          networking.firewall.allowedTCPPorts = [ 80 ];
+          networking.hostName = "hydra";
+
+          services.hydra-dev.useSubstitutes = true;
+        }
+      ];
+  };
+
+  hydraServer =
+    { config, pkgs, ... }:
+      {
+        imports = [ hydraTest ];
+
+        virtualisation.memorySize = 1024;
+        virtualisation.writableStore = true;
+
+        environment.systemPackages = [ pkgs.perlPackages.LWP pkgs.perlPackages.JSON ];
+
+        nix = {
+          # Without this nix tries to fetch packages from the default
+          # cache.nixos.org which is not reachable from this sandboxed NixOS test.
+          binaryCaches = [];
+        };
+      };
+
+in
+{
+
+  build.x86_64-linux = packages.x86_64-linux.hydra;
+
+  manual =
+    pkgs.runCommand "hydra-manual-${version}" {}
+      ''
+        mkdir -p $out/share
+        cp -prvd ${pkgs.hydra}/share/doc $out/share/
+
+            mkdir $out/nix-support
+            echo "doc manual $out/share/doc/hydra" >> $out/nix-support/hydra-build-products
+      '';
+
+  tests.install.x86_64-linux =
+    with import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; };
+    simpleTest {
+      machine = hydraServer;
+      testScript =
+        ''
+          machine.wait_for_job("hydra-init")
+          machine.wait_for_job("hydra-server")
+          machine.wait_for_job("hydra-evaluator")
+          machine.wait_for_job("hydra-queue-runner")
+          machine.wait_for_open_port("3000")
+          machine.succeed("curl --fail http://localhost:3000/")
+        '';
+    };
+
+  tests.api.x86_64-linux =
+    with import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; };
+    simpleTest {
+      machine = hydraServer;
+      testScript =
+        let
+          dbi = "dbi:Pg:dbname=hydra;user=root;";
+        in
+          ''
+              machine.wait_for_job("hydra-init")
+
+            # Create an admin account and some other state.
+              machine.succeed(
+                """
+                    su - hydra -c "hydra-create-user root --email-address 'alice@example.org' --password foobar --role admin"
+                    mkdir /run/jobset /tmp/nix
+                    chmod 755 /run/jobset /tmp/nix
+                    cp ${./tests/api-test.nix} /run/jobset/default.nix
+                    chmod 644 /run/jobset/default.nix
+                    chown -R hydra /run/jobset /tmp/nix
+              """
+              )
+
+              machine.succeed("systemctl stop hydra-evaluator hydra-queue-runner")
+              machine.wait_for_job("hydra-server")
+              machine.wait_for_open_port("3000")
+
+            # Run the API tests.
+              machine.succeed(
+                "su - hydra -c 'perl -I ${pkgs.hydra.perlDeps}/lib/perl5/site_perl ${./tests/api-test.pl}' >&2"
+              )
+          '';
+    };
+
+  tests.notifications.x86_64-linux =
+    with import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; };
+    simpleTest {
+      machine = { pkgs, ... }: {
+        imports = [ hydraServer ];
+        services.hydra-dev.extraConfig = ''
+          <influxdb>
+          url = http://127.0.0.1:8086
+          db = hydra
+          </influxdb>
+        '';
+        services.influxdb.enable = true;
+      };
+      testScript = ''
+              machine.wait_for_job("hydra-init")
+
+        # Create an admin account and some other state.
+              machine.succeed(
+              """
+                su - hydra -c "hydra-create-user root --email-address 'alice@example.org' --password foobar --role admin"
+                mkdir /run/jobset
+                chmod 755 /run/jobset
+                cp ${./tests/api-test.nix} /run/jobset/default.nix
+                chmod 644 /run/jobset/default.nix
+                chown -R hydra /run/jobset
+              """
+              )
+
+        # Wait until InfluxDB can receive web requests
+              machine.wait_for_job("influxdb")
+              machine.wait_for_open_port("8086")
+
+        # Create an InfluxDB database where hydra will write to
+              machine.succeed(
+              "curl -XPOST 'http://127.0.0.1:8086/query' "
+              + "--data-urlencode 'q=CREATE DATABASE hydra'"
+              )
+
+        # Wait until hydra-server can receive HTTP requests
+              machine.wait_for_job("hydra-server")
+              machine.wait_for_open_port("3000")
+
+        # Setup the project and jobset
+              machine.succeed(
+              "su - hydra -c 'perl -I ${pkgs.hydra.perlDeps}/lib/perl5/site_perl ${./tests/setup-notifications-jobset.pl}' >&2"
+              )
+
+        # Wait until hydra has build the job and
+        # the InfluxDBNotification plugin uploaded its notification to InfluxDB
+              machine.wait_until_succeeds(
+              "curl -s -H 'Accept: application/csv' "
+              + "-G 'http://127.0.0.1:8086/query?db=hydra' "
+              + "--data-urlencode 'q=SELECT * FROM hydra_build_status' | grep success"
+              )
+      '';
+    };
+
+  container = nixosConfigurations.container.config.system.build.toplevel;
+}

--- a/nix/hydra-jobs.nix
+++ b/nix/hydra-jobs.nix
@@ -3,7 +3,6 @@
   hydraProxy,
   hydraTest,
   nixpkgs,
-  packages,
   perlPackages,
   rev,
   runCommand,
@@ -52,7 +51,7 @@ let
 in
 {
 
-  build.x86_64-linux = packages.x86_64-linux.hydra;
+  build.x86_64-linux = hydra;
 
   manual =
     runCommand "hydra-manual-${version}" {}

--- a/nix/hydra.nix
+++ b/nix/hydra.nix
@@ -1,0 +1,128 @@
+{ pkgs, hydraSrc, version, system }:
+with pkgs;
+let
+  perlDeps = buildEnv {
+    name = "hydra-perl-deps";
+    paths = with perlPackages; lib.closePropagation [
+      ModulePluggable
+      CatalystActionREST
+      CatalystAuthenticationStoreDBIxClass
+      CatalystDevel
+      CatalystDispatchTypeRegex
+      CatalystPluginAccessLog
+      CatalystPluginAuthorizationRoles
+      CatalystPluginCaptcha
+      CatalystPluginSessionStateCookie
+      CatalystPluginSessionStoreFastMmap
+      CatalystPluginStackTrace
+      CatalystPluginUnicodeEncoding
+      CatalystTraitForRequestProxyBase
+      CatalystViewDownload
+      CatalystViewJSON
+      CatalystViewTT
+      CatalystXScriptServerStarman
+      CatalystXRoleApplicator
+      CryptRandPasswd
+      DBDPg
+      DBDSQLite
+      DataDump
+      DateTime
+      DigestSHA1
+      EmailMIME
+      EmailSender
+      FileSlurp
+      IOCompress
+      IPCRun
+      JSON
+      JSONAny
+      JSONXS
+      LWP
+      LWPProtocolHttps
+      NetAmazonS3
+      NetPrometheus
+      NetStatsd
+      PadWalker
+      Readonly
+      SQLSplitStatement
+      SetScalar
+      Starman
+      SysHostnameLong
+      TermSizeAny
+      TestMore
+      TextDiff
+      TextTable
+      XMLSimple
+      nix
+      nix.perl-bindings
+      git
+    ];
+  };
+in
+    stdenv.mkDerivation {
+
+      name = "hydra-${version}";
+      src = hydraSrc;
+      buildInputs =
+        [ makeWrapper autoconf automake libtool unzip nukeReferences pkgconfig libpqxx
+        gitAndTools.topGit mercurial darcs subversion bazaar openssl bzip2 libxslt
+        perlDeps perl nix
+        boost
+        postgresql95
+        (if lib.versionAtLeast lib.version "20.03pre"
+        then nlohmann_json
+        else nlohmann_json.override { multipleHeaders = true; })
+      ];
+
+      checkInputs = [
+        foreman
+      ];
+
+      hydraPath = lib.makeBinPath (
+        [ subversion openssh nix coreutils findutils pixz
+        gzip bzip2 lzma gnutar unzip git gitAndTools.topGit mercurial darcs gnused bazaar
+      ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
+
+      configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
+
+      shellHook = ''
+            PATH=$(pwd)/src/hydra-evaluator:$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$PATH
+            PERL5LIB=$(pwd)/src/lib:$PERL5LIB
+            export HYDRA_HOME="src/"
+            mkdir -p .hydra-data
+            export HYDRA_DATA="$(pwd)/.hydra-data"
+            export HYDRA_DBI='dbi:Pg:dbname=hydra;host=localhost;port=64444'
+      '';
+
+      preConfigure = "autoreconf -vfi";
+
+      NIX_LDFLAGS = [ "-lpthread" ];
+
+      enableParallelBuilding = true;
+
+      doCheck = true;
+
+      preCheck = ''
+            patchShebangs .
+            export LOGNAME=''${LOGNAME:-foo}
+      '';
+
+      postInstall = ''
+            mkdir -p $out/nix-support
+
+            for i in $out/bin/*; do
+                read -n 4 chars < $i
+                if [[ $chars =~ ELF ]]; then continue; fi
+                wrapProgram $i \
+                    --prefix PERL5LIB ':' $out/libexec/hydra/lib:$PERL5LIB \
+                    --prefix PATH ':' $out/bin:$hydraPath \
+                    --set HYDRA_RELEASE ${version} \
+                    --set HYDRA_HOME $out/libexec/hydra \
+                    --set NIX_RELEASE ${nix.name or "unknown"}
+            done
+      '';
+
+      dontStrip = true;
+
+      meta.description = "Build of Hydra on ${system}";
+      passthru.perlDeps = perlDeps;
+    }


### PR DESCRIPTION
**Motivation**
The goal is to make the `flake.nix` easier to grasp and parse. The returned attribute set should be small and easy to recognize with few big bindings.

**Details**
This is first and foremost about splitting up `flake.nix` into:
- nix/hydra-jobs.nix
- nix/hydra.nix

I also added a couple of comments and `build.x86_64-linux` in `hydra-jobs` now refers to `pkgs.hydra` instead of `packages.x86_64-linux` which (to my understanding) is identical.