### PR TITLE
Remove Debug prints from GitLabStatus.pm

### DIFF
--- a/src/lib/Hydra/Plugin/GithubStatus.pm
+++ b/src/lib/Hydra/Plugin/GithubStatus.pm
@@ -37,7 +37,6 @@ sub common {
         my $ua = LWP::UserAgent->new();
 
         foreach my $conf (@config) {
-            print STDERR "GithubStatus_Debug job name $jobName\n";
             next unless $jobName =~ /^$conf->{jobs}$/;
             # Don't send out "pending" status updates if the build is already finished
             next if !$finished && $b->finished == 1;
@@ -70,7 +69,6 @@ sub common {
                     my $owner = $1;
                     my $repo = $2;
                     my $url = "https://api.github.com/repos/$owner/$repo/statuses/$rev";
-                    print STDERR "GithubStatus_Debug POSTing to '", $url, "'\n";
                     my $req = HTTP::Request->new('POST', $url);
                     $req->header('Content-Type' => 'application/json');
                     $req->header('Accept' => 'application/vnd.github.v3+json');


### PR DESCRIPTION
These make the hydra-queue-runner logs very noisy even when not using the GitlabStatus plugin.
Also, they shouldn't be necessary except when developing the plugin itself and should have been removed before release.