### PR TITLE
Allow for evaluator_pure_eval to be configured

### DIFF
--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -274,6 +274,8 @@ int main(int argc, char * * argv)
 
         myArgs.parseCmdline(argvToStrings(argc, argv));
 
+        auto pureEval = config->getBoolOption("evaluator_pure_eval", myArgs.flake);
+
         /* FIXME: The build hook in conjunction with import-from-derivation is causing "unexpected EOF" during eval */
         settings.builders = "";
 
@@ -283,7 +285,7 @@ int main(int argc, char * * argv)
 
         /* When building a flake, use pure evaluation (no access to
            'getEnv', 'currentSystem' etc. */
-        evalSettings.pureEval = myArgs.flake;
+        evalSettings.pureEval = pureEval;
 
         if (myArgs.dryRun) settings.readOnlyMode = true;
 


### PR DESCRIPTION
In a similar vein to #888 allow users to configure purity.

The main reason for this is to support legacy nix code which may call things like `builtins.currentSystem`. With large highly coupled code bases, it's often the case that there is a lot of IFD and impurity going on...