### PR TITLE
User Roles: make checkboxes

### DIFF
--- a/src/root/user.tt
+++ b/src/root/user.tt
@@ -2,17 +2,23 @@
 [% PROCESS common.tt %]
 
 [% BLOCK roleoption %]
-  <option value="[% role %]"
-    [% checked = false %]
-    [% FOREACH r IN user.userroles %]
-      [% checked = r.role == role %]
-      [% BREAK IF checked %]
-    [% END %]
+  [% checked = false %]
+  [% FOREACH r IN user.userroles %]
+    [% checked = r.role == role %]
+    [% BREAK IF checked %]
+  [% END %]
+  <input
+    type="checkbox"
+    name="roles"
     [% IF checked %]
-      selected="selected"
+      checked="checked"
     [% END %]
-    >[% role %]</option>
-[% END %]
+    [% IF !mutable %]
+      disabled="disabled"
+    [% END %]
+    [% HTML.attributes(id => "role-${role}", value => role) %] />
+  <label [% HTML.attributes(for => "role-${role}") %]> [% role %]</label><br />
+  [% END %]
 
 <form>
 
@@ -70,16 +76,22 @@
   </div>
 
   [% IF !create || c.check_user_roles('admin') %]
-    <div class="form-group row">
-      <label class="col-sm-3">Roles</label>
-      <div class="col-sm-9">
-        <select multiple="multiple" name="roles" class="form-control" [% IF !c.check_user_roles('admin') %]disabled="disabled"[% END %]>
-          [% INCLUDE roleoption role="admin" %]
-          [% INCLUDE roleoption role="create-projects" %]
-          [% INCLUDE roleoption role="restart-jobs" %]
-          [% INCLUDE roleoption role="bump-to-front" %]
-          [% INCLUDE roleoption role="cancel-build" %]
-        </select>
+    [% mutable = c.check_user_roles('admin') %]
+    <div class="form-group row card [% mutable ? "border-danger" : "border-light" %]">
+      <div class="card-header">User Roles</div>
+      <div class="card-body [% mutable ? "text-danger" : "" %]">
+        [% IF mutable %]
+          <h5 class="card-title">Take care, you're allowed to change [% HTML.escape(user.fullname || user.emailaddress || "this user") %]'s roles.</h5>
+        [% ELSE %]
+          <h5 class="card-title">[% HTML.escape(user.fullname || user.emailaddress || "this user") %]'s roles.</h5>
+        [% END %]
+        <p class="card-text">
+          [% INCLUDE roleoption mutable=mutable role="admin" %]
+          [% INCLUDE roleoption mutable=mutable role="create-projects" %]
+          [% INCLUDE roleoption mutable=mutable role="restart-jobs" %]
+          [% INCLUDE roleoption mutable=mutable role="bump-to-front" %]
+          [% INCLUDE roleoption mutable=mutable role="cancel-build" %]
+        </p>
       </div>
     </div>
   [% END %]
@@ -115,7 +127,6 @@
       Delete this user
     </button>
   [% END %]
-
 </form>
 
 <script>


### PR DESCRIPTION
A user thought they had admin access because "admin" appeared in their list of roles. They had *no* special roles, so they didn't know the deselected ones were ones they didn't have.

This PR (built on top of #677; will rebase when that merges) changes the multi select to checkboxes. This change made the "admin" checkbox close visually and distance closer to the "public dashboard" tickbox. A bit scary. So, this PR also made the role checkboxes more separate.

Thanks to @samueldr for help on this.

For admins:

![image](https://user-images.githubusercontent.com/76716/113238492-6d37f480-9298-11eb-99cb-53b7b81bd76f.png)

For regular users:
![image](https://user-images.githubusercontent.com/76716/113238525-7a54e380-9298-11eb-8a44-8f20b495702f.png)
