### PR TITLE
meta.outputsToInstall: store and propogate

### DIFF
--- a/src/lib/Hydra/Base/Controller/ListBuilds.pm
+++ b/src/lib/Hydra/Base/Controller/ListBuilds.pm
@@ -38,7 +38,7 @@ sub nix : Chained('get_builds') PathPart('channel/latest') CaptureArgs(0) {
     $c->stash->{channelName} = $c->stash->{channelBaseName} . "-latest";
     $c->stash->{channelBuilds} = $c->stash->{latestSucceeded}
         ->search_literal("exists (select 1 from buildproducts where build = me.id and type = 'nix-build')")
-        ->search({}, { columns => [@buildListColumns, 'drvpath', 'description', 'homepage']
+        ->search({}, { columns => [@buildListColumns, 'drvpath', 'description', 'homepage', 'outputstoinstall']
                      , join => ["buildoutputs"]
                      , order_by => ["me.id", "buildoutputs.name"]
                      , '+select' => ['buildoutputs.path', 'buildoutputs.name'], '+as' => ['outpath', 'outname'] });

--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -65,6 +65,12 @@ sub build_GET {
     my $build = $c->stash->{build};
 
     $c->stash->{template} = 'build.tt';
+    if ($build->outputstoinstall) {
+        $c->stash->{outputsToInstall} = decode_json $build->outputstoinstall;
+    } else {
+        $c->stash->{outputsToInstall} = [];
+    }
+
     $c->stash->{isLocalStore} = isLocalStore();
     $c->stash->{available} =
         $c->stash->{isLocalStore}

--- a/src/lib/Hydra/Plugin/RunCommand.pm
+++ b/src/lib/Hydra/Plugin/RunCommand.pm
@@ -76,6 +76,7 @@ sub buildFinished {
                 homepage => $build->get_column('homepage'),
                 description => $build->get_column('description'),
                 license => $build->get_column('license'),
+                outputsToInstall => decode_json($build->get_column('outputstoinstall')),
                 outputs => [],
                 products => [],
                 metrics => [],

--- a/src/lib/Hydra/Schema/Builds.pm
+++ b/src/lib/Hydra/Schema/Builds.pm
@@ -110,6 +110,11 @@ __PACKAGE__->table("builds");
   data_type: 'text'
   is_nullable: 1
 
+=head2 outputstoinstall
+
+  data_type: 'jsonb'
+  is_nullable: 1
+
 =head2 maxsilent
 
   data_type: 'integer'
@@ -228,6 +233,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "maintainers",
   { data_type => "text", is_nullable => 1 },
+  "outputstoinstall",
+  { data_type => "jsonb", is_nullable => 1 },
   "maxsilent",
   { data_type => "integer", default_value => 3600, is_nullable => 1 },
   "timeout",
@@ -528,8 +535,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Df5N0EByYJqoSUqA0dld/A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-02-02 16:49:21
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:F3VjMvX+DndC9mCgOaMO5g
 
 __PACKAGE__->has_many(
   "dependents",

--- a/src/lib/Hydra/View/NixExprs.pm
+++ b/src/lib/Hydra/View/NixExprs.pm
@@ -8,8 +8,7 @@ use Hydra::Helper::AttributeSet;
 use Archive::Tar;
 use IO::Compress::Bzip2 qw(bzip2);
 use Encode;
-use Data::Dumper;
-
+use JSON::PP;
 
 sub process {
     my ($self, $c) = @_;
@@ -76,6 +75,12 @@ EOF
                 if $build->license;
             $res .= "      maintainers = ${\escapeString $build->maintainers};\n"
                 if $build->maintainers;
+            if ($build->outputstoinstall) {
+                $res .= "      outputsToInstall = [ ";
+                $res .= join " ", map escape($_), @{decode_json $build->outputstoinstall};
+                $res .= "];\n"
+            }
+
             $res .= "    };\n";
             $res .= "  } {\n";
             my @outputNames = sort (keys %{$pkg->{outputs}});

--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -370,6 +370,10 @@ END;
         <td>[% IF build.maintainers %][% HTML.escape(build.maintainers) %][% ELSE %]<em>not given</em>[% END %]</td>
       </tr>
       <tr>
+        <th>Outputs to install:</th>
+        <td>[% IF build.outputstoinstall %]<tt>[% HTML.escape(build.outputstoinstall) %]</tt>[% ELSE %]<em>not given</em>[% END %]</td>
+      </tr>
+      <tr>
         <th>System:</th>
         <td><tt>[% build.system %]</tt></td>
       </tr>

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -451,6 +451,11 @@ sub checkBuild {
             return $s eq "" ? undef : $s;
         }
 
+        my $outputstoinstall = undef;
+        if ($buildInfo->{outputsToInstall}) {
+            $outputstoinstall = encode_json $buildInfo->{outputsToInstall};
+        }
+
         # Add the build to the database.
         $build = $jobset->builds->create(
             { timestamp => $time
@@ -462,6 +467,7 @@ sub checkBuild {
             , license => null($buildInfo->{license})
             , homepage => null($buildInfo->{homepage})
             , maintainers => null($buildInfo->{maintainers})
+            , outputstoinstall => $outputstoinstall
             , maxsilent => $buildInfo->{maxSilent}
             , timeout => $buildInfo->{timeout}
             , nixname => $buildInfo->{nixName}

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -172,6 +172,7 @@ create table Builds (
     license       text, -- meta.license
     homepage      text, -- meta.homepage
     maintainers   text, -- meta.maintainers (concatenated, comma-separated)
+    outputsToInstall jsonb, -- meta.outputsToInstall
     maxsilent     integer default 3600, -- meta.maxsilent
     timeout       integer default 36000, -- meta.timeout
 

--- a/src/sql/upgrade-75.sql
+++ b/src/sql/upgrade-75.sql
@@ -1,0 +1,1 @@
+alter table Builds add column outputsToInstall jsonb;

--- a/t/Controller/Jobset/channel.t
+++ b/t/Controller/Jobset/channel.t
@@ -18,45 +18,51 @@ Catalyst::Test->import('Hydra');
 my $db = Hydra::Model::DB->new;
 hydra_setup($db);
 
-my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+subtest "Nested attributes generate valid Nix expressions" => sub {
+    # Most basic test case, no parameters
+    my $jobset = createBaseJobset("nested-attributes", "nested-attributes.nix", $ctx{jobsdir});
 
-# Most basic test case, no parameters
-my $jobset = createBaseJobset("nested-attributes", "nested-attributes.nix", $ctx{jobsdir});
+    subtest "Evaluating and building the jobset succeeds" => sub {
+        ok(evalSucceeds($jobset));
+        is(nrQueuedBuildsForJobset($jobset), 4);
 
-ok(evalSucceeds($jobset));
-is(nrQueuedBuildsForJobset($jobset), 4);
+        for my $build (queuedBuildsForJobset($jobset)) {
+            ok(runBuild($build), "Build '".$build->job."' should exit with code 0");
+            my $newbuild = $db->resultset('Builds')->find($build->id);
+            is($newbuild->finished, 1, "Build '".$build->job."' should be finished.");
+            is($newbuild->buildstatus, 0, "Build '".$build->job."' should have buildstatus 0.");
+        }
+    };
 
-for my $build (queuedBuildsForJobset($jobset)) {
-    ok(runBuild($build), "Build '".$build->job."' should exit with code 0");
-    my $newbuild = $db->resultset('Builds')->find($build->id);
-    is($newbuild->finished, 1, "Build '".$build->job."' should be finished.");
-    is($newbuild->buildstatus, 0, "Build '".$build->job."' should have buildstatus 0.");
-}
 
-my $compressed = get('/jobset/tests/nested-attributes/channel/latest/nixexprs.tar.bz2');
-my $tarcontent;
-bunzip2(\$compressed => \$tarcontent);
-open(my $tarfh, "<", \$tarcontent);
-my $tar = Archive::Tar->new($tarfh);
+    # Fetch and extract the channel
+    my $compressed = get('/jobset/tests/nested-attributes/channel/latest/nixexprs.tar.bz2');
+    my $tarcontent;
+    bunzip2(\$compressed => \$tarcontent);
+    open(my $tarfh, "<", \$tarcontent);
+    my $tar = Archive::Tar->new($tarfh);
 
-my $defaultnix = $ctx{"tmpdir"} . "/channel-default.nix";
-$tar->extract_file("channel/default.nix", $defaultnix);
+    my $defaultnix = $ctx{"tmpdir"} . "/channel-default.nix";
+    $tar->extract_file("channel/default.nix", $defaultnix);
 
-print STDERR $tar->get_content("channel/default.nix");
+    print STDERR $tar->get_content("channel/default.nix");
 
-(my $status, my $stdout, my $stderr) = Hydra::Helper::Nix::captureStdoutStderr(5, "nix-env", "--json", "--query", "--available", "--attr-path", "--file", $defaultnix);
-is($stderr, "", "Stderr should be empty");
-is($status, 0, "Querying the packages should succeed");
+    subtest "nix-env processes the nested attribute sets, finding nested packages" => sub {
+        (my $status, my $stdout, my $stderr) = Hydra::Helper::Nix::captureStdoutStderr(5, "nix-env", "--json", "--query", "--available", "--attr-path", "--file", $defaultnix);
+        is($stderr, "", "Stderr should be empty");
+        is($status, 0, "Querying the packages should succeed");
 
-my $packages = decode_json($stdout);
-my $keys = [sort keys %$packages];
-is($keys, [
-    "packageset-nested",
-    "packageset.deeper.deeper.nested",
-    "packageset.nested",
-    "packageset.nested2",
-]);
-is($packages->{"packageset-nested"}->{"name"}, "actually-top-level");
-is($packages->{"packageset.nested"}->{"name"}, "actually-nested");
+        my $packages = decode_json($stdout);
+        my $keys = [sort keys %$packages];
+        is($keys, [
+            "packageset-nested",
+            "packageset.deeper.deeper.nested",
+            "packageset.nested",
+            "packageset.nested2",
+        ]);
+        is($packages->{"packageset-nested"}->{"name"}, "actually-top-level");
+        is($packages->{"packageset.nested"}->{"name"}, "actually-nested");
+    };
+};
 
 done_testing;

--- a/t/Controller/Jobset/channel.t
+++ b/t/Controller/Jobset/channel.t
@@ -65,4 +65,14 @@ subtest "Nested attributes generate valid Nix expressions" => sub {
     };
 };
 
+subtest 'Outputs To Install are present in the channel data' => sub {
+    my $jobset = createBaseJobset("outputs-to-install", "outputs-to-install.nix",, $ctx{jobsdir});
+    ok(evalSucceeds($jobset), "Evaluating jobs/outputs-to-install.nix should exit with return code 0");
+    my $build = $jobset->builds->find({job => "example"});
+    isnt($build, undef, "Our build was created.");
+
+    my $outputstoinstall = $build->get_column("outputstoinstall");
+    is(decode_json($outputstoinstall), [ "out", "installed" ], "Outputs to install include out and installed");
+};
+
 done_testing;

--- a/t/jobs/outputs-to-install.nix
+++ b/t/jobs/outputs-to-install.nix
@@ -1,0 +1,21 @@
+with import ./config.nix;
+{
+  example = (mkDerivation {
+    name = "example";
+    builder = "/bin/sh";
+    outputs = [ "out" "installed" "notinstalled" ];
+    args = [
+      (
+        builtins.toFile "builder.sh" ''
+          #! /bin/sh
+
+          mkdir $out $installed $notinstalled
+        ''
+      )
+    ];
+  }) // {
+    meta = {
+      outputsToInstall = [ "out" "installed" ];
+    };
+  };
+}

--- a/t/jobs/runcommand.nix
+++ b/t/jobs/runcommand.nix
@@ -25,6 +25,7 @@ with import ./config.nix;
     }
   ) // {
     meta = {
+      outputsToInstall = [ "bin" ];
       license = "GPL";
       description = "An example meta property.";
       homepage = "https://github.com/NixOS/hydra";

--- a/t/plugins/runcommand.t
+++ b/t/plugins/runcommand.t
@@ -40,7 +40,7 @@ ok(sendNotifications(), "Notifications execute successfully.");
 my $dat = do {
     my $filename = $ENV{'HYDRA_DATA'} . "/joboutput.json";
     open(my $json_fh, "<", $filename)
-        or die("Can't open \$filename\": $!\n");
+        or die("Can't open $filename\": $!\n");
     local $/;
     my $json = JSON->new;
     $json->decode(<$json_fh>)
@@ -66,6 +66,7 @@ subtest "Validate the top level fields match" => sub {
     is($dat->{homepage}, "https://github.com/NixOS/hydra", "The homepage is passed.");
     is($dat->{description}, "An example meta property.", "The description is passed.");
     is($dat->{license}, "GPL", "The license is passed.");
+    is($dat->{outputsToInstall}, ["bin"], "The list of outputs to install are passed.");
 };
 
 subtest "Validate the outputs match" => sub {


### PR DESCRIPTION
Allow RunCommand to access the outputs to install, and propagate the fake expressions to the generated Nix channel.