### PR TITLE
Run the tests with a remote dest store

### DIFF
--- a/t/Controller/Jobset/channel.t
+++ b/t/Controller/Jobset/channel.t
@@ -5,7 +5,9 @@ use IO::Uncompress::Bunzip2 qw(bunzip2);
 use Archive::Tar;
 use JSON qw(decode_json);
 use Data::Dumper;
-my %ctx = test_init();
+my %ctx = test_init(
+  use_external_destination_store => 0
+);
 
 require Hydra::Schema;
 require Hydra::Model::DB;

--- a/t/lib/Setup.pm
+++ b/t/lib/Setup.pm
@@ -20,6 +20,9 @@ our @EXPORT = qw(test_init hydra_setup nrBuildsForJobset queuedBuildsForJobset
 #
 #  * hydra_config: configuration for the Hydra processes for your test.
 #  * nix_config: text to include in the test's nix.conf
+#  * use_external_destination_store: Boolean indicating whether hydra should
+#       use a destination store different from the evaluation store.
+#       True by default.
 #
 # This clears several environment variables and sets them to ephemeral
 # values: a temporary database, temporary Nix store, temporary Hydra

--- a/t/lib/Setup.pm
+++ b/t/lib/Setup.pm
@@ -54,6 +54,7 @@ sub test_init {
     $ENV{'HYDRA_CONFIG'} = "$dir/hydra.conf";
 
     open(my $fh, '>', $ENV{'HYDRA_CONFIG'}) or die "Could not open file '" . $ENV{'HYDRA_CONFIG'}. " $!";
+    print $fh "store_uri = file:$dir/nix/dest-store\n";
     print $fh $opts{'hydra_config'} || "";
     close $fh;
 

--- a/t/lib/Setup.pm
+++ b/t/lib/Setup.pm
@@ -54,7 +54,9 @@ sub test_init {
     $ENV{'HYDRA_CONFIG'} = "$dir/hydra.conf";
 
     open(my $fh, '>', $ENV{'HYDRA_CONFIG'}) or die "Could not open file '" . $ENV{'HYDRA_CONFIG'}. " $!";
-    print $fh "store_uri = file:$dir/nix/dest-store\n";
+    if ($opts{'use_external_destination_store'} // 1) {
+        print $fh "store_uri = file:$dir/nix/dest-store\n"
+    }
     print $fh $opts{'hydra_config'} || "";
     close $fh;
 


### PR DESCRIPTION
Set `dest_store` in the test hydra config, so that the testsuite ensures
that the distinction between the local store and the destination store
is properly taken into account.

Fix #938

This currently causes the `channel.t` test to fail − [this call](https://github.com/NixOS/hydra/blob/019aef3d419b03266f7a137300b54bcfa167350e/t/Controller/Jobset/channel.t#L36) returns a 404.
I'm not sure whether this is an issue with the test or hydra itself (I've no idea how the channels feature works). @grahamc do you have an idea as the author of the test?
