### PR TITLE
Fix syntax error in `hydra-send-stats`

### DIFF
--- a/src/script/hydra-send-stats
+++ b/src/script/hydra-send-stats
@@ -63,7 +63,7 @@ while (1) {
     eval {
         sendQueueRunnerStats();
         1;
-    } or do { warn "$@"; }
+    } or do { warn "$@"; };
 
     my $meminfo = read_file("/proc/meminfo", err_mode => 'quiet') // "";
     $meminfo =~ m/Dirty:\s*(\d+) kB/;


### PR DESCRIPTION
cc @edolstra @knl 

----
Introduced in f79810bac1a3a45abe488e975b06bd867105e26e.