### PR TITLE
Allow specifying jobset inputs for flake builds for Hydra plugins

### DIFF
--- a/src/lib/Hydra/Controller/Jobset.pm
+++ b/src/lib/Hydra/Controller/Jobset.pm
@@ -285,26 +285,24 @@ sub updateJobset {
     # Set the inputs of this jobset.
     $jobset->jobsetinputs->delete;
 
-    if ($type == 0) {
-        foreach my $name (keys %{$c->stash->{params}->{inputs}}) {
-            my $inputData = $c->stash->{params}->{inputs}->{$name};
-            my $type = $inputData->{type};
-            my $value = $inputData->{value};
-            my $emailresponsible = defined $inputData->{emailresponsible} ? 1 : 0;
-            my $types = knownInputTypes($c);
+    foreach my $name (keys %{$c->stash->{params}->{inputs}}) {
+        my $inputData = $c->stash->{params}->{inputs}->{$name};
+        my $type = $inputData->{type};
+        my $value = $inputData->{value};
+        my $emailresponsible = defined $inputData->{emailresponsible} ? 1 : 0;
+        my $types = knownInputTypes($c);
 
-            badRequest($c, "Invalid input name ‘$name’.") unless $name =~ /^[[:alpha:]][\w-]*$/;
-            badRequest($c, "Invalid input type ‘$type’; valid types: $types.") unless defined $c->stash->{inputTypes}->{$type};
+        badRequest($c, "Invalid input name ‘$name’.") unless $name =~ /^[[:alpha:]][\w-]*$/;
+        badRequest($c, "Invalid input type ‘$type’; valid types: $types.") unless defined $c->stash->{inputTypes}->{$type};
 
-            my $input = $jobset->jobsetinputs->create(
-                { name => $name,
-                  type => $type,
-                  emailresponsible => $emailresponsible
-                });
+        my $input = $jobset->jobsetinputs->create(
+            { name => $name,
+              type => $type,
+              emailresponsible => $emailresponsible
+            });
 
-            $value = checkInputValue($c, $name, $type, $value);
-            $input->jobsetinputalts->create({altnr => 0, value => $value});
-        }
+        $value = checkInputValue($c, $name, $type, $value);
+        $input->jobsetinputalts->create({altnr => 0, value => $value});
     }
 }
 

--- a/src/root/edit-jobset.tt
+++ b/src/root/edit-jobset.tt
@@ -42,7 +42,15 @@
 [% END %]
 
 [% BLOCK renderJobsetInputs %]
-  <table class="table table-striped table-condensed show-on-legacy">
+  <div class="card show-on-flake border-danger">
+    <div class="text-danger card-body">
+      <h5 class="card-title">Jobset Inputs don't take any effect for flakes</h5>
+      <p class="card-text">
+        These are only available to configure Hydra plugins.
+      </p>
+    </div>
+  </div>
+  <table class="table table-striped table-condensed">
     <thead>
       <tr><th></th><th>Input name</th><th>Type</th><th style="width: 50%">Value</th><th>Notify committers</th></tr>
     </thead>


### PR DESCRIPTION
It seems to be a common pattern to configure Hydra plugins on a
per-jobset basis with jobset inputs. Since these are not needed anymore
for flakes, it's also not possible anymore to use plugins for flake
jobsets.

This patch changes this and adds a warning to avoid confusion. In the
future, we may want to restrict jobset inputs for flakes to string
values only.

cc @grahamc 