### PR TITLE
hydra-api: add missing `name` property

### DIFF
--- a/hydra-api.yaml
+++ b/hydra-api.yaml
@@ -160,8 +160,11 @@ paths:
             schema:
               type: object
               properties:
-                displayname:
+                name:
                   description: name of the project
+                  type: string
+                displayname:
+                  description: display name of the project
                   type: string
                 description:
                   description: description of the project


### PR DESCRIPTION
The Hydra website allows you to change the name of a Project, so it only makes
sense for the API to expose this functionality as well.