### PR TITLE
Remove deprecation notice for binary_cache_secret_key_file

### DIFF
--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -57,8 +57,6 @@ State::State()
         printMsg(lvlError, "hydra.conf: binary_cache_dir is deprecated and ignored. use store_uri=file:// instead");
     if (config->getStrOption("binary_cache_s3_bucket") != "")
         printMsg(lvlError, "hydra.conf: binary_cache_s3_bucket is deprecated and ignored. use store_uri=s3:// instead");
-    if (config->getStrOption("binary_cache_secret_key_file") != "")
-        printMsg(lvlError, "hydra.conf: binary_cache_secret_key_file is deprecated and ignored. use store_uri=...?secret-key= instead");
 
     createDirs(rootsDir);
 }


### PR DESCRIPTION
It's still used for signing `narinfo` files if using Hydra as a binary cache server. See https://github.com/NixOS/hydra/blob/master/src/lib/Hydra/View/NARInfo.pm#L37