### PR TITLE
Fix `std::bad_alloc` errors for remote builds

### DIFF
--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -338,6 +338,9 @@ void State::buildRemote(ref<Store> destStore,
                 result.stopTime = stop;
             }
         }
+        if (GET_PROTOCOL_MINOR(remoteVersion) >= 6) {
+            worker_proto::read(*localStore, from, Phantom<DrvOutputs> {});
+        }
         switch ((BuildResult::Status) res) {
             case BuildResult::Built:
                 result.stepStatus = bsSuccess;


### PR DESCRIPTION
In Nix the protocol was slightly altered[1] to also contain more
information about realisations. This however wasn't read from the pipe
that was used to read from the store.

After the `cmdBuildDerivation` command which caused this issue, Hydra
will issue a `cmdQueryPathInfos` that tries to read from the remote
store as well. However, there's still left over to read from the
previous command and thus Nix fails to properly allocate the expected
string.

[1] See rev a2b69660a9b326b95d48bd222993c5225bbd5b5f

Fixes #898


cc @regnat @edolstra @grahamc 