### PR TITLE
/build/ID/evals: fix after #860

### DIFF
--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -558,7 +558,7 @@ sub evals : Chained('buildChain') PathPart('evals') Args(0) {
     $c->stash->{page} = $page;
     $c->stash->{resultsPerPage} = $resultsPerPage;
     $c->stash->{total} = $evals->search({hasnewbuilds => 1})->count;
-    $c->stash->{evals} = getEvals($self, $c, $evals, ($page - 1) * $resultsPerPage, $resultsPerPage)
+    $c->stash->{evals} = getEvals($c, $evals, ($page - 1) * $resultsPerPage, $resultsPerPage)
 }
 
 

--- a/src/lib/Hydra/Controller/Jobset.pm
+++ b/src/lib/Hydra/Controller/Jobset.pm
@@ -41,7 +41,7 @@ sub jobset_GET {
 
     $c->stash->{template} = 'jobset.tt';
 
-    $c->stash->{evals} = getEvals($self, $c, scalar $c->stash->{jobset}->jobsetevals, 0, 10);
+    $c->stash->{evals} = getEvals($c, scalar $c->stash->{jobset}->jobsetevals, 0, 10);
 
     $c->stash->{latestEval} = $c->stash->{jobset}->jobsetevals->search({ hasnewbuilds => 1 }, { rows => 1, order_by => ["id desc"] })->single;
 
@@ -337,7 +337,7 @@ sub evals_GET {
     $c->stash->{resultsPerPage} = $resultsPerPage;
     $c->stash->{total} = $evals->search({hasnewbuilds => 1})->count;
     my $offset = ($page - 1) * $resultsPerPage;
-    $c->stash->{evals} = getEvals($self, $c, $evals, $offset, $resultsPerPage);
+    $c->stash->{evals} = getEvals($c, $evals, $offset, $resultsPerPage);
     my %entity = (
         evals => [ map { $_->{eval} } @{$c->stash->{evals}} ],
         first => "?page=1",

--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -398,7 +398,7 @@ sub evals :Local Args(0) {
     $c->stash->{page} = $page;
     $c->stash->{resultsPerPage} = $resultsPerPage;
     $c->stash->{total} = $evals->search({hasnewbuilds => 1})->count;
-    $c->stash->{evals} = getEvals($self, $c, $evals, ($page - 1) * $resultsPerPage, $resultsPerPage);
+    $c->stash->{evals} = getEvals($c, $evals, ($page - 1) * $resultsPerPage, $resultsPerPage);
 
     $self->status_ok($c, entity => $c->stash->{evals});
 }

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -223,12 +223,39 @@ sub getEvalInfo {
 }
 
 
+=head2 getEvals
+
+This method returns a list of evaluations with details about what changed,
+intended to be used with `eval.tt`.
+
+Arguments:
+
+=over 4
+
+=item C<$c>
+L<Hydra> - the entire application.
+
+=item C<$evals_result_set>
+
+A L<DBIx::Class::ResultSet> for the result class of L<Hydra::Model::DB::JobsetEvals>
+
+=item C<$offset>
+
+Integer offset when selecting evaluations
+
+=item C<$rows>
+
+Integer rows to fetch
+
+=back
+
+=cut
 sub getEvals {
-    my ($self, $c, $evals_query_builder, $offset, $rows) = @_;
+    my ($c, $evals_result_set, $offset, $rows) = @_;
 
-    my $me = $evals_query_builder->current_source_alias;
+    my $me = $evals_result_set->current_source_alias;
 
-    my @evals = $evals_query_builder->search(
+    my @evals = $evals_result_set->search(
         { hasnewbuilds => 1 },
         { order_by => "$me.id DESC", rows => $rows, offset => $offset
         , prefetch => { evaluationerror => [ ] } });

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -226,10 +226,12 @@ sub getEvalInfo {
 sub getEvals {
     my ($self, $c, $evals, $offset, $rows) = @_;
 
+    my $me = $evals->current_source_alias;
+
     my @evals = $evals->search(
         { hasnewbuilds => 1 },
-        { order_by => "me.id DESC", rows => $rows, offset => $offset
-        , prefetch => { evaluationerror => [  ] } });
+        { order_by => "$me.id DESC", rows => $rows, offset => $offset
+        , prefetch => { evaluationerror => [ ] } });
     my @res = ();
     my $cache = {};
 

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -224,11 +224,11 @@ sub getEvalInfo {
 
 
 sub getEvals {
-    my ($self, $c, $evals, $offset, $rows) = @_;
+    my ($self, $c, $evals_query_builder, $offset, $rows) = @_;
 
-    my $me = $evals->current_source_alias;
+    my $me = $evals_query_builder->current_source_alias;
 
-    my @evals = $evals->search(
+    my @evals = $evals_query_builder->search(
         { hasnewbuilds => 1 },
         { order_by => "$me.id DESC", rows => $rows, offset => $offset
         , prefetch => { evaluationerror => [ ] } });

--- a/t/Controller/Build/evals.t
+++ b/t/Controller/Build/evals.t
@@ -1,0 +1,33 @@
+use strict;
+use Setup;
+use Data::Dumper;
+my %ctx = test_init();
+
+require Hydra::Schema;
+require Hydra::Model::DB;
+require Hydra::Helper::Nix;
+
+use Test2::V0;
+require Catalyst::Test;
+use HTTP::Request::Common;
+Catalyst::Test->import('Hydra');
+
+my $db = Hydra::Model::DB->new;
+hydra_setup($db);
+
+my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+
+my $jobset = createBaseJobset("basic", "basic.nix", $ctx{jobsdir});
+
+ok(evalSucceeds($jobset),               "Evaluating jobs/basic.nix should exit with return code 0");
+is(nrQueuedBuildsForJobset($jobset), 3, "Evaluating jobs/basic.nix should result in 3 builds");
+my ($build, @builds) = queuedBuildsForJobset($jobset);
+
+ok(runBuild($build), "Build '".$build->job."' from jobs/basic.nix should exit with code 0");
+
+subtest "/build/ID/evals" => sub {
+    my $evals = request(GET '/build/' . $build->id . '/evals');
+    ok($evals->is_success, "The page listing evaluations this build is part of returns 200.");
+};
+
+done_testing;

--- a/t/Controller/Build/evals.t
+++ b/t/Controller/Build/evals.t
@@ -23,7 +23,7 @@ ok(evalSucceeds($jobset),               "Evaluating jobs/basic.nix should exit w
 is(nrQueuedBuildsForJobset($jobset), 3, "Evaluating jobs/basic.nix should result in 3 builds");
 my ($build, @builds) = queuedBuildsForJobset($jobset);
 
-ok(runBuild($build), "Build '".$build->job."' from jobs/basic.nix should exit with code 0");
+ok(runBuild($build), "Build '".$build->job."' from jobs/basic.nix should exit with return code 0");
 
 subtest "/build/ID/evals" => sub {
     my $evals = request(GET '/build/' . $build->id . '/evals');

--- a/t/Controller/Jobset/channel.t
+++ b/t/Controller/Jobset/channel.t
@@ -29,7 +29,7 @@ ok(evalSucceeds($jobset));
 is(nrQueuedBuildsForJobset($jobset), 4);
 
 for my $build (queuedBuildsForJobset($jobset)) {
-    ok(runBuild($build), "Build '".$build->job."' should exit with code 0");
+    ok(runBuild($build), "Build '".$build->job."' should exit with return code 0");
     my $newbuild = $db->resultset('Builds')->find($build->id);
     is($newbuild->finished, 1, "Build '".$build->job."' should be finished.");
     is($newbuild->buildstatus, 0, "Build '".$build->job."' should have buildstatus 0.");

--- a/t/Controller/Jobset/evals.t
+++ b/t/Controller/Jobset/evals.t
@@ -1,0 +1,34 @@
+use strict;
+use Setup;
+use Data::Dumper;
+my %ctx = test_init();
+
+require Hydra::Schema;
+require Hydra::Model::DB;
+require Hydra::Helper::Nix;
+
+use Test2::V0;
+require Catalyst::Test;
+use HTTP::Request::Common;
+Catalyst::Test->import('Hydra');
+
+my $db = Hydra::Model::DB->new;
+hydra_setup($db);
+
+my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+
+my $jobset = createBaseJobset("basic", "basic.nix", $ctx{jobsdir});
+
+ok(evalSucceeds($jobset), "Evaluating jobs/basic.nix should exit with return code 0");
+
+subtest "/jobset/PROJECT/JOBSET" => sub {
+    my $jobset = request(GET '/jobset/' . $project->name . '/' . $jobset->name);
+    ok($jobset->is_success, "The page showing the jobset returns 200.");
+};
+
+subtest "/jobset/PROJECT/JOBSET/evals" => sub {
+    my $jobsetevals = request(GET '/jobset/' . $project->name . '/' . $jobset->name . '/evals');
+    ok($jobsetevals->is_success, "The page showing the jobset evals returns 200.");
+};
+
+done_testing;

--- a/t/Controller/Root/evals.t
+++ b/t/Controller/Root/evals.t
@@ -1,0 +1,29 @@
+use strict;
+use Setup;
+use Data::Dumper;
+my %ctx = test_init();
+
+require Hydra::Schema;
+require Hydra::Model::DB;
+require Hydra::Helper::Nix;
+
+use Test2::V0;
+require Catalyst::Test;
+use HTTP::Request::Common;
+Catalyst::Test->import('Hydra');
+
+my $db = Hydra::Model::DB->new;
+hydra_setup($db);
+
+my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+
+my $jobset = createBaseJobset("basic", "basic.nix", $ctx{jobsdir});
+
+ok(evalSucceeds($jobset), "Evaluating jobs/basic.nix should exit with return code 0");
+
+subtest "/evals" => sub {
+    my $global = request(GET '/evals');
+    ok($global->is_success, "The page showing the all evals returns 200.");
+};
+
+done_testing;

--- a/t/build-products.t
+++ b/t/build-products.t
@@ -21,7 +21,7 @@ is(nrQueuedBuildsForJobset($jobset), 2, "Evaluating jobs/build-products.nix shou
 
 for my $build (queuedBuildsForJobset($jobset)) {
     subtest "For the build job '" . $build->job . "'" => sub {
-        ok(runBuild($build), "Build should exit with code 0");
+        ok(runBuild($build), "Build should exit with return code 0");
         my $newbuild = $db->resultset('Builds')->find($build->id);
 
         is($newbuild->finished, 1, "Build should have finished");

--- a/t/evaluate-basic.t
+++ b/t/evaluate-basic.t
@@ -21,7 +21,7 @@ ok(evalSucceeds($jobset),               "Evaluating jobs/basic.nix should exit w
 is(nrQueuedBuildsForJobset($jobset), 3, "Evaluating jobs/basic.nix should result in 3 builds");
 
 for my $build (queuedBuildsForJobset($jobset)) {
-    ok(runBuild($build), "Build '".$build->job."' from jobs/basic.nix should exit with code 0");
+    ok(runBuild($build), "Build '".$build->job."' from jobs/basic.nix should exit with return code 0");
     my $newbuild = $db->resultset('Builds')->find($build->id);
     is($newbuild->finished, 1, "Build '".$build->job."' from jobs/basic.nix should be finished.");
     my $expected = $build->job eq "fails" ? 1 : $build->job =~ /with_failed/ ? 6 : 0;

--- a/t/evaluate-dependent-jobsets.t
+++ b/t/evaluate-dependent-jobsets.t
@@ -21,7 +21,7 @@ subtest "For the 'build1' job" => sub {
     my ($build) = queuedBuildsForJobset($jobset);
     is($build->job, "build1", "Verify the only job we got is for 'build1'");
 
-    ok(runBuild($build), "Build should exit with code 0");
+    ok(runBuild($build), "Build should exit with return code 0");
     my $newbuild = $db->resultset('Builds')->find($build->id);
     is($newbuild->finished, 1, "Build should be finished.");
     is($newbuild->buildstatus, 0, "Build should have buildstatus 0.");
@@ -33,7 +33,7 @@ subtest "For the 'build2' job" => sub {
     my ($build) = queuedBuildsForJobset($jobset);
     is($build->job, "build2", "Verify the only job we got is for 'build2'");
 
-    ok(runBuild($build), "Build should exit with code 0");
+    ok(runBuild($build), "Build should exit with return code 0");
     my $newbuild = $db->resultset('Builds')->find($build->id);
     is($newbuild->finished, 1, "Build should be finished.");
     is($newbuild->buildstatus, 0, "Build should have buildstatus 0.");

--- a/t/plugins/runcommand.t
+++ b/t/plugins/runcommand.t
@@ -30,7 +30,7 @@ is(nrQueuedBuildsForJobset($jobset), 1, "Evaluating jobs/runcommand.nix should r
 (my $build) = queuedBuildsForJobset($jobset);
 
 is($build->job, "metrics", "The only job should be metrics");
-ok(runBuild($build), "Build should exit with code 0");
+ok(runBuild($build), "Build should exit with return code 0");
 my $newbuild = $db->resultset('Builds')->find($build->id);
 is($newbuild->finished, 1, "Build should be finished.");
 is($newbuild->buildstatus, 0, "Build should have buildstatus 0.");

--- a/t/queue-runner/default-machine-file.t
+++ b/t/queue-runner/default-machine-file.t
@@ -24,7 +24,7 @@ ok(evalSucceeds($jobset),               "Evaluating jobs/default-machine-file.ni
 is(nrQueuedBuildsForJobset($jobset), 1, "Evaluating jobs/default-machine-file.nix should result in 1 build");
 
 for my $build (queuedBuildsForJobset($jobset)) {
-    ok(runBuild($build), "Build '".$build->job."' from jobs/default-machine-file.nix should exit with code 0");
+    ok(runBuild($build), "Build '".$build->job."' from jobs/default-machine-file.nix should exit with return code 0");
     my $newbuild = $db->resultset('Builds')->find($build->id);
     is($newbuild->finished, 1, "Build '".$build->job."' from jobs/default-machine-file.nix should be finished.");
     my $expected = $build->job eq "fails" ? 1 : $build->job =~ /with_failed/ ? 6 : 0;

--- a/t/queue-runner/notifications.t
+++ b/t/queue-runner/notifications.t
@@ -88,7 +88,7 @@ my @builds = queuedBuildsForJobset($jobset);
 
 subtest "Build: substitutable, canbesubstituted" => sub {
     my ($build) = grep { $_->nixname eq "can-be-substituted" } @builds;
-    ok(runBuild($build), "Build should exit with code 0");
+    ok(runBuild($build), "Build should exit with return code 0");
 
     my $newbuild = $db->resultset('Builds')->find($build->id);
     is($newbuild->finished, 1, "Build should be finished.");
@@ -107,7 +107,7 @@ subtest "Build: substitutable, canbesubstituted" => sub {
 
 subtest "Build: not substitutable, unsubstitutable" => sub {
     my ($build) = grep { $_->nixname eq "unsubstitutable" } @builds;
-    ok(runBuild($build), "Build should exit with code 0");
+    ok(runBuild($build), "Build should exit with return code 0");
 
     my $newbuild = $db->resultset('Builds')->find($build->id);
     is($newbuild->finished, 1, "Build should be finished.");


### PR DESCRIPTION
Closes #917 

I broke this when I added `me.` in f1e75c8

I added me. to disambiguate `id`, but:

* eval.id works on the per-build page
* me.id works on the other pages
* Just id works everywhere if I drop:

    , prefetch => { evaluationerror => [ ] },

  but this causes a query per row to collect the evaluationerror
  records later, this becomes significantly slow on non-trivial
  datasets.

Using evals->current_source_alias will use the correct alias
whether it is me or eval or something else.