### PR TITLE
Fix issue #706: do not use locally cached last build ID.

### DIFF
--- a/src/hydra-queue-runner/queue-monitor.cc
+++ b/src/hydra-queue-runner/queue-monitor.cc
@@ -33,12 +33,10 @@ void State::queueMonitorLoop()
 
     auto destStore = getDestStore();
 
-    unsigned int lastBuildId = 0;
-
     while (true) {
         localStore->clearPathInfoCache();
 
-        bool done = getQueuedBuilds(*conn, destStore, lastBuildId);
+        bool done = getQueuedBuilds(*conn, destStore);
 
         /* Sleep until we get notification from the database about an
            event. */
@@ -49,12 +47,10 @@ void State::queueMonitorLoop()
             conn->get_notifs();
 
         if (auto lowestId = buildsAdded.get()) {
-            lastBuildId = std::min(lastBuildId, static_cast<unsigned>(std::stoul(*lowestId) - 1));
             printMsg(lvlTalkative, "got notification: new builds added to the queue");
         }
         if (buildsRestarted.get()) {
             printMsg(lvlTalkative, "got notification: builds restarted");
-            lastBuildId = 0; // check all builds
         }
         if (buildsCancelled.get() || buildsDeleted.get() || buildsBumped.get()) {
             printMsg(lvlTalkative, "got notification: builds cancelled or bumped");
@@ -74,10 +70,9 @@ struct PreviousFailure : public std::exception {
 };
 
 
-bool State::getQueuedBuilds(Connection & conn,
-    ref<Store> destStore, unsigned int & lastBuildId)
+bool State::getQueuedBuilds(Connection & conn, ref<Store> destStore)
 {
-    printInfo("checking the queue for builds > %d...", lastBuildId);
+    printInfo("checking the queue for new builds...");
 
     /* Grab the queued builds from the database, but don't process
        them yet (since we don't want a long-running transaction). */
@@ -85,21 +80,17 @@ bool State::getQueuedBuilds(Connection & conn,
     std::map<BuildID, Build::ptr> newBuildsByID;
     std::multimap<StorePath, BuildID> newBuildsByPath;
 
-    unsigned int newLastBuildId = lastBuildId;
-
     {
         pqxx::work txn(conn);
 
         auto res = txn.exec_params
             ("select id, project, jobset, job, drvPath, maxsilent, timeout, timestamp, globalPriority, priority from Builds "
-             "where id > $1 and finished = 0 order by globalPriority desc, id",
-            lastBuildId);
+             "where finished = 0 order by globalPriority desc, id");
 
         for (auto const & row : res) {
             auto builds_(builds.lock());
             BuildID id = row["id"].as<BuildID>();
             if (buildOne && id != buildOne) continue;
-            if (id > newLastBuildId) newLastBuildId = id;
             if (builds_->count(id)) continue;
 
             auto build = std::make_shared<Build>(
@@ -293,7 +284,6 @@ bool State::getQueuedBuilds(Connection & conn,
         if (std::chrono::system_clock::now() > start + std::chrono::seconds(600)) break;
     }
 
-    lastBuildId = newBuildsByID.empty() ? newLastBuildId : newBuildsByID.begin()->first - 1;
     return newBuildsByID.empty();
 }
 

--- a/src/hydra-queue-runner/state.hh
+++ b/src/hydra-queue-runner/state.hh
@@ -474,8 +474,7 @@ private:
     void queueMonitorLoop();
 
     /* Check the queue for new builds. */
-    bool getQueuedBuilds(Connection & conn,
-        nix::ref<nix::Store> destStore, unsigned int & lastBuildId);
+    bool getQueuedBuilds(Connection & conn, nix::ref<nix::Store> destStore);
 
     /* Handle cancellation, deletion and priority bumps. */
     void processQueueChange(Connection & conn);


### PR DESCRIPTION
Relies on database optimizations instead of local lookup
optimizations, but resolves the issue where the local ID was being
updated prematurely and leaving builds permanently (until the next
hydra restart) in the unstarted condition.

Previous to this change, builds were frequently left in a Pending status and required manual starting or a restart of the hydra-queue-runner.  After implementing this change, the local hydra instance has run for several months without any builds left Pending.