### PR TITLE
Fix login if Hydra runs behind HTTP proxy with sub-path location

### DIFF
--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -76,8 +76,8 @@ sub begin :Private {
 
     # XSRF protection: require POST requests to have the same origin.
     if ($c->req->method eq "POST" && $c->req->path ne "api/push-github") {
-        my $referer = $c->req->header('Origin');
-        $referer //= $c->req->header('Referer');
+        my $referer = $c->req->header('Referer');
+        $referer //= $c->req->header('Origin');
         my $base = $c->req->base;
         die unless $base =~ /\/$/;
         $referer .= "/";


### PR DESCRIPTION
The used HTTP proxy is nginx.