### PR TITLE
reproduce bash script must supply revCount as int

### DIFF
--- a/src/root/reproduce.tt
+++ b/src/root/reproduce.tt
@@ -117,7 +117,7 @@ else
     revCount="$(cat "$tmpDir/[% input.name %]/rev-count")"
 fi
 
-args+=(--arg '[% input.name %]' "{ outPath = $inputDir; rev = \"[% input.revision %]\"; shortRev = \"[% input.revision.substr(0, 7) %]\"; revCount = \"$revCount\"; }")
+args+=(--arg '[% input.name %]' "{ outPath = $inputDir; rev = \"[% input.revision %]\"; shortRev = \"[% input.revision.substr(0, 7) %]\"; revCount = $revCount; }")
 
 [%+ ELSIF input.type == "hg" %]
 
@@ -139,7 +139,7 @@ else
     revCount="$(cat "$tmpDir/[% input.name %]/rev-count")"
 fi
 
-args+=(--arg '[% input.name %]' "{ outPath = $inputDir; rev = \"[% input.revision %]\"; revCount = \"$revCount\"; }")
+args+=(--arg '[% input.name %]' "{ outPath = $inputDir; rev = \"[% input.revision %]\"; revCount = $revCount; }")
 
 [%+ ELSIF input.type == "svn" %]
 


### PR DESCRIPTION
The reproduce script would fail for me, because it passed revCount as
a string to nix-build, which would then fail to subtract from it.