### PR TITLE
Properly report hash mismatches

### DIFF
--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -387,8 +387,6 @@ void State::buildRemote(ref<Store> destStore,
         }
         if (result.stepStatus != bsSuccess) return;
 
-        result.errorMsg = "";
-
         /* If the path was substituted or already valid, then we didn't
            get a build log. */
         if (result.isCached) {

--- a/src/hydra-queue-runner/builder.cc
+++ b/src/hydra-queue-runner/builder.cc
@@ -228,11 +228,6 @@ State::StepResult State::doBuildStep(nix::ref<Store> destStore,
     time_t stepStopTime = time(0);
     if (!result.stopTime) result.stopTime = stepStopTime;
 
-    /* For standard failures, we don't care about the error
-       message. */
-    if (result.stepStatus != bsAborted)
-        result.errorMsg = "";
-
     /* Account the time we spent building this step by dividing it
        among the jobsets that depend on it. */
     {

--- a/t/jobs/fixed-output.nix
+++ b/t/jobs/fixed-output.nix
@@ -1,0 +1,19 @@
+with import ./config.nix;
+{
+  fixed_output = mkDerivation {
+    name = "fixed-output";
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-INobAY6wP6WMUdr0Wr2CsEpdJbu46nX55BYSDmvSkas=";
+    builder = ./name-builder.sh;
+  };
+
+  fixed_output_bad_hash = mkDerivation {
+    name = "wrong-hash";
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-ANobAY6wP6WMUdr0Wr2CsEpdJbu46nX55BYSDmvSkas=";
+    builder = ./name-builder.sh;
+  };
+}
+

--- a/t/jobs/name-builder.sh
+++ b/t/jobs/name-builder.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+mkdir -p $out
+echo $name > $out/myName

--- a/t/queue-runner/fixed-output-derivations.t
+++ b/t/queue-runner/fixed-output-derivations.t
@@ -1,0 +1,48 @@
+use feature 'unicode_strings';
+use strict;
+use Setup;
+
+my %ctx = test_init();
+
+require Hydra::Schema;
+require Hydra::Model::DB;
+
+use Test2::V0;
+
+my $db = Hydra::Model::DB->new;
+hydra_setup($db);
+
+my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+
+my $nixSource = "fixed-output.nix";
+
+my $jobset = createBaseJobset("fixed-output", $nixSource, $ctx{jobsdir});
+
+ok(evalSucceeds($jobset),               "Evaluating jobs/".$nixSource." should exit with return code 0");
+is(nrQueuedBuildsForJobset($jobset), 2, "Evaluating jobs/".$nixSource." should result in 2 builds");
+
+my @builds = queuedBuildsForJobset($jobset);
+
+subtest "valid fixed-output derivation" => sub {
+    my ($build) = grep { $_->nixname eq "fixed-output" } @builds;
+    ok(runBuild($build), "Build should exit with code 0");
+
+    my $newbuild = $db->resultset('Builds')->find($build->id);
+    is($newbuild->finished, 1, "Build should be finished.");
+    is($newbuild->buildstatus, 0, "Build should have buildstatus 0.");
+};
+
+subtest "fixed-output derivation with a wrong hash" => sub {
+    my ($build) = grep { $_->nixname eq "wrong-hash" } @builds;
+    ok(runBuild($build), "Build should exit with code 0");
+
+    my $newbuild = $db->resultset('Builds')->find($build->id);
+    is($newbuild->finished, 1, "Build should be finished.");
+    is($newbuild->buildstatus, 1, "Build should have buildstatus 1.");
+
+    my $latestBuildStep = ($newbuild->buildsteps)[0];
+    like($latestBuildStep->errormsg, qr/hash mismatch/, "The hash mismatch should be properly reported");
+};
+
+done_testing;
+


### PR DESCRIPTION
Fix #947

I’m not utterly sure what the implications of not setting `errorMsg` to the empty string are. Removing it seems like the right thing to do, but maybe I’m missing something
