### PR TITLE
Make PathInput plugin cache validity configurable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -198,7 +198,14 @@
         tests.api.x86_64-linux =
           with import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; };
           simpleTest {
-            machine = hydraServer;
+            machine = { pkgs, ... }: {
+              imports = [ hydraServer ];
+              # No caching for PathInput plugin, otherwise we get wrong values
+              # (as it has a 30s window where no changes to the file are considered).
+              services.hydra-dev.extraConfig = ''
+                path_input_cache_validity_seconds = 0
+              '';
+            };
             testScript =
               let dbi = "dbi:Pg:dbname=hydra;user=root;"; in
               ''

--- a/src/lib/Hydra/Plugin/PathInput.pm
+++ b/src/lib/Hydra/Plugin/PathInput.pm
@@ -22,9 +22,11 @@ sub fetchInput {
     my $sha256;
     my $storePath;
 
+    my $timeout = $self->{config}->{path_input_cache_validity_seconds} // 30;
+
     # Some simple caching: don't check a path more than once every N seconds.
     (my $cachedInput) = $self->{db}->resultset('CachedPathInputs')->search(
-        {srcpath => $uri, lastseen => {">", $timestamp - 30}},
+        {srcpath => $uri, lastseen => {">", $timestamp - $timeout}},
         {rows => 1, order_by => "lastseen DESC"});
 
     if (defined $cachedInput && isValidPath($cachedInput->storepath)) {

--- a/tests/api-test.pl
+++ b/tests/api-test.pl
@@ -1,6 +1,6 @@
 use LWP::UserAgent;
 use JSON;
-use Test::Simple tests => 19;
+use Test::Simple tests => 20;
 
 my $ua = LWP::UserAgent->new;
 $ua->cookie_jar({});
@@ -59,6 +59,7 @@ ok($eval->{hasnewbuilds} == 1, "The first eval of a jobset has new builds");
 
 system("echo >> /run/jobset/default.nix; hydra-eval-jobset sample default");
 my $evals = decode_json(request_json({ uri => '/jobset/sample/default/evals' })->content())->{evals};
+ok(scalar(@$evals) == 2, "Changing a jobset source creates the second evaluation");
 ok($evals->[0]->{jobsetevalinputs}->{"my-src"}->{revision} != $evals->[1]->{jobsetevalinputs}->{"my-src"}->{revision}, "Changing a jobset source changes its revision");
 
 my $build = decode_json(request_json({ uri => "/build/" . $evals->[0]->{builds}->[0] })->content());


### PR DESCRIPTION
PathInput plugin keeps a cache of path evaluations. This cache is simple, and
path is not checked more than once every N seconds, where N=30. The caching is
there to avoid expensive calls to `nix-store --add`.

This change makes the validity period configurable. The main use case is
`api-test.pl` which was implemented wrong for a while, as the invocation of
`hydra-eval-jobset` would return the previous evaluation, claiming there are no
changes. The test has been fixed to check better for a new evaluation.