### PR TITLE
lib/makefile: include Event/*.pm

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -10,6 +10,7 @@ PERL_MODULES =					\
   $(wildcard Hydra/Base/Controller/*.pm) 	\
   $(wildcard Hydra/Script/*.pm)			\
   $(wildcard Hydra/Component/*.pm)		\
+  $(wildcard Hydra/Event/*.pm)		\
   $(wildcard Hydra/Plugin/*.pm)
 
 EXTRA_DIST = \


### PR DESCRIPTION
Event/*.pm files were not included in the final Nix store result. Not sure how to test this in PRs.