### PR TITLE
Fix transition from declarative non-flake to flake jobset

### DIFF
--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -49,6 +49,18 @@ sub updateDeclarativeJobset {
         $update{$key} = $declSpec->{$key};
         delete $declSpec->{$key};
     }
+    # Ensure jobset constraints are met, only have nixexpr{path,input} or
+    # flakes set if the type is 0 or 1 respectively. So in the update we need
+    # to null the field of the other type.
+    if (defined $update{type}) {
+        if ($update{type} == 0) {
+            $update{flake} = undef;
+        } elsif ($update{type} == 1) {
+            $update{nixexprpath} = undef;
+            $update{nixexprinput} = undef;
+        }
+    }
+
     $db->txn_do(sub {
         my $jobset = $project->jobsets->update_or_create(\%update);
         $jobset->jobsetinputs->delete;


### PR DESCRIPTION
The database has these constraints (or improved ones with #856):

```sql
check ((type = 0) = (nixExprInput is not null and nixExprPath is not null)),
check ((type = 1) = (flake is not null)),
```

which prevented switching to flakes in a declarative jobspec, since the
`nixexpr{path,input}` fields were not nulled in such an update.

This commit explicitly `null`'s the fields that are needed for the specific `type`.

I have verified that this change allows switching a declarative jobset from non-flakes to flakes.

Ping @grahamc, he helped writing this fix