### PR TITLE
#998: Batch of fixups

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -554,7 +554,7 @@
                       su - hydra -c "hydra-create-user root --email-address 'alice@example.org' --password foobar --role admin"
                       mkdir /run/jobset
                       chmod 755 /run/jobset
-                      cp ${./t/api-test.nix} /run/jobset/default.nix
+                      cp ${./t/jobs/api-test.nix} /run/jobset/default.nix
                       chmod 644 /run/jobset/default.nix
                       chown -R hydra /run/jobset
               """

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -68,7 +68,7 @@ while (!$queued_only) {
         my $payload = $message->{"payload"};
 
         eval {
-            my $event = Hydra::Event::new_event($channelName, $message->{"payload"});
+            my $event = Hydra::Event->new_event($channelName, $message->{"payload"});
             runPluginsForEvent($event);
 
             1;

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -2,12 +2,13 @@
 
 use strict;
 use utf8;
+use Getopt::Long;
+use Hydra::Event;
 use Hydra::Event::BuildFinished;
 use Hydra::Helper::AddBuilds;
 use Hydra::Helper::Nix;
 use Hydra::Plugin;
 use Hydra::PostgresListener;
-use Getopt::Long;
 
 STDERR->autoflush(1);
 STDOUT->autoflush(1);

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -50,7 +50,7 @@ sub runPluginsForEvent {
 for my $build ($db->resultset('Builds')->search(
                    { notificationpendingsince => { '!=', undef } }))
 {
-    print STDERR "sending notifications for build $build->id...\n";
+    print STDERR "sending notifications for build ${\$build->id}...\n";
 
 
     my $event = Hydra::Event::BuildFinished->new($build->id);


### PR DESCRIPTION
If anything, these little fixups are a strong argument for moving more code out of hydra-notify and in to a structure with `.t` files.

Sorry for the issues :sweat:.