### PR TITLE
flake: stdenv.lib -> lib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -299,7 +299,7 @@
             propagatedBuildInputs = with final.perlPackages; [ NetLDAP ConvertASN1 ];
             meta = {
               description = "LDAP server side protocol handling";
-              license = with final.stdenv.lib.licenses; [ artistic1 ];
+              license = with final.lib.licenses; [ artistic1 ];
             };
           };
 
@@ -312,7 +312,7 @@
             };
             meta = {
               description= "Active Directory Security Identifier manipulation";
-              license = with final.stdenv.lib.licenses; [ artistic2 ];
+              license = with final.lib.licenses; [ artistic2 ];
             };
           };
 
@@ -326,7 +326,7 @@
             propagatedBuildInputs = with final.perlPackages; [ NetLDAP NetLDAPServer TestMore DataDump NetLDAPSID ];
             meta = {
               description= "test Net::LDAP code";
-              license = with final.stdenv.lib.licenses; [ artistic1 ];
+              license = with final.lib.licenses; [ artistic1 ];
             };
           };
 
@@ -341,7 +341,7 @@
             buildInputs = with final.perlPackages; [ TestMore TestMockObject TestException NetLDAPServerTest ];
             meta = {
               description= "Authentication from an LDAP Directory";
-              license = with final.stdenv.lib.licenses; [ artistic1 ];
+              license = with final.lib.licenses; [ artistic1 ];
             };
           };
 


### PR DESCRIPTION
Nixpkgs on unstable has removed `stdenv.lib` as they've been warning for a while now. This removes the extra references to it in the flake.nix

I'm not entirely sure if this is right, but I figured it was trivial enough to give a quick try using the GH Editor while I was waiting for a job to finish