### PR TITLE
tests: replace the flat list of contexts with a hash

### DIFF
--- a/tests/build-products.t
+++ b/tests/build-products.t
@@ -2,7 +2,7 @@ use strict;
 use Cwd;
 use Setup;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;

--- a/tests/build-products.t
+++ b/tests/build-products.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 
 my %ctx = test_init();

--- a/tests/build-products.t
+++ b/tests/build-products.t
@@ -15,7 +15,7 @@ hydra_setup($db);
 
 # Test build products
 
-my $jobset = createBaseJobset("build-products", "build-products.nix");
+my $jobset = createBaseJobset("build-products", "build-products.nix", $ctx{jobsdir});
 
 ok(evalSucceeds($jobset),               "Evaluating jobs/build-products.nix should exit with return code 0");
 is(nrQueuedBuildsForJobset($jobset), 2, "Evaluating jobs/build-products.nix should result in 2 builds");

--- a/tests/evaluate-basic.t
+++ b/tests/evaluate-basic.t
@@ -16,7 +16,7 @@ hydra_setup($db);
 my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
 
 # Most basic test case, no parameters
-my $jobset = createBaseJobset("basic", "basic.nix");
+my $jobset = createBaseJobset("basic", "basic.nix", $ctx{jobsdir});
 
 ok(evalSucceeds($jobset),               "Evaluating jobs/basic.nix should exit with return code 0");
 is(nrQueuedBuildsForJobset($jobset), 3, "Evaluating jobs/basic.nix should result in 3 builds");

--- a/tests/evaluate-basic.t
+++ b/tests/evaluate-basic.t
@@ -1,6 +1,5 @@
 use feature 'unicode_strings';
 use strict;
-use Cwd;
 use Setup;
 
 my %ctx = test_init();

--- a/tests/evaluate-basic.t
+++ b/tests/evaluate-basic.t
@@ -3,7 +3,7 @@ use strict;
 use Cwd;
 use Setup;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;

--- a/tests/evaluate-dependent-jobsets.t
+++ b/tests/evaluate-dependent-jobsets.t
@@ -2,7 +2,7 @@ use strict;
 use Cwd;
 use Setup;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;

--- a/tests/evaluate-dependent-jobsets.t
+++ b/tests/evaluate-dependent-jobsets.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 
 my %ctx = test_init();

--- a/tests/evaluate-dependent-jobsets.t
+++ b/tests/evaluate-dependent-jobsets.t
@@ -13,7 +13,7 @@ my $db = Hydra::Model::DB->new;
 hydra_setup($db);
 
 # Test jobset with 2 jobs, one has parameter of succeeded build of the other
-my $jobset = createJobsetWithOneInput("build-output-as-input", "build-output-as-input.nix", "build1", "build", "build1");
+my $jobset = createJobsetWithOneInput("build-output-as-input", "build-output-as-input.nix", "build1", "build", "build1", $ctx{jobsdir});
 
 ok(evalSucceeds($jobset), "Evaluating jobs/build-output-as-input.nix should exit with return code 0");
 is(nrQueuedBuildsForJobset($jobset), 1 , "Evaluation should result in 1 build in queue");

--- a/tests/input-types/bzr-checkout.t
+++ b/tests/input-types/bzr-checkout.t
@@ -3,7 +3,7 @@ use Cwd;
 use Setup;
 use TestScmInput;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;
@@ -21,8 +21,9 @@ testScmInput(
   update => 'jobs/bzr-checkout-update.sh',
 
   # directories
-  datadir => $datadir,
-  testdir => getcwd,
+  datadir => $ctx{tmpdir},
+  testdir => $ctx{testdir},
+  jobsdir => $ctx{jobsdir},
 );
 
 done_testing;

--- a/tests/input-types/bzr-checkout.t
+++ b/tests/input-types/bzr-checkout.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 use TestScmInput;
 

--- a/tests/input-types/bzr.t
+++ b/tests/input-types/bzr.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 use TestScmInput;
 

--- a/tests/input-types/bzr.t
+++ b/tests/input-types/bzr.t
@@ -3,7 +3,7 @@ use Cwd;
 use Setup;
 use TestScmInput;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;
@@ -21,8 +21,9 @@ testScmInput(
   update => 'jobs/bzr-update.sh',
 
   # directories
-  datadir => $datadir,
-  testdir => getcwd,
+  datadir => $ctx{tmpdir},
+  testdir => $ctx{testdir},
+  jobsdir => $ctx{jobsdir},
 );
 
 done_testing;

--- a/tests/input-types/darcs.t
+++ b/tests/input-types/darcs.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 use TestScmInput;
 

--- a/tests/input-types/darcs.t
+++ b/tests/input-types/darcs.t
@@ -3,7 +3,7 @@ use Cwd;
 use Setup;
 use TestScmInput;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;
@@ -21,8 +21,9 @@ testScmInput(
   update => 'jobs/darcs-update.sh',
 
   # directories
-  datadir => $datadir,
-  testdir => getcwd,
+  datadir => $ctx{tmpdir},
+  testdir => $ctx{testdir},
+  jobsdir => $ctx{jobsdir},
 );
 
 done_testing;

--- a/tests/input-types/deepgit.t
+++ b/tests/input-types/deepgit.t
@@ -3,7 +3,7 @@ use Cwd;
 use Setup;
 use TestScmInput;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;
@@ -22,8 +22,9 @@ testScmInput(
   update => 'jobs/git-update.sh',
 
   # directories
-  datadir => $datadir,
-  testdir => getcwd,
+  datadir => $ctx{tmpdir},
+  testdir => $ctx{testdir},
+  jobsdir => $ctx{jobsdir},
 );
 
 done_testing;

--- a/tests/input-types/deepgit.t
+++ b/tests/input-types/deepgit.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 use TestScmInput;
 

--- a/tests/input-types/git-rev.t
+++ b/tests/input-types/git-rev.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 use TestScmInput;
 

--- a/tests/input-types/git-rev.t
+++ b/tests/input-types/git-rev.t
@@ -3,7 +3,7 @@ use Cwd;
 use Setup;
 use TestScmInput;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;
@@ -22,8 +22,9 @@ testScmInput(
   update => 'jobs/git-rev-update.sh',
 
   # directories
-  datadir => $datadir,
-  testdir => getcwd,
+  datadir => $ctx{tmpdir},
+  testdir => $ctx{testdir},
+  jobsdir => $ctx{jobsdir},
 );
 
 done_testing;

--- a/tests/input-types/git.t
+++ b/tests/input-types/git.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 use TestScmInput;
 

--- a/tests/input-types/git.t
+++ b/tests/input-types/git.t
@@ -3,7 +3,7 @@ use Cwd;
 use Setup;
 use TestScmInput;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;
@@ -21,8 +21,9 @@ testScmInput(
   update => 'jobs/git-update.sh',
 
   # directories
-  datadir => $datadir,
-  testdir => getcwd,
+  datadir => $ctx{tmpdir},
+  testdir => $ctx{testdir},
+  jobsdir => $ctx{jobsdir},
 );
 
 done_testing;

--- a/tests/input-types/hg.t
+++ b/tests/input-types/hg.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 use TestScmInput;
 

--- a/tests/input-types/hg.t
+++ b/tests/input-types/hg.t
@@ -3,7 +3,7 @@ use Cwd;
 use Setup;
 use TestScmInput;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;
@@ -21,8 +21,9 @@ testScmInput(
   update => 'jobs/hg-update.sh',
 
   # directories
-  datadir => $datadir,
-  testdir => getcwd,
+  datadir => $ctx{tmpdir},
+  testdir => $ctx{testdir},
+  jobsdir => $ctx{jobsdir},
 );
 
 done_testing;

--- a/tests/input-types/svn-checkout.t
+++ b/tests/input-types/svn-checkout.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 use TestScmInput;
 

--- a/tests/input-types/svn-checkout.t
+++ b/tests/input-types/svn-checkout.t
@@ -3,7 +3,7 @@ use Cwd;
 use Setup;
 use TestScmInput;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;
@@ -21,8 +21,9 @@ testScmInput(
   update => 'jobs/svn-checkout-update.sh',
 
   # directories
-  datadir => $datadir,
-  testdir => getcwd,
+  datadir => $ctx{tmpdir},
+  testdir => $ctx{testdir},
+  jobsdir => $ctx{jobsdir},
 );
 
 done_testing;

--- a/tests/input-types/svn.t
+++ b/tests/input-types/svn.t
@@ -1,5 +1,4 @@
 use strict;
-use Cwd;
 use Setup;
 use TestScmInput;
 

--- a/tests/input-types/svn.t
+++ b/tests/input-types/svn.t
@@ -3,7 +3,7 @@ use Cwd;
 use Setup;
 use TestScmInput;
 
-(my $datadir, my $pgsql) = test_init();
+my %ctx = test_init();
 
 require Hydra::Schema;
 require Hydra::Model::DB;
@@ -21,8 +21,9 @@ testScmInput(
   update => 'jobs/svn-update.sh',
 
   # directories
-  datadir => $datadir,
-  testdir => getcwd,
+  datadir => $ctx{tmpdir},
+  testdir => $ctx{testdir},
+  jobsdir => $ctx{jobsdir},
 );
 
 done_testing;

--- a/tests/lib/Setup.pm
+++ b/tests/lib/Setup.pm
@@ -62,7 +62,10 @@ sub test_init {
     );
     $ENV{'HYDRA_DBI'} = $pgsql->dsn;
     system("hydra-init") == 0 or die;
-    return ($dir, $pgsql);
+    return (
+        tmpdir => $dir,
+        db => $pgsql
+    );
 }
 
 sub captureStdoutStderr {

--- a/tests/lib/TestScmInput.pm
+++ b/tests/lib/TestScmInput.pm
@@ -36,6 +36,7 @@ sub testScmInput {
   # Get directories
   my $testdir = $args{testdir} // die "required arg 'testdir' missing";
   my $datadir = $args{datadir} // die "required arg 'datadir' missing";
+  my $jobsdir = $args{jobsdir} // die "required arg 'jobsdir' missing";
 
   my $update = $args{update} // die "required arg 'update' missing";
   $update = "$testdir/$update";
@@ -49,7 +50,7 @@ sub testScmInput {
   $uri = "file://$scratchdir/$uri";
 
   subtest "With the SCM input named $name" => sub {
-    my $jobset = createJobsetWithOneInput($name, $expr, 'src', $type, $uri);
+    my $jobset = createJobsetWithOneInput($name, $expr, 'src', $type, $uri, $jobsdir);
 
     my ($mutations, $queueSize) = (0, 0);
 

--- a/tests/plugins/runcommand.t
+++ b/tests/plugins/runcommand.t
@@ -1,7 +1,6 @@
 use feature 'unicode_strings';
 use strict;
 use warnings;
-use Cwd;
 use JSON;
 use Setup;
 

--- a/tests/plugins/runcommand.t
+++ b/tests/plugins/runcommand.t
@@ -5,7 +5,7 @@ use Cwd;
 use JSON;
 use Setup;
 
-(my $datadir, my $pgsql) = test_init(
+my %ctx = test_init(
     hydra_config => q|
     <runcommand>
       command = cp "$HYDRA_JSON" "$HYDRA_DATA/joboutput.json"

--- a/tests/plugins/runcommand.t
+++ b/tests/plugins/runcommand.t
@@ -23,7 +23,7 @@ hydra_setup($db);
 my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
 
 # Most basic test case, no parameters
-my $jobset = createBaseJobset("basic", "runcommand.nix");
+my $jobset = createBaseJobset("basic", "runcommand.nix", $ctx{jobsdir});
 
 ok(evalSucceeds($jobset), "Evaluating jobs/runcommand.nix should exit with return code 0");
 is(nrQueuedBuildsForJobset($jobset), 1, "Evaluating jobs/runcommand.nix should result in 1 build1");


### PR DESCRIPTION
This way we can return more values without breaking callers.

---

Also add `jobsdir` and `testdir` to the ctx hash.