### PR TITLE
Fix check in jobsets

### DIFF
--- a/src/sql/upgrade-74.sql
+++ b/src/sql/upgrade-74.sql
@@ -1,0 +1,9 @@
+alter table Jobsets add constraint jobsets_type_known_check   check (type = 0 or type = 1);
+alter table Jobsets add constraint jobsets_legacy_paths_check check ((type = 0) = (nixExprInput is not null and nixExprPath is not null and flake is     null));
+alter table Jobsets add constraint jobsets_flake_paths_check  check ((type = 1) = (nixExprInput is     null and nixExprPath is     null and flake is not null));
+alter table Jobsets add constraint jobsets_schedulingshares_nonzero_check check (schedulingShares > 0);
+
+alter table Jobsets drop constraint if exists jobsets_schedulingshares_check;
+alter table Jobsets drop constraint if exists jobsets_check;
+alter table Jobsets drop constraint if exists jobsets_check1;
+alter table Jobsets drop constraint if exists jobsets_check2;


### PR DESCRIPTION
The current check happening in jobsets is incorrect.
The wanted constraint is stated as follow :
- If type is 0 (legacy), then the flake field should be null, and both nixExprInput and nixExprPath should be non-null
- If type is 1 (flake), then the flake field should be non-null, and both nixExprInput and nixExprPath should be null

The current version will not catch (i.e. it will accept) situations
where you have for instance :
```
type = 1, nixExprPath null, nixExprInput non-null, flake non-null
```

This commit fixes that.

I split(ted) that into two constraints, to make it more readable and
easier to extend if a new type appears in the future.

The complete query could be instead :
```
( type = 0
  AND nixExprInput IS NOT NULL AND nixExprPath IS NOT NULL AND flake IS NULL )
OR ( type = 1
  AND nixExprInput IS NULL AND nixExprPath IS NULL AND flake IS NOT NULL )
```

(but an "OR" cannot be split, hence the other formulation)

At the meantime I statically named the checks, because otherwise it’s impossible to guess their name (in case we need to update them later)

cc @grahamc 