### PR TITLE
Docs: document derivation attributes

### DIFF
--- a/doc/manual/src/SUMMARY.md
+++ b/doc/manual/src/SUMMARY.md
@@ -3,6 +3,7 @@
 - [Introduction](introduction.md)
 - [Installation](installation.md)
 - [Creating and Managing Projects](projects.md)
+- [Hydra jobs](./jobs.md)
 - [Using the external API](api.md)
 - [Monitoring Hydra](./monitoring/README.md)
 

--- a/doc/manual/src/jobs.md
+++ b/doc/manual/src/jobs.md
@@ -1,0 +1,21 @@
+# Hydra Jobs
+
+## Derivation Attributes
+
+Hydra stores the following job attributes in its database:
+
+* `nixName` - the Derivation's `name` attribute
+* `system` - the Derivation's `system` attribute
+* `drvPath` - the Derivation's path in the Nix store
+* `outputs` - A JSON dictionary of output names and their store path.
+
+### Meta fields
+
+* `description` - `meta.description`, a string
+* `license` - a comma separated list of license names from `meta.license`, expected to be a list of attribute sets with an attribute named `shortName`, ex: `[ { shortName = "licensename"} ]`.
+* `homepage` - `meta.homepage`, a string
+* `maintainers` - a comma separated list of maintainer email addresses from `meta.maintainers`, expected to be a list of attribute sets with an attribute named `email`, ex: `[ { email = "alice@example.com"} ]`.
+* `schedulingPriority` - `meta.schedulingPriority`, an integer. Default: 100. Slightly prioritizes this job over other jobs within this jobset.
+* `timeout` - `meta.timeout`, an integer. Default: 36000. Number of seconds this job must complete within.
+* `maxSilent` - `meta.maxSilent`, an integer. Default: 7200. Number of seconds of no output on stderr / stdout before considering the job failed. 
+* `isChannel` - `meta.isHydraChannel`, bool. Default: false. Deprecated.


### PR DESCRIPTION
From a question matrix:

> wucke13
> Even more noise: where can the timeout be configured for hydra jobs? Couldn't find the term timeout in the manual nor the nixos options
