### PR TITLE
Fix build with the latest Nix master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,32 +1,15 @@
 {
   "nodes": {
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1598695561,
-        "narHash": "sha256-gyH/5j+h/nWw0W8AcR2WKvNBUsiQ7QuxqSJNXAwV+8E=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "1705b4a26fbf065d9574dce47a94e8c7c79e052f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
-        "lowdown-src": "lowdown-src",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1605715425,
-        "narHash": "sha256-h4VEpxnPBoUigXeoy0/8z8jUFKkJD9XG5dR/lt/rQCk=",
+        "lastModified": 1614031855,
+        "narHash": "sha256-mN4GIcilBoUXqpFwx5RA3lsi3iMbzSvJ/W/MXVOpv3c=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "79aa7d95183cbe6c0d786965f0dbff414fd1aa67",
+        "rev": "35205e2e922952fc0654260a07fc3191c5afc2cc",
         "type": "github"
       },
       "original": {

--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -38,15 +38,6 @@ struct MyArgs : MixEvalArgs, MixCommonArgs
     MyArgs() : MixCommonArgs("hydra-eval-jobs")
     {
         addFlag({
-            .longName = "help",
-            .description = "show usage information",
-            .handler = {[&]() {
-                printHelp(programName, std::cout);
-                throw Exit();
-            }}
-        });
-
-        addFlag({
             .longName = "gc-roots-dir",
             .description = "garbage collector roots directory",
             .labels = {"path"},

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -96,8 +96,10 @@ void State::parseMachines(const std::string & contents)
         machine->sshName = tokens[0];
         machine->systemTypes = tokenizeString<StringSet>(tokens[1], ",");
         machine->sshKey = tokens[2] == "-" ? string("") : tokens[2];
-        if (tokens[3] != "")
-            string2Int(tokens[3], machine->maxJobs);
+        if (tokens[3] != "") {
+          if (auto maxJobs = string2Int<unsigned int>(tokens[3]))
+              machine->maxJobs = *maxJobs;
+        }
         else
             machine->maxJobs = 1;
         machine->speedFactor = atof(tokens[4].c_str());
@@ -862,7 +864,9 @@ int main(int argc, char * * argv)
             else if (*arg == "--status")
                 status = true;
             else if (*arg == "--build-one") {
-                if (!string2Int<BuildID>(getArg(*arg, arg, end), buildOne))
+                if (auto maybeBuildOne = string2Int<BuildID>(getArg(*arg, arg, end)))
+                    buildOne = *maybeBuildOne;
+                else
                     throw Error("‘--build-one’ requires a build ID");
             } else
                 return false;


### PR DESCRIPTION
Fix the build to adjust to some breaking changes in Nix master:

- string2Int now has a slightly different signature
- The printHelp function doesn't exist anymore.

Note that this removes the --help of hydra-eval-jobs.
That doesn't seem too bad given that most hydra commands don't have such a flag, but ideally we should probably migrate it to use the same autogenerated manpages as Nix now uses.
