### PR TITLE
Projects: don't respond with unnecessary declarative field

### DIFF
--- a/src/lib/Hydra/Schema/Projects.pm
+++ b/src/lib/Hydra/Schema/Projects.pm
@@ -263,14 +263,18 @@ sub as_json {
         "enabled" => $self->get_column("enabled") ? JSON::true : JSON::false,
         "hidden" => $self->get_column("hidden") ? JSON::true : JSON::false,
 
+        "jobsets" => [ map { $_->name } $self->jobsets ]
+    );
+
+    my %decl = (
         "declarative" => {
             "file" => $self->get_column("declfile") // "",
             "type" => $self->get_column("decltype") // "",
             "value" => $self->get_column("declvalue") // ""
-        },
-
-        "jobsets" => [ map { $_->name } $self->jobsets ]
+        }
     );
+
+    %json = (%json, %decl) if !($decl{"declarative"}->{"file"} eq "");
 
     return \%json;
 }

--- a/t/Controller/projects.t
+++ b/t/Controller/projects.t
@@ -49,12 +49,7 @@ subtest "Read project 'tests'" => sub {
         homepage => "",
         jobsets => [],
         name => "tests",
-        owner => "root",
-        declarative => {
-            file => "",
-            type => "",
-            value => ""
-        }
+        owner => "root"
     });
 };
 
@@ -136,12 +131,7 @@ subtest "Transitioning from declarative project to normal" => sub {
             homepage => "",
             jobsets => [],
             name => "tests",
-            owner => "root",
-            declarative => {
-                file => "",
-                type => "",
-                value => ""
-            }
+            owner => "root"
         });
     };
 };


### PR DESCRIPTION
If the project isn't declarative, who cares about it in the response? After
setting the `declfile` to an empty string, everything related to declarative-
ness is wiped out, anyways.

```
$ curl 'http://0:63333/project/ofborg' -H 'accept: application/json' | jq
{
  "hidden": false,
  "description": "grahamcofborg automation",
  "jobsets": [],
  "name": "ofborg",
  "owner": "alice",
  "displayname": "ofborg",
  "enabled": true,
  "homepage": "https://github.com/grahamc/ofborg"
}

$ curl 'http://0:63333/project/nixpkgs-declarative' -H 'accept: application/json' | jq
{
  "jobsets": [
    ".jobsets"
  ],
  "description": "Nix Packages collection",
  "name": "nixpkgs-declarative",
  "owner": "alice",
  "homepage": "https://nixos.org/nixpkgs",
  "displayname": "Nixpkgs",
  "enabled": false,
  "declarative": {
    "value": "https://github.com/DeterminateSystems/hydra-examples.git main",
    "type": "git",
    "file": "static-declarative-project/declarative.json"
  },
  "hidden": false
}
```