### PR TITLE
search: limit results to 50, default to 10

### DIFF
--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -13,6 +13,7 @@ use Nix::Config;
 use Encode;
 use File::Basename;
 use JSON;
+use List::Util qw[min max];
 use List::MoreUtils qw{any};
 use Net::Prometheus;
 
@@ -438,12 +439,8 @@ sub search :Local Args(0) {
     error($c, "Invalid character in query.")
         unless $query =~ /^[a-zA-Z0-9_\-\/.]+$/;
 
-    my $limit = trim $c->request->params->{"limit"};
-    if ($limit eq "") {
-        $c->stash->{limit} = 500;
-    } else {
-        $c->stash->{limit} = $limit;
-    }
+    my $limit = int(trim ($c->request->params->{"limit"} || "10"));
+    $c->stash->{limit} = min(50, max(1, $limit));
 
     $c->stash->{projects} = [ $c->model('DB::Projects')->search(
         { -and =>


### PR DESCRIPTION
This search query is pretty heavy. Defaulting to 500 has caused
Hydra's web UI to appear to be down. Since 500 can take it down, users
probably shouldn't be allowed t ask for that many.