### PR TITLE
Support multiple jobsets per Flake

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -584,12 +584,18 @@ sub checkJobsetWrapped {
 
     my $flakeRef = $jobset->flake;
     if (defined $flakeRef) {
+        my @refParts = split(/#/, $flakeRef, 2);
+        $flakeRef = @refParts[0];
+        my $fragment = @refParts[1];
         (my $res, my $json, my $stderr) = captureStdoutStderr(
             600, "nix", "flake", "info", "--tarball-ttl", 0, "--json", "--", $flakeRef);
         die "'nix flake info' returned " . ($res & 127 ? "signal $res" : "exit code " . ($res >> 8))
             . ":\n" . ($stderr ? decode("utf-8", $stderr) : "(no output)\n")
             if $res;
         $flakeRef = decode_json($json)->{'url'};
+        if ($fragment) {
+            $flakeRef .= "#" . $fragment;
+        };
     }
 
     Net::Statsd::increment("hydra.evaluator.checkouts");


### PR DESCRIPTION
This allows usage of `#`, just as `nix run` does. This way, multiple
jobsets can be configured per flake.nix. For the path given after `#`,
an attribute is looked up and either `hydraJobs` or `checks` is searched
there.

For example `nixpkgs#example` will try to evaluate `example.hydraJobs`
in nixpkgs.