### PR TITLE
Support restarting components as admin

### DIFF
--- a/src/hydra-evaluator/hydra-evaluator.cc
+++ b/src/hydra-evaluator/hydra-evaluator.cc
@@ -355,6 +355,7 @@ struct Evaluator
                 receiver jobsetsAdded(*conn, "jobsets_added");
                 receiver jobsetsDeleted(*conn, "jobsets_deleted");
                 receiver jobsetsChanged(*conn, "jobset_scheduling_changed");
+                receiver kill(*conn, "kill_evaluator");
 
                 while (true) {
                     /* Note: we read/notify before
@@ -363,6 +364,10 @@ struct Evaluator
                     readJobsets();
                     maybeDoWork.notify_one();
                     conn->await_notification();
+                    if (kill.get()) {
+                        printMsg(lvlError, "got notification: kys");
+                        exit(1);
+                    }
                     printInfo("received jobset event");
                 }
 

--- a/src/hydra-queue-runner/queue-monitor.cc
+++ b/src/hydra-queue-runner/queue-monitor.cc
@@ -30,6 +30,7 @@ void State::queueMonitorLoop()
     receiver buildsDeleted(*conn, "builds_deleted");
     receiver buildsBumped(*conn, "builds_bumped");
     receiver jobsetSharesChanged(*conn, "jobset_shares_changed");
+    receiver kill(*conn, "kill_queue_runner");
 
     auto destStore = getDestStore();
 
@@ -66,6 +67,10 @@ void State::queueMonitorLoop()
         if (jobsetSharesChanged.get()) {
             printMsg(lvlTalkative, "got notification: jobset shares changed");
             processJobsetSharesChange(*conn);
+        }
+        if (kill.get()) {
+            printMsg(lvlError, "got notification: kys");
+            exit(1);
         }
     }
 

--- a/src/lib/Hydra/Controller/Admin.pm
+++ b/src/lib/Hydra/Controller/Admin.pm
@@ -58,6 +58,32 @@ sub clearvcscache : Chained('admin') PathPart('clear-vcs-cache') Args(0) {
     $c->res->redirect($c->request->referer // "/");
 }
 
+sub restart_queue_runner : Chained('admin') PathPart('restart-queue-runner') Args(0) {
+    my ($self, $c) = @_;
+    $c->model('DB')->storage->dbh->do("notify kill_queue_runner");
+    $c->flash->{successMsg} = "Queue runner was killed and should restart soon.";
+    $c->res->redirect($c->request->referer // "/");
+}
+
+sub restart_evaluator : Chained('admin') PathPart('restart-evaluator') Args(0) {
+    my ($self, $c) = @_;
+    $c->model('DB')->storage->dbh->do("notify kill_evaluator");
+    $c->flash->{successMsg} = "Evaluator was killed and should restart soon.";
+    $c->res->redirect($c->request->referer // "/");
+}
+
+sub restart_www : Chained('admin') PathPart('restart-www') Args(0) {
+    my ($self, $c) = @_;
+    print("was asked to kms\n");
+    exit 1;
+}
+
+sub restart_notify : Chained('admin') PathPart('restart-notify') Args(0) {
+    my ($self, $c) = @_;
+    $c->model('DB')->storage->dbh->do("notify kill_notify");
+    $c->flash->{successMsg} = "Notification daemon was killed and should restart soon.";
+    $c->res->redirect($c->request->referer // "/");
+}
 
 sub managenews : Chained('admin') PathPart('news') Args(0) {
     my ($self, $c) = @_;

--- a/src/root/topbar.tt
+++ b/src/root/topbar.tt
@@ -110,6 +110,27 @@
         title = "Clear VCS caches"
         confirmmsg = "Are you sure you want to clear the VCS cache?"
         class = "" %]
+      <div class="dropdown-divider"></div>
+      [% INCLUDE menuItem
+        uri = c.uri_for(c.controller('Admin').action_for('restart_queue_runner'))
+        title = "Kill Queue Runner"
+        confirmmsg = "Are you sure you want to restart the queue runner?"
+        class = "" %]
+      [% INCLUDE menuItem
+        uri = c.uri_for(c.controller('Admin').action_for('restart_evaluator'))
+        title = "Kill Evaluator"
+        confirmmsg = "Are you sure you want to restart the evaluator?"
+        class = "" %]
+      [% INCLUDE menuItem
+        uri = c.uri_for(c.controller('Admin').action_for('restart_www'))
+        title = "Kill Webserver"
+        confirmmsg = "Are you sure you want to restart the web server?"
+        class = "" %]
+      [% INCLUDE menuItem
+        uri = c.uri_for(c.controller('Admin').action_for('restart_notify'))
+        title = "Kill Notify"
+        confirmmsg = "Are you sure you want to restart the notify daemon?"
+        class = "" %]
       [% END %]
     [% END %]
   [% END %]

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -104,6 +104,7 @@ $listener->subscribe("eval_failed");
 $listener->subscribe("eval_started");
 $listener->subscribe("hydra_notify_dump_metrics");
 $listener->subscribe("step_finished");
+$listener->subscribe("kill_notify");
 
 
 # Process builds that finished while hydra-notify wasn't running.
@@ -130,6 +131,11 @@ while (!$queued_only) {
         my $payload = $message->{"payload"};
 
         $prom->inc("notify_event", { channel => $channelName });
+
+        if ($channelName eq "kill_notify") {
+            print("got notification: kys\n");
+            exit 1;
+        }
 
         if ($channelName eq "hydra_notify_dump_metrics") {
             print STDERR "Dumping prometheus metrics:\n${\$prom->format}\n";


### PR DESCRIPTION
It's tedious to always log in when one of the components hangs. Instead,
expose buttons for admins to kill each process, letting systemd restart
them (they all have Restart=always).