### PR TITLE
Add notification of steps that cannot be run on any current worker.

### DIFF
--- a/src/hydra-queue-runner/dispatcher.cc
+++ b/src/hydra-queue-runner/dispatcher.cc
@@ -282,6 +282,19 @@ system_time State::doDispatch()
             if (keepGoing) break;
         }
 
+        for (auto & stepInfo : runnableSorted) {
+            auto & step(stepInfo.step);
+            bool couldRunStep = false;
+            for (auto & mi : machinesSorted)
+                if (mi.machine->supportsStep(step)) {
+                    couldRunStep = true;
+                    break;
+                }
+            if (couldRunStep) continue;
+            printMsg(lvlError, format("No machine available to run step '%1%' (needs system type '%2%')") %
+                     localStore->printStorePath(step->drvPath) % step->systemType);
+        }
+
         /* Update the stats for the auto-scaler. */
         {
             auto machineTypes_(machineTypes.lock());


### PR DESCRIPTION
Currently there is no notification of steps that cannot be run because there is no compatible worker configured for those steps, which makes this hard to diagnose.  This PR adds a log entry in the `hydra-queue-runner` job to provide that information.