### PR TITLE
lazy tabs: trigger the load event

### DIFF
--- a/src/root/static/js/common.js
+++ b/src/root/static/js/common.js
@@ -60,6 +60,7 @@ $(document).ready(function() {
 
     /* Activates tab according to URL anchor. */
     if (window.location.hash) {
+        setTimeout(function () { $('.nav-tabs > .nav-item:not(.dropdown) a[href="' + window.location.hash + '"]').trigger('show.bs.tab'); }, 0);
         $('.nav-tabs > .nav-item:not(.dropdown) a[href="' + window.location.hash + '"]').tab('show');
     }
 


### PR DESCRIPTION
Something in the upgrade of Bootstrap and JQuery broke lazy tab loading.
I don't understand what is providing the tab behavior, how it should
work, or what the correct fix is.

I can tell you that this patch fixes the issue: when loading a tab
with a URL fragment deep-linking to a lazily loaded tab... it now
loads.

Close #959