### PR TITLE
Remove SSL_CERT_FILE

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -18,7 +18,6 @@ let
 
   env =
     { NIX_REMOTE = "daemon";
-      SSL_CERT_FILE = "/etc/ssl/certs/ca-certificates.crt"; # Remove in 16.03
       PGPASSFILE = "${baseDir}/pgpass";
       NIX_REMOTE_SYSTEMS = concatStringsSep ":" cfg.buildMachinesFiles;
     } // optionalAttrs (cfg.smtpHost != null) {


### PR DESCRIPTION
This was slated to be removed with Nix 16.03. We're now in 20.03, so
it's good to clean that up a bit.