### PR TITLE
Fix: Set notificationpendingsince for dependent builds

### DIFF
--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -63,7 +63,13 @@ sub buildFinished {
         }
     }
 
-    $build->update({ notificationpendingsince => undef });
+    # We have to iterate through all dependents as well, and if they are finished
+    # to mark their notificationpendingsince.
+    # Otherwise, the dependent builds will remain with notificationpendingsince set
+    # until hydra-notify is started, as buildFinished is never emitted for them.
+    foreach my $b ($build, @dependents) {
+        $b->update({ notificationpendingsince => undef }) if $b->finished;
+    }
 }
 
 sub stepFinished {


### PR DESCRIPTION
`build_finished` Postgres event will never be fired for the dependent builds.

For example, on our Hydra, the following query always returns increasing
numbers, even though all notifications have been delivered:

```
hydra=> select count(1) from builds where notificationpendingsince is not null;
 count
-------
  4583
(1 row)
```

Thus, we have to iterate over all dependent builds and mark their
`notificationpendingsince` as `null`, otherwise they will pile up until
the next restart of hydra-notify, when they will get delivered.