### PR TITLE
LDAP support continued (with missing packages & tests)

### DIFF
--- a/doc/manual/installation.xml
+++ b/doc/manual/installation.xml
@@ -272,6 +272,62 @@ server {
 
     </para>
   </section>
+  <section>
+    <title>Using LDAP as authentication backend (optional)</title>
+    <para>
+      Instead of using Hydra's built-in user management you can optionally use LDAP to manage roles and users.
+    </para>
+
+    <para>
+      The <command>hydra-server</command> accepts the environment
+      variable <emphasis>HYDRA_LDAP_CONFIG</emphasis>. The value of
+      the variable should point to a valid YAML file containing the
+      Catalyst LDAP configuration. The format of the configuration
+      file is describe in the
+      <link xlink:href="https://metacpan.org/pod/Catalyst::Authentication::Store::LDAP#CONFIGURATION-OPTIONS">
+        <emphasis>Catalyst::Authentication::Store::LDAP</emphasis> documentation</link>.
+      An example is given below.
+    </para>
+
+    <para>
+      Roles can be assigned to users based on their LDAP group membership
+      (<emphasis>use_roles: 1</emphasis> in the below example).
+      For a user to have the role <emphasis>admin</emphasis> assigned to them
+      they should be in the group <emphasis>hydra_admin</emphasis>. In general
+      any LDAP group of the form <emphasis>hydra_some_role</emphasis>
+      (notice the <emphasis>hydra_</emphasis> prefix) will work.
+    </para>
+
+    <screen>
+credential:
+  class: Password
+  password_field: password
+  password_type: self_check
+store:
+  class: LDAP
+  ldap_server: localhost
+  ldap_server_options.timeout: 30
+  binddn: "cn=root,dc=example"
+  bindpw: notapassword
+  start_tls: 0
+  start_tls_options
+    verify:  none
+  user_basedn: "ou=users,dc=example"
+  user_filter: "(&amp;(objectClass=inetOrgPerson)(cn=%s))"
+  user_scope: one
+  user_field: cn
+  user_search_options:
+    deref: always
+  use_roles: 1
+  role_basedn: "ou=groups,dc=example"
+  role_filter: "(&amp;(objectClass=groupOfNames)(member=%s))"
+  role_scope: one
+  role_field: cn
+  role_value: dn
+  role_search_options:
+    deref: always
+    </screen>
+  </section>
 </chapter>
 
 <!--

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,7 @@
                 TextDiff
                 TextTable
                 XMLSimple
+                YAML
                 final.nix
                 final.nix.perl-bindings
                 git

--- a/flake.nix
+++ b/flake.nix
@@ -35,14 +35,73 @@
       # A Nixpkgs overlay that provides a 'hydra' package.
       overlay = final: prev: {
 
-        hydra = with final; let
+        # Add LDAP dependencies that aren't currently found within nixpkgs.
+        perlPackages = prev.perlPackages // {
+          NetLDAPServer = prev.perlPackages.buildPerlPackage {
+            pname = "Net-LDAP-Server";
+            version = "0.43";
+            src = final.fetchurl {
+              url = "mirror://cpan/authors/id/A/AA/AAR/Net-LDAP-Server-0.43.tar.gz";
+              sha256 = "0qmh3cri3fpccmwz6bhwp78yskrb3qmalzvqn0a23hqbsfs4qv6x";
+            };
+            propagatedBuildInputs = with final.perlPackages; [ NetLDAP ConvertASN1 ];
+            meta = {
+              description = "LDAP server side protocol handling";
+              license = with final.stdenv.lib.licenses; [ artistic1 ];
+            };
+          };
 
+          NetLDAPSID = prev.perlPackages.buildPerlPackage {
+            pname = "Net-LDAP-SID";
+            version = "0.0001";
+            src = final.fetchurl {
+              url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-SID-0.001.tar.gz";
+              sha256 = "1mnnpkmj8kpb7qw50sm8h4sd8py37ssy2xi5hhxzr5whcx0cvhm8";
+            };
+            meta = {
+              description= "Active Directory Security Identifier manipulation";
+              license = with final.stdenv.lib.licenses; [ artistic2 ];
+            };
+          };
+
+          NetLDAPServerTest = prev.perlPackages.buildPerlPackage {
+            pname = "Net-LDAP-Server-Test";
+            version = "0.22";
+            src = final.fetchurl {
+              url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-Server-Test-0.22.tar.gz";
+              sha256 = "13idip7jky92v4adw60jn2gcc3zf339gsdqlnc9nnvqzbxxp285i";
+            };
+            propagatedBuildInputs = with final.perlPackages; [ NetLDAP NetLDAPServer TestMore DataDump NetLDAPSID ];
+            meta = {
+              description= "test Net::LDAP code";
+              license = with final.stdenv.lib.licenses; [ artistic1 ];
+            };
+          };
+
+          CatalystAuthenticationStoreLDAP = prev.perlPackages.buildPerlPackage {
+            pname = "Catalyst-Authentication-Store-LDAP";
+            version = "1.016";
+            src = final.fetchurl {
+              url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Authentication-Store-LDAP-1.016.tar.gz";
+              sha256 = "0cm399vxqqf05cjgs1j5v3sk4qc6nmws5nfhf52qvpbwc4m82mq8";
+            };
+            propagatedBuildInputs = with final.perlPackages; [ NetLDAP CatalystPluginAuthentication ClassAccessorFast ];
+            buildInputs = with final.perlPackages; [ TestMore TestMockObject TestException NetLDAPServerTest ];
+            meta = {
+              description= "Authentication from an LDAP Directory";
+              license = with final.stdenv.lib.licenses; [ artistic1 ];
+            };
+          };
+        };
+
+        hydra = with final; let
           perlDeps = buildEnv {
             name = "hydra-perl-deps";
             paths = with perlPackages; lib.closePropagation
               [ ModulePluggable
                 CatalystActionREST
                 CatalystAuthenticationStoreDBIxClass
+                CatalystAuthenticationStoreLDAP
                 CatalystDevel
                 CatalystDispatchTypeRegex
                 CatalystPluginAccessLog

--- a/src/lib/Hydra.pm
+++ b/src/lib/Hydra.pm
@@ -20,7 +20,8 @@ use Catalyst qw/ConfigLoader
                 Captcha/,
                 '-Log=warn,fatal,error';
 use CatalystX::RoleApplicator;
-
+use YAML qw(LoadFile);
+use Path::Class 'file';
 
 our $VERSION = '0.01';
 
@@ -44,6 +45,9 @@ __PACKAGE__->config(
                     role_field => "role",
                 },
             },
+            ldap => LoadFile(
+		file($ENV{'HYDRA_LDAP_CONFIG'})
+	    )
         },
     },
     'Plugin::Static::Simple' => {

--- a/src/lib/Hydra.pm
+++ b/src/lib/Hydra.pm
@@ -45,9 +45,9 @@ __PACKAGE__->config(
                     role_field => "role",
                 },
             },
-            ldap => LoadFile(
-		file($ENV{'HYDRA_LDAP_CONFIG'})
-	    )
+            ldap => $ENV{'HYDRA_LDAP_CONFIG'} ? LoadFile(
+                file($ENV{'HYDRA_LDAP_CONFIG'})
+            ) : undef
         },
     },
     'Plugin::Static::Simple' => {


### PR DESCRIPTION
This is picking up the work from @ajs124 in #684.

The main difference to the previous PR is that I started writing tests for it (while I was trying to figure out if it is working). That work required adding the missing perl packages which I'm also adding to NixPkgs in https://github.com/NixOS/nixpkgs/pull/97673. For the meantime they should probably be kept in here until NixOS 21.03 is released.

As written in the original PR this still has the hard coded `hydra_` prefix for all the roles that are currently supported by hydra. IMO extending that is out of scope for an initial implementation. If someone really needs different names and/or has multiple hydra setups with different permissions for the same person they can still have a different OU's in their LDAP and filter accordingly.