### PR TITLE
Fix non-static declarative jobsets

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -573,7 +573,14 @@ sub checkJobsetWrapped {
         die "Declarative specification file $declFile not valid JSON: $@\n" if $@;
 
         if (ref $declSpec eq "HASH") {
-            if (grep ref $_ eq "HASH", values %$declSpec) {
+            my $isStatic = 1;
+            foreach my $elem (values %$declSpec) {
+                if (ref $elem ne "HASH") {
+                    $isStatic = 0;
+                    last;
+                }
+            }
+            if ($isStatic) {
                 # Since all of its keys are hashes, assume the json document
                 # itself is the entire set of jobs
                 handleDeclarativeJobsetJson($db, $project, $declSpec);


### PR DESCRIPTION
With the current implementation, if ANY hash was found inside the decl
spec, the spec would be treated as static. This is problematic since
`inputs` is a hash and hence any configuration would be handled as a
static one.
This fixes the code to match the documentation and only switch to static
processing when ALL values are hashes.

cc @grahamc @edolstra