### PR TITLE
Declarative jobsets: move event handling to a plugin

### DIFF
--- a/src/lib/Hydra/Plugin/DeclarativeJobsets.pm
+++ b/src/lib/Hydra/Plugin/DeclarativeJobsets.pm
@@ -1,0 +1,17 @@
+package Hydra::Plugin::DeclarativeJobsets;
+
+use strict;
+use parent 'Hydra::Plugin';
+use Hydra::Helper::AddBuilds;
+
+sub buildFinished {
+    my ($self, $build, $dependents) = @_;
+
+    my $project = $build->project;
+    my $jobsetName = $build->get_column('jobset');
+    if (length($project->declfile) && $jobsetName eq ".jobsets" && $build->iscurrent) {
+        handleDeclarativeJobsetBuild($self->{"db"}, $project, $build);
+    }
+}
+
+1;

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -49,12 +49,6 @@ sub buildStarted {
 sub buildFinished {
     my ($build, @deps) = @_;
 
-    my $project = $build->project;
-    my $jobsetName = $build->get_column('jobset');
-    if (length($project->declfile) && $jobsetName eq ".jobsets" && $build->iscurrent) {
-        handleDeclarativeJobsetBuild($db, $project, $build);
-    }
-
     my @dependents;
     foreach my $id (@deps) {
         my $dep = $db->resultset('Builds')->find($id)


### PR DESCRIPTION
Declarative jobsets were sort of tucked in to the event handler
itself. It turned out that it could have been implemented as a
plugin without much trouble.

Declarative jobsets have no tests, so this should be tested
by hand.