### PR TITLE
ldap: Use hashed passwords in the test

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,16 +52,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1599903709,
-        "narHash": "sha256-tinVKY7zRdSXmVOp7BAulNtIb2iP5nvNp5UAxihKXNI=",
+        "lastModified": 1602230526,
+        "narHash": "sha256-3/ucBPYg42P+1ji5/7q227Ek/Eq2C7zeiB9sZl5UpIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "252bfe0107587d40092057f338e9ffcf7bbd90cb",
+        "rev": "0b8799ecaaf0dc6b4c11583a3c96ca5b40fcfdfb",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-20.03",
+        "ref": "nixos-20.09",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A Nix-based continuous build system";
 
-  inputs.nixpkgs.url = "nixpkgs/nixos-20.03";
+  inputs.nixpkgs.url = "nixpkgs/nixos-20.09";
 
   outputs = { self, nixpkgs, nix }:
     let
@@ -162,7 +162,7 @@
 
           buildInputs =
             [ makeWrapper autoconf automake libtool unzip nukeReferences pkgconfig libpqxx
-              gitAndTools.topGit mercurial darcs subversion bazaar openssl bzip2 libxslt
+              gitAndTools.topGit mercurial darcs subversion breezy openssl bzip2 libxslt
               perlDeps perl final.nix
               boost
               postgresql_11
@@ -177,7 +177,7 @@
 
           hydraPath = lib.makeBinPath (
             [ subversion openssh final.nix coreutils findutils pixz
-              gzip bzip2 lzma gnutar unzip git gitAndTools.topGit mercurial darcs gnused bazaar
+              gzip bzip2 lzma gnutar unzip git gitAndTools.topGit mercurial darcs gnused breezy
             ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
 
           configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
@@ -202,6 +202,8 @@
           preCheck = ''
             patchShebangs .
             export LOGNAME=''${LOGNAME:-foo}
+            # set $HOME for bzr so it can create its trace file
+            export HOME=$(mktemp -d)
           '';
 
           postInstall = ''

--- a/flake.nix
+++ b/flake.nix
@@ -366,9 +366,14 @@
                 rootpw = "notapassword";
                 database = "bdb";
                 dataDir = "/var/lib/openldap";
+                extraConfig = ''
+                  moduleload pw-sha2
+                '';
                 extraDatabaseConfig = ''
                 '';
 
+                # userPassword generated via `slappasswd -o module-load=pw-sha2  -h '{SSHA256}'`
+                # The admin user has the password `password and `user` has the password `foobar`.
                 declarativeContents = ''
                   dn: dc=example
                   dc: example
@@ -401,7 +406,7 @@
                   sn: user
                   cn: user
                   mail: user@example
-                  userPassword: foobar
+                  userPassword: {SSHA256}B9rfUbNgv8nIGn1Hm5qbVQdv6AIQb012ORJwegqELB0DWCzoMCY+4A==
 
                   dn: cn=admin,ou=users,dc=example
                   objectClass: organizationalPerson
@@ -409,7 +414,7 @@
                   sn: admin
                   cn: admin
                   mail: admin@example
-                  userPassword: password
+                  userPassword: {SSHA256}meKP7fSWhkzXFC1f8RWRb8V8ssmN/VQJp7xJrUFFcNUDuwP1PbitMg==
                 '';
               };
               systemd.services.hdyra-server.environment.CATALYST_DEBUG = "1";


### PR DESCRIPTION
We should lead with good example and when users copy code from this repo
it should not incentivize them to use plain text passwords.

I also had to update to nixos-20.09-small as that allows us to use the pw-sha2 ldap module in the test (they were not being built in the 20.03 version of the expression).

The 20.09 upgrade requires us to use breezy and not `bazaar` as bazaar had been deprecated.