### PR TITLE
hydra-queue-runner: --build-one: correctly handle a cached build

### DIFF
--- a/src/hydra-queue-runner/dispatcher.cc
+++ b/src/hydra-queue-runner/dispatcher.cc
@@ -374,7 +374,6 @@ void State::abortUnsupported()
             if (!build) build = *dependents.begin();
 
             bool stepFinished = false;
-            bool quit = false;
 
             failStep(
                 *conn, step, build->id,
@@ -385,9 +384,9 @@ void State::abortUnsupported()
                     .startTime = now2,
                     .stopTime = now2,
                 },
-                nullptr, stepFinished, quit);
+                nullptr, stepFinished);
 
-            if (quit) exit(1);
+            if (buildOneDone) exit(1);
         }
     }
 

--- a/src/hydra-queue-runner/state.hh
+++ b/src/hydra-queue-runner/state.hh
@@ -367,6 +367,7 @@ private:
 
     /* Specific build to do for --build-one (testing only). */
     BuildID buildOne;
+    bool buildOneDone = false;
 
     /* Statistics per machine type for the Hydra auto-scaler. */
     struct MachineType
@@ -485,8 +486,7 @@ private:
         BuildID buildId,
         const RemoteResult & result,
         Machine::ptr machine,
-        bool & stepFinished,
-        bool & quit);
+        bool & stepFinished);
 
     Jobset::ptr createJobset(pqxx::work & txn,
         const std::string & projectName, const std::string & jobsetName);


### PR DESCRIPTION
Previously, the already-done, cached, build ID would never flow through channels which
exited.

This patch tracks the buildOne state as part of State and exits avoids
waiting forever for new work.

The code around buildOnly is a bit rough, making this a bit weird to
implement but since it is only used for testing the value of improving
it on its own is a bit questionable.