### PR TITLE
hydra-api: hidden -> visible

### DIFF
--- a/hydra-api.yaml
+++ b/hydra-api.yaml
@@ -175,7 +175,7 @@ paths:
                 enabled:
                   description: when set to true the project gets scheduled for evaluation
                   type: boolean
-                hidden:
+                visible:
                   description: when set to true the project is displayed in the web interface
                   type: boolean
       responses:


### PR DESCRIPTION
The PUT API doesn't accept `hidden` (even though the GET API responds with it).

---

See: https://github.com/NixOS/hydra/issues/930.

A better fix would be to unify these, but I'll leave that for another day. Let's just fix the spec file to reflect the current API.