### PR TITLE
hydra-queue-runner: fix building on machines specified with the `ssh-ng` protocol

### DIFF
--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -54,7 +54,13 @@ static void openConnection(Machine::ptr machine, Path tmpDir, int stderrFD, Chil
         }
         else {
             pgmName = "ssh";
-            argv = {"ssh", machine->sshName};
+            auto sshName = machine->sshName;
+            std::string prefix = "ssh-ng://";
+            size_t pos = sshName.find(prefix);
+            if (pos != std::string::npos) {
+                sshName.erase(pos, prefix.length());
+            }
+            argv = {"ssh", sshName};
             if (machine->sshKey != "") append(argv, {"-i", machine->sshKey});
             if (machine->sshPublicHostKey != "") {
                 Path fileName = tmpDir + "/host-key";


### PR DESCRIPTION
Most of my machines in `/etc/nix/machines` are specified as
`ssh-ng://foobar` where `foobar` is defined in e.g. `~/.ssh/config`. The
problem here is that while it's possible to use the remote Nix
installation via SSH, `hydra-queue-runner` refuses to do so since `ssh(1)`
can't resolve hostnames that begin with `ssh-ng://`.

To work around this problem, this prefix will be drop if it exists on a
machine declaration that was chosen for a build step.

cc @grahamc @edolstra 