### PR TITLE
Jobset -> JobsetEvals by JobsetEvals.jobset_id

### DIFF
--- a/src/hydra-evaluator/hydra-evaluator.cc
+++ b/src/hydra-evaluator/hydra-evaluator.cc
@@ -68,7 +68,9 @@ struct Evaluator
         pqxx::work txn(*conn);
 
         auto res = txn.exec
-            ("select project, j.name, lastCheckedTime, triggerTime, checkInterval, j.enabled as jobset_enabled from Jobsets j join Projects p on j.project = p.name "
+            ("select project, j.name, lastCheckedTime, triggerTime, checkInterval, j.enabled as jobset_enabled "
+             "from Jobsets j "
+             "join Projects p on j.project = p.name "
              "where j.enabled != 0 and p.enabled != 0");
 
 

--- a/src/hydra-evaluator/hydra-evaluator.cc
+++ b/src/hydra-evaluator/hydra-evaluator.cc
@@ -13,7 +13,7 @@
 
 using namespace nix;
 
-typedef std::pair<std::string, std::string> JobsetName;
+typedef std::pair<std::string, std::string> JobsetIdentity;
 
 enum class EvaluationStyle
 {
@@ -30,16 +30,16 @@ struct Evaluator
 
     struct Jobset
     {
-        JobsetName name;
+        JobsetIdentity name;
         std::optional<EvaluationStyle> evaluation_style;
         time_t lastCheckedTime, triggerTime;
         int checkInterval;
         Pid pid;
     };
 
-    typedef std::map<JobsetName, Jobset> Jobsets;
+    typedef std::map<JobsetIdentity, Jobset> Jobsets;
 
-    std::optional<JobsetName> evalOne;
+    std::optional<JobsetIdentity> evalOne;
 
     const size_t maxEvals;
 
@@ -76,10 +76,10 @@ struct Evaluator
 
         auto state(state_.lock());
 
-        std::set<JobsetName> seen;
+        std::set<JobsetIdentity> seen;
 
         for (auto const & row : res) {
-            auto name = JobsetName{row["project"].as<std::string>(), row["name"].as<std::string>()};
+            auto name = JobsetIdentity{row["project"].as<std::string>(), row["name"].as<std::string>()};
 
             if (evalOne && name != *evalOne) continue;
 
@@ -466,7 +466,7 @@ int main(int argc, char * * argv)
         else {
             if (!args.empty()) {
                 if (args.size() != 2) throw UsageError("Syntax: hydra-evaluator [<project> <jobset>]");
-                evaluator.evalOne = JobsetName(args[0], args[1]);
+                evaluator.evalOne = JobsetIdentity(args[0], args[1]);
             }
             evaluator.run();
         }

--- a/src/hydra-evaluator/hydra-evaluator.cc
+++ b/src/hydra-evaluator/hydra-evaluator.cc
@@ -13,9 +13,9 @@
 
 using namespace nix;
 
-typedef std::pair<std::string, std::string> JobsetSymbolicIdentity;
+typedef std::pair<std::string, std::string> JobsetName;
 
-class JobsetIdentity {
+class JobsetId {
     public:
 
     std::string project;
@@ -23,44 +23,44 @@ class JobsetIdentity {
     int id;
 
 
-    JobsetIdentity(const std::string& project, const std::string& jobset, const int id)
+    JobsetId(const std::string & project, const std::string & jobset, int id)
         : project{ project }, jobset{ jobset }, id{ id }
     {
     }
 
-    friend bool operator== (const JobsetIdentity &lhs, const JobsetIdentity &rhs);
-    friend bool operator!= (const JobsetIdentity &lhs, const JobsetIdentity &rhs);
-    friend bool operator< (const JobsetIdentity &lhs, const JobsetIdentity &rhs);
+    friend bool operator== (const JobsetId & lhs, const JobsetId & rhs);
+    friend bool operator!= (const JobsetId & lhs, const JobsetId & rhs);
+    friend bool operator< (const JobsetId & lhs, const JobsetId & rhs);
 
 
-    friend bool operator== (const JobsetIdentity &lhs, const JobsetSymbolicIdentity &rhs);
-    friend bool operator!= (const JobsetIdentity &lhs, const JobsetSymbolicIdentity &rhs);
+    friend bool operator== (const JobsetId & lhs, const JobsetName & rhs);
+    friend bool operator!= (const JobsetId & lhs, const JobsetName & rhs);
 
     std::string display() const {
         return str(format("%1%:%2% (jobset#%3%)") % project % jobset % id);
     }
 };
-bool operator==(const JobsetIdentity & lhs, const JobsetIdentity & rhs)
+bool operator==(const JobsetId & lhs, const JobsetId & rhs)
 {
     return lhs.id == rhs.id;
 }
 
-bool operator!=(const JobsetIdentity & lhs, const JobsetIdentity & rhs)
+bool operator!=(const JobsetId & lhs, const JobsetId & rhs)
 {
     return lhs.id != rhs.id;
 }
 
-bool operator<(const JobsetIdentity & lhs, const JobsetIdentity & rhs)
+bool operator<(const JobsetId & lhs, const JobsetId & rhs)
 {
     return lhs.id < rhs.id;
 }
 
-bool operator==(const JobsetIdentity & lhs, const JobsetSymbolicIdentity & rhs)
+bool operator==(const JobsetId & lhs, const JobsetName & rhs)
 {
     return lhs.project == rhs.first && lhs.jobset == rhs.second;
 }
 
-bool operator!=(const JobsetIdentity & lhs, const JobsetSymbolicIdentity & rhs)
+bool operator!=(const JobsetId & lhs, const JobsetName & rhs)
 {
     return ! (lhs == rhs);
 }
@@ -80,16 +80,16 @@ struct Evaluator
 
     struct Jobset
     {
-        JobsetIdentity name;
+        JobsetId name;
         std::optional<EvaluationStyle> evaluation_style;
         time_t lastCheckedTime, triggerTime;
         int checkInterval;
         Pid pid;
     };
 
-    typedef std::map<JobsetIdentity, Jobset> Jobsets;
+    typedef std::map<JobsetId, Jobset> Jobsets;
 
-    std::optional<JobsetSymbolicIdentity> evalOne;
+    std::optional<JobsetName> evalOne;
 
     const size_t maxEvals;
 
@@ -126,10 +126,10 @@ struct Evaluator
 
         auto state(state_.lock());
 
-        std::set<JobsetIdentity> seen;
+        std::set<JobsetId> seen;
 
         for (auto const & row : res) {
-            auto name = JobsetIdentity{row["project"].as<std::string>(), row["name"].as<std::string>(), row["id"].as<int>()};
+            auto name = JobsetId{row["project"].as<std::string>(), row["name"].as<std::string>(), row["id"].as<int>()};
 
             if (evalOne && name != *evalOne) continue;
 
@@ -511,7 +511,7 @@ int main(int argc, char * * argv)
         else {
             if (!args.empty()) {
                 if (args.size() != 2) throw UsageError("Syntax: hydra-evaluator [<project> <jobset>]");
-                evaluator.evalOne = JobsetSymbolicIdentity(args[0], args[1]);
+                evaluator.evalOne = JobsetName(args[0], args[1]);
             }
             evaluator.run();
         }

--- a/src/lib/Hydra/Controller/Admin.pm
+++ b/src/lib/Hydra/Controller/Admin.pm
@@ -34,7 +34,7 @@ sub machines : Chained('admin') PathPart('machines') Args(0) {
 sub clear_queue_non_current : Chained('admin') PathPart('clear-queue-non-current') Args(0) {
     my ($self, $c) = @_;
     my $builds = $c->model('DB::Builds')->search(
-        { id => { -in => \ "select id from Builds where id in ((select id from Builds where finished = 0) except (select build from JobsetEvalMembers where eval in (select max(id) from JobsetEvals where hasNewBuilds = 1 group by project, jobset)))" }
+        { id => { -in => \ "select id from Builds where id in ((select id from Builds where finished = 0) except (select build from JobsetEvalMembers where eval in (select max(id) from JobsetEvals where hasNewBuilds = 1 group by jobset_id)))" }
         });
     my $n = cancelBuilds($c->model('DB')->schema, $builds);
     $c->flash->{successMsg} = "$n builds have been cancelled.";

--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -16,8 +16,8 @@ sub evalChain : Chained('/') PathPart('eval') CaptureArgs(1) {
         or notFound($c, "Evaluation $evalId doesn't exist.");
 
     $c->stash->{eval} = $eval;
-    $c->stash->{project} = $eval->project;
     $c->stash->{jobset} = $eval->jobset;
+    $c->stash->{project} = $eval->jobset->project;
 }
 
 

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -219,7 +219,7 @@ sub getEvals {
     foreach my $curEval (@evals) {
 
         my ($prevEval) = $c->model('DB::JobsetEvals')->search(
-            { project => $curEval->get_column('project'), jobset => $curEval->get_column('jobset')
+            { jobset_id => $curEval->get_column('jobset_id')
             , hasnewbuilds => 1, id => { '<', $curEval->id } },
             { order_by => "id DESC", rows => 1 });
 

--- a/src/lib/Hydra/Schema/JobsetEvals.pm
+++ b/src/lib/Hydra/Schema/JobsetEvals.pm
@@ -42,15 +42,9 @@ __PACKAGE__->table("jobsetevals");
   is_nullable: 0
   sequence: 'jobsetevals_id_seq'
 
-=head2 project
+=head2 jobset_id
 
-  data_type: 'text'
-  is_foreign_key: 1
-  is_nullable: 0
-
-=head2 jobset
-
-  data_type: 'text'
+  data_type: 'integer'
   is_foreign_key: 1
   is_nullable: 0
 
@@ -124,10 +118,8 @@ __PACKAGE__->add_columns(
     is_nullable       => 0,
     sequence          => "jobsetevals_id_seq",
   },
-  "project",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
-  "jobset",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  "jobset_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "errormsg",
   { data_type => "text", is_nullable => 1 },
   "errortime",
@@ -179,8 +171,8 @@ Related object: L<Hydra::Schema::Jobsets>
 __PACKAGE__->belongs_to(
   "jobset",
   "Hydra::Schema::Jobsets",
-  { name => "jobset", project => "project" },
-  { is_deferrable => 0, on_delete => "CASCADE", on_update => "CASCADE" },
+  { id => "jobset_id" },
+  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
 );
 
 =head2 jobsetevalinputs
@@ -213,24 +205,9 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 project
 
-Type: belongs_to
-
-Related object: L<Hydra::Schema::Projects>
-
-=cut
-
-__PACKAGE__->belongs_to(
-  "project",
-  "Hydra::Schema::Projects",
-  { name => "project" },
-  { is_deferrable => 0, on_delete => "CASCADE", on_update => "CASCADE" },
-);
-
-
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:43:28
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VKQNG53wwdbO8p1CTdX+WA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:44:07
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OVxeYH+eoZZrAsAJ2/mAAA
 
 __PACKAGE__->has_many(
   "buildIds",

--- a/src/lib/Hydra/Schema/JobsetEvals.pm
+++ b/src/lib/Hydra/Schema/JobsetEvals.pm
@@ -89,16 +89,6 @@ __PACKAGE__->table("jobsetevals");
   data_type: 'text'
   is_nullable: 0
 
-=head2 nixexprinput
-
-  data_type: 'text'
-  is_nullable: 1
-
-=head2 nixexprpath
-
-  data_type: 'text'
-  is_nullable: 1
-
 =head2 nrbuilds
 
   data_type: 'integer'
@@ -110,6 +100,16 @@ __PACKAGE__->table("jobsetevals");
   is_nullable: 1
 
 =head2 flake
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 nixexprinput
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 nixexprpath
 
   data_type: 'text'
   is_nullable: 1
@@ -142,15 +142,15 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_nullable => 0 },
   "hash",
   { data_type => "text", is_nullable => 0 },
-  "nixexprinput",
-  { data_type => "text", is_nullable => 1 },
-  "nixexprpath",
-  { data_type => "text", is_nullable => 1 },
   "nrbuilds",
   { data_type => "integer", is_nullable => 1 },
   "nrsucceeded",
   { data_type => "integer", is_nullable => 1 },
   "flake",
+  { data_type => "text", is_nullable => 1 },
+  "nixexprinput",
+  { data_type => "text", is_nullable => 1 },
+  "nixexprpath",
   { data_type => "text", is_nullable => 1 },
 );
 
@@ -229,8 +229,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hdu+0WWo2363dVvImMKxdA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:43:28
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VKQNG53wwdbO8p1CTdX+WA
 
 __PACKAGE__->has_many(
   "buildIds",

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -301,10 +301,7 @@ Related object: L<Hydra::Schema::JobsetEvals>
 __PACKAGE__->has_many(
   "jobsetevals",
   "Hydra::Schema::JobsetEvals",
-  {
-    "foreign.jobset"  => "self.name",
-    "foreign.project" => "self.project",
-  },
+  { "foreign.jobset_id" => "self.id" },
   undef,
 );
 
@@ -375,8 +372,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:6P1qlC5oVSPRSgRBp6nmrw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:38:14
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:7XtIqrrGAIvReqly1kapog
 
 
 =head2 builds

--- a/src/lib/Hydra/Schema/Projects.pm
+++ b/src/lib/Hydra/Schema/Projects.pm
@@ -157,21 +157,6 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 jobsetevals
-
-Type: has_many
-
-Related object: L<Hydra::Schema::JobsetEvals>
-
-=cut
-
-__PACKAGE__->has_many(
-  "jobsetevals",
-  "Hydra::Schema::JobsetEvals",
-  { "foreign.project" => "self.name" },
-  undef,
-);
-
 =head2 jobsetrenames
 
 Type: has_many
@@ -258,8 +243,8 @@ Composing rels: L</projectmembers> -> username
 __PACKAGE__->many_to_many("usernames", "projectmembers", "username");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Ff5gJejFu+02b0lInobOoQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:38:14
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+4yWd9UjCyxxLZYDrVUAxA
 
 my %hint = (
     columns => [

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -463,7 +463,7 @@ BLOCK renderEvals %]
         <tr>
           <td><a class="row-link" href="[% link %]">[% eval.id %]</a></td>
           [% IF !jobset && !build %]
-            <td>[% INCLUDE renderFullJobsetName project=eval.get_column('project') jobset=eval.get_column('jobset') %]</td>
+            <td>[% INCLUDE renderFullJobsetName project=eval.jobset.project.name jobset=eval.jobset.name %]</td>
           [% END %]
           <td class="nowrap">[% INCLUDE renderRelativeDate timestamp = eval.timestamp %]</td>
           <td>

--- a/src/script/hydra-dev-server
+++ b/src/script/hydra-dev-server
@@ -5,6 +5,11 @@ BEGIN {
 }
 
 use Catalyst::ScriptRunner;
+
+STDOUT->autoflush();
+STDERR->autoflush(1);
+binmode STDERR, ":encoding(utf8)";
+
 Catalyst::ScriptRunner->run('Hydra', 'DevServer');
 
 1;

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -191,8 +191,11 @@ sub fetchInputEval {
         $eval = getLatestFinishedEval($jobset);
         die "jobset ‘$value’ does not have a finished evaluation\n" unless defined $eval;
     } elsif ($value =~ /^($projectNameRE):($jobsetNameRE):($jobNameRE)$/) {
+        my $jobset = $db->resultset('Jobsets')->find({ project => $1, name => $2 });
+        die "jobset ‘$1:$2’ does not exist\n" unless defined $jobset;
+
         $eval = $db->resultset('JobsetEvals')->find(
-            { project => $1, jobset => $2, hasnewbuilds => 1 },
+            { jobset_id => $jobset->id, hasnewbuilds => 1 },
             { order_by => "id DESC", rows => 1
             , where =>
                 \ [ # All builds in this jobset should be finished...

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -440,9 +440,7 @@ create table SystemTypes (
 
 create table JobsetEvals (
     id            serial primary key not null,
-
-    project       text not null,
-    jobset        text not null,
+    jobset_id     integer not null,
 
     errorMsg      text, -- error output from the evaluator
     errorTime     integer, -- timestamp associated with errorMsg
@@ -473,8 +471,7 @@ create table JobsetEvals (
     nixExprInput  text, -- name of the jobsetInput containing the Nix or Guix expression
     nixExprPath   text, -- relative path of the Nix or Guix expression
 
-    foreign key   (project) references Projects(name) on delete cascade on update cascade,
-    foreign key   (project, jobset) references Jobsets(project, name) on delete cascade on update cascade
+    foreign key   (jobset_id) references Jobsets(id) on delete cascade
 );
 
 
@@ -629,7 +626,8 @@ create index IndexBuildOutputsPath on BuildOutputs using hash(path);
 create index IndexBuildsOnKeep on Builds(keep) where keep = 1;
 
 -- To get the most recent eval for a jobset.
-create index IndexJobsetEvalsOnJobsetId on JobsetEvals(project, jobset, id desc) where hasNewBuilds = 1;
+create index IndexJobsetEvalsOnJobsetId on JobsetEvals(jobset_id, id desc) where hasNewBuilds = 1;
+create index IndexJobsetIdEvals on JobsetEvals(jobset_id) where hasNewBuilds = 1;
 
 create index IndexBuildsOnNotificationPendingSince on Builds(notificationPendingSince) where notificationPendingSince is not null;
 

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -1,3 +1,14 @@
+-- Making a database change:
+--
+-- 1. Update this schema document to match what the end result should be.
+--
+-- 2. Run `make -C src/sql update-dbix hydra-postgresql.sql` in the root
+--    of the project directory, and git add / git commit the changed,
+--    generated files.
+--
+-- 3. Create a migration in this same directory, named `upgrade-N.sql`
+--
+
 -- Singleton table to keep track of the schema version.
 create table SchemaVersion (
     version       integer not null

--- a/src/sql/update-dbix-harness.sh
+++ b/src/sql/update-dbix-harness.sh
@@ -1,24 +1,26 @@
 #!/usr/bin/env bash
 
+set -eux
+
 readonly scratch=$(mktemp -d -t tmp.XXXXXXXXXX)
 
 readonly socket=$scratch/socket
 readonly data=$scratch/data
 readonly dbname=hydra-update-dbix
 
-function finish {
-    set +e
-    pg_ctl -D "$data" \
-           -o "-F -h '' -k \"$socket\"" \
-           -w stop -m immediate
+function finish() {
+       set +e
+       pg_ctl -D "$data" \
+              -o "-F -h '' -k \"$socket\"" \
+              -w stop -m immediate
 
-    if [ -f "$data/postmaster.pid" ]; then
-        pg_ctl -D "$data" \
-               -o "-F -h '' -k \"$socket\"" \
-               -w kill TERM "$(cat "$data/postmaster.pid")"
-    fi
+       if [ -f "$data/postmaster.pid" ]; then
+              pg_ctl -D "$data" \
+                     -o "-F -h '' -k \"$socket\"" \
+                     -w kill TERM "$(cat "$data/postmaster.pid")"
+       fi
 
-    rm -rf "$scratch"
+       rm -rf "$scratch"
 }
 trap finish EXIT
 
@@ -33,8 +35,11 @@ pg_ctl -D "$data" \
 
 createdb -h "$socket" "$dbname"
 
-psql -h "$socket" "$dbname" -f ./hydra.sql
+psql --host "$socket" \
+       --set ON_ERROR_STOP=1 \
+       --file ./hydra.sql \
+       "$dbname"
 
 perl -I ../lib \
-     -MDBIx::Class::Schema::Loader=make_schema_at,dump_to_dir:../lib \
-     update-dbix.pl "dbi:Pg:dbname=$dbname;host=$socket"
+       -MDBIx::Class::Schema::Loader=make_schema_at,dump_to_dir:../lib \
+       update-dbix.pl "dbi:Pg:dbname=$dbname;host=$socket"

--- a/src/sql/upgrade-72.sql
+++ b/src/sql/upgrade-72.sql
@@ -1,0 +1,22 @@
+
+ALTER TABLE JobsetEvals
+  ADD COLUMN jobset_id integer NULL,
+  ADD FOREIGN KEY (jobset_id)
+      REFERENCES Jobsets(id)
+      ON DELETE CASCADE;
+
+UPDATE JobsetEvals
+  SET jobset_id = (
+    SELECT jobsets.id
+    FROM jobsets
+    WHERE jobsets.name = JobsetEvals.jobset
+      AND jobsets.project = JobsetEvals.project
+  );
+
+
+ALTER TABLE JobsetEvals
+  ALTER COLUMN jobset_id SET NOT NULL,
+  DROP COLUMN jobset,
+  DROP COLUMN project;
+
+create index IndexJobsetIdEvals on JobsetEvals(jobset_id) where hasNewBuilds = 1;


### PR DESCRIPTION
Instead of referring to the jobset by its project's name and the jobset's name, refer to it by a jobset_id.

* I added a little in-line notes about how to write database migrations.
* I fixed a problem where the `make` for updating the schema libraries would succeed even if the SQL was invalid.
* I fixed a minor problem where hydra-dev-server was buffering output to stderr/stdout
* The C++ in hydra-evaluator feels a bit heavy on boilerplate, but it seemed like a good way to go. I'm open to doing something different. I wrote this in a few separate commits to make it easier for me to grok.
* The perl patches were surprisingly short and easy. I clicked around, ran the tests, ran some evaluations and builds