### PR TITLE
Jobsets: remove defunct Jobs relationship

### DIFF
--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -392,21 +392,6 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 jobs
-
-Type: has_many
-
-Related object: L<Hydra::Schema::Jobs>
-
-=cut
-
-__PACKAGE__->has_many(
-  "jobs",
-  "Hydra::Schema::Jobs",
-  { "foreign.jobset_id" => "self.id" },
-  undef,
-);
-
 __PACKAGE__->add_column(
     "+id" => { retrieve_on_insert => 1 }
 );


### PR DESCRIPTION
It appears the Jobs table was removed in
8adb433e3b48638f3faaecc61ae5cb63efefff6e, but the Jobsets schema was never
updated to reflect this. This relationship was added in
efa1f1d4fbdc468c61f7403e8709d0295e052c7f, roughly 3 months prior.

Previously, one would see a message similar to the following logged when
deleting a jobset:

    17:38:23 hydra-server.1       | DBIx::Class::Relationship::CascadeActions::delete(): Skipping cascade delete on relationship 'jobs' - related resultsource 'Hydra::Schema::Jobs' is not registered with this schema at /home/vin/workspace/vcs/hydra/src/script/../lib/Hydra/Controller/Jobset.pm line 106