### PR TITLE
Add endpoint to generate a shields.io badge

### DIFF
--- a/hydra-api.yaml
+++ b/hydra-api.yaml
@@ -384,6 +384,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /job/{project-id}/{jobset-id}/{job-id}/shield:
+    get:
+      summary: Generate data for a shields.io badge
+      parameters:
+      - name: project-id
+        in: path
+        description: project identifier
+        required: true
+        schema:
+          type: string
+      - name: jobset-id
+        in: path
+        description: jobset identifier
+        required: true
+        schema:
+          type: string
+      - name: job-id
+        in: path
+        description: job identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: see <a href="https://shields.io/endpoint">https://shields.io/endpoint</a> on how to use this
+          content:
+            application/json:
+              examples:
+                shield-success:
+                  value:
+                    color: green
+                    schemaVersion: 1
+                    label: hydra build
+                    message: passing
+
   /build/{build-id}:
     get:
       summary: Retrieves a single build of a jobset by id


### PR DESCRIPTION
Closes #163

Here is an example using a hydra server that I host:


![Build status](https://img.shields.io/endpoint?url=https%3A%2F%2Fhydra.technicie.nl%2Fjob%2Fconcrexit%2Fmain%2Fconcrexit-release%2Fshield)

generated from this url: `https://img.shields.io/endpoint?url=https%3A%2F%2Fhydra.technicie.nl%2Fjob%2Fconcrexit%2Fmaster%2Fconcrexit-release%2Fshield`