### PR TITLE
ldap: only try the LDAP realm when it is configured

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -425,7 +425,7 @@
                     binddn: "cn=root,dc=example"
                     bindpw: notapassword
                     start_tls: 0
-                    start_tls_options
+                    start_tls_options:
                       verify:  none
                     user_basedn: "ou=users,dc=example"
                     user_filter: "(&(objectClass=inetOrgPerson)(cn=%s))"

--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -29,7 +29,7 @@ sub login_POST {
     error($c, "You must specify a user name.") if $username eq "";
     error($c, "You must specify a password.") if $password eq "";
 
-    if ($c->authenticate({username => $username, password => $password}, 'ldap')) {
+    if ($c->get_auth_realm('ldap') && $c->authenticate({username => $username, password => $password}, 'ldap')) {
         doLDAPLogin($self, $c, $username);
     } elsif ($c->authenticate({username => $username, password => $password})) {}
     else {


### PR DESCRIPTION
This is follow-up to #805 in which I broken non-LDAP login by accident. This also fixes the test that got broken while massaging all the formatting and whitespaces in the LDAP test.

I did run all the tests locally but would very much welcome someone else to execute them just to be sure. cc @ajs124  @grahamc 