### PR TITLE
Remove references to hydra-postgresql.sql

### DIFF
--- a/src/script/hydra-init
+++ b/src/script/hydra-init
@@ -25,7 +25,7 @@ my @tables = $dbh->tables;
 if (! grep { /SchemaVersion/i } @tables) {
     print STDERR "initialising the Hydra database schema...\n";
     my $schema = read_file(
-        $dbh->{Driver}->{Name} eq 'Pg' ? "$home/sql/hydra-postgresql.sql" :
+        $dbh->{Driver}->{Name} eq 'Pg' ? "$home/sql/hydra.sql" :
         die "unsupported database type $dbh->{Driver}->{Name}\n");
     my @statements = $sql_splitter->split($schema);
     eval {

--- a/src/sql/Makefile.am
+++ b/src/sql/Makefile.am
@@ -1,13 +1,9 @@
 sqldir = $(libexecdir)/hydra/sql
 nobase_dist_sql_DATA =				\
-  hydra-postgresql.sql				\
   hydra.sql					\
   test.sql					\
   upgrade-*.sql					\
   update-dbix.pl
 
-hydra-postgresql.sql: hydra.sql
-	cpp -P -E -traditional-cpp -DPOSTGRESQL hydra.sql > $@ || rm -f $@
-
-update-dbix: hydra-postgresql.sql
+update-dbix: hydra.sql
 	./update-dbix-harness.sh

--- a/src/sql/update-dbix-harness.sh
+++ b/src/sql/update-dbix-harness.sh
@@ -33,7 +33,7 @@ pg_ctl -D "$data" \
 
 createdb -h "$socket" "$dbname"
 
-psql -h "$socket" "$dbname" -f ./hydra-postgresql.sql
+psql -h "$socket" "$dbname" -f ./hydra.sql
 
 perl -I ../lib \
      -MDBIx::Class::Schema::Loader=make_schema_at,dump_to_dir:../lib \


### PR DESCRIPTION
As of https://github.com/NixOS/hydra/pull/737 (removal of sqlite
dependency), the only supported database is Postgresql.

This change removes all references to hydra-postgresql.sql file. This
file is generated using a cpp on hydra.sql, but doesn't differ from
hydra.sql at all.