### PR TITLE
Avoid $a, $b

### DIFF
--- a/src/lib/Hydra/Controller/Job.pm
+++ b/src/lib/Hydra/Controller/Job.pm
@@ -121,10 +121,10 @@ sub overview : Chained('job') PathPart('') Args(0) {
 
     my $aggregates = {};
     my %constituentJobs;
-    foreach my $b (@constituents) {
-        $aggregates->{$b->get_column('aggregate')}->{constituents}->{$b->job} =
-            { id => $b->id, finished => $b->finished, buildstatus => $b->buildstatus };
-        $constituentJobs{$b->job} = 1;
+    foreach my $build (@constituents) {
+        $aggregates->{$build->get_column('aggregate')}->{constituents}->{$build->job} =
+            { id => $build->id, finished => $build->finished, buildstatus => $build->buildstatus };
+        $constituentJobs{$build->job} = 1;
     }
 
     foreach my $agg (keys %$aggregates) {

--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -64,9 +64,9 @@ sub view_GET {
     $c->stash->{otherEval} = $eval2 if defined $eval2;
 
     sub cmpBuilds {
-        my ($a, $b) = @_;
-        return $a->get_column('job') cmp $b->get_column('job')
-            || $a->get_column('system') cmp $b->get_column('system')
+        my ($left, $right) = @_;
+        return $left->get_column('job') cmp $right->get_column('job')
+            || $left->get_column('system') cmp $right->get_column('system')
     }
 
     my @builds = $eval->builds->search($filter, { columns => [@buildListColumns] });

--- a/src/lib/Hydra/Event/BuildFinished.pm
+++ b/src/lib/Hydra/Event/BuildFinished.pm
@@ -53,9 +53,9 @@ sub execute {
     #
     # Otherwise, the dependent builds will remain with notificationpendingsince set
     # until hydra-notify is started, as buildFinished is never emitted for them.
-    foreach my $b ($self->{"build"}, @{$self->{"dependents"}}) {
-        if ($b->finished && defined($b->notificationpendingsince)) {
-            $b->update({ notificationpendingsince => undef })
+    foreach my $build ($self->{"build"}, @{$self->{"dependents"}}) {
+        if ($build->finished && defined($build->notificationpendingsince)) {
+            $build->update({ notificationpendingsince => undef })
         }
     }
 

--- a/src/lib/Hydra/Helper/CatalystUtils.pm
+++ b/src/lib/Hydra/Helper/CatalystUtils.pm
@@ -109,14 +109,14 @@ sub searchBuildsAndEvalsForJobset {
             { columns => ['id', 'job', 'finished', 'buildstatus'] }
         );
 
-        foreach my $b (@allBuilds) {
-            my $jobName = $b->get_column('job');
+        foreach my $build (@allBuilds) {
+            my $jobName = $build->get_column('job');
 
             $evals->{$eval->id}->{timestamp} = $eval->timestamp;
             $evals->{$eval->id}->{builds}->{$jobName} = {
-                id => $b->id,
-                finished => $b->finished,
-                buildstatus => $b->buildstatus
+                id => $build->id,
+                finished => $build->finished,
+                buildstatus => $build->buildstatus
             };
             $builds{$jobName} = 1;
             $nrBuilds++;

--- a/src/lib/Hydra/Plugin/BitBucketStatus.pm
+++ b/src/lib/Hydra/Plugin/BitBucketStatus.pm
@@ -22,21 +22,21 @@ sub toBitBucketState {
 }
 
 sub common {
-    my ($self, $build, $dependents, $finished) = @_;
+    my ($self, $topbuild, $dependents, $finished) = @_;
     my $bitbucket = $self->{config}->{bitbucket};
     my $baseurl = $self->{config}->{'base_uri'} || "http://localhost:3000";
 
-    foreach my $b ($build, @{$dependents}) {
-        my $jobName = showJobName $b;
-        my $evals = $build->jobsetevals;
+    foreach my $build ($topbuild, @{$dependents}) {
+        my $jobName = showJobName $build;
+        my $evals = $topbuild->jobsetevals;
         my $ua = LWP::UserAgent->new();
         my $body = encode_json(
             {
-                state => $finished ? toBitBucketState($b->buildstatus) : "INPROGRESS",
-                url => "$baseurl/build/" . $b->id,
+                state => $finished ? toBitBucketState($tbuild->buildstatus) : "INPROGRESS",
+                url => "$baseurl/build/" . $tbuild->id,
                 name => $jobName,
-                key => $b->id,
-                description => "Hydra build #" . $b->id . " of $jobName",
+                key => $tbuild->id,
+                description => "Hydra build #" . $tbuild->id . " of $jobName",
             });
         while (my $eval = $evals->next) {
             foreach my $i ($eval->jobsetevalinputs){

--- a/src/lib/Hydra/Plugin/BitBucketStatus.pm
+++ b/src/lib/Hydra/Plugin/BitBucketStatus.pm
@@ -32,11 +32,11 @@ sub common {
         my $ua = LWP::UserAgent->new();
         my $body = encode_json(
             {
-                state => $finished ? toBitBucketState($tbuild->buildstatus) : "INPROGRESS",
-                url => "$baseurl/build/" . $tbuild->id,
+                state => $finished ? toBitBucketState($build->buildstatus) : "INPROGRESS",
+                url => "$baseurl/build/" . $build->id,
                 name => $jobName,
-                key => $tbuild->id,
-                description => "Hydra build #" . $tbuild->id . " of $jobName",
+                key => $build->id,
+                description => "Hydra build #" . $build->id . " of $jobName",
             });
         while (my $eval = $evals->next) {
             foreach my $i ($eval->jobsetevalinputs){

--- a/src/lib/Hydra/Plugin/CircleCINotification.pm
+++ b/src/lib/Hydra/Plugin/CircleCINotification.pm
@@ -13,22 +13,22 @@ sub isEnabled {
 }
 
 sub buildFinished {
-    my ($self, $build, $dependents) = @_;
+    my ($self, $topbuild, $dependents) = @_;
     my $cfg = $self->{config}->{circleci};
     my @config = defined $cfg ? ref $cfg eq "ARRAY" ? @$cfg : ($cfg) : ();
 
     # Figure out to which branches to send notification.
     my %branches;
-    foreach my $b ($build, @{$dependents}) {
-        my $prevBuild = getPreviousBuild($b);
-        my $jobName = showJobName $b;
+    foreach my $build ($topbuild, @{$dependents}) {
+        my $prevBuild = getPreviousBuild($build);
+        my $jobName = showJobName $build;
 
         foreach my $branch (@config) {
             my $force = $branch->{force};
             next unless $jobName =~ /^$branch->{jobs}$/;
 
             # If build is failed, don't trigger circleci
-            next if ! $force && $b->buildstatus != 0;
+            next if ! $force && $build->buildstatus != 0;
 
             my $fullUrl = "https://circleci.com/api/v1.1/project/" . $branch->{vcstype} . "/" . $branch->{username} . "/" . $branch->{project} . "/tree/" . $branch->{branch} . "?circle-token=" . $branch->{token};
             $branches{$fullUrl} = 1;

--- a/src/lib/Hydra/Plugin/CoverityScan.pm
+++ b/src/lib/Hydra/Plugin/CoverityScan.pm
@@ -12,19 +12,19 @@ sub isEnabled {
 }
 
 sub buildFinished {
-    my ($self, $b, $dependents) = @_;
+    my ($self, $build, $dependents) = @_;
 
     my $cfg = $self->{config}->{coverityscan};
     my @config = defined $cfg ? ref $cfg eq "ARRAY" ? @$cfg : ($cfg) : ();
 
     # Scan the job and see if it matches any of the Coverity Scan projects
     my $proj;
-    my $jobName = showJobName $b;
+    my $jobName = showJobName $build;
     foreach my $p (@config) {
         next unless $jobName =~ /^$p->{jobs}$/;
 
         # If build is cancelled or aborted, do not upload build
-        next if $b->buildstatus == 4 || $b->buildstatus == 3;
+        next if $build->buildstatus == 4 || $build->buildstatus == 3;
 
         # Otherwise, select this Coverity project
         $proj = $p; last;
@@ -47,7 +47,7 @@ sub buildFinished {
         unless defined $token;
 
     # Get tarball locations
-    my $storePath = ($b->buildoutputs)[0]->path;
+    my $storePath = ($build->buildoutputs)[0]->path;
     my $tarballs  = "$storePath/tarballs";
     my $covTarball;
 
@@ -87,7 +87,7 @@ sub buildFinished {
         unless defined $version;
 
     # Submit build
-    my $jobid = $b->id;
+    my $jobid = $build->id;
     my $desc = "Hydra Coverity Build ($jobName) - $jobid:$version";
 
     print STDERR "uploading $desc ($shortName) to Coverity Scan\n";

--- a/src/lib/Hydra/Plugin/GiteaStatus.pm
+++ b/src/lib/Hydra/Plugin/GiteaStatus.pm
@@ -29,25 +29,25 @@ sub toGiteaState {
 }
 
 sub common {
-    my ($self, $build, $dependents, $status) = @_;
+    my ($self, $topbuild, $dependents, $status) = @_;
     my $baseurl = $self->{config}->{'base_uri'} || "http://localhost:3000";
 
     # Find matching configs
-    foreach my $b ($build, @{$dependents}) {
-        my $jobName = showJobName $b;
-        my $evals = $build->jobsetevals;
+    foreach my $build ($topbuild, @{$dependents}) {
+        my $jobName = showJobName $build;
+        my $evals = $topbuild->jobsetevals;
         my $ua = LWP::UserAgent->new();
 
         # Don't send out "pending/running" status updates if the build is already finished
-        next if $status < 2 && $b->finished == 1;
+        next if $status < 2 && $build->finished == 1;
 
-        my $state = toGiteaState($status, $b->buildstatus);
+        my $state = toGiteaState($status, $build->buildstatus);
         my $body = encode_json(
             {
                 state => $state,
-                target_url => "$baseurl/build/" . $b->id,
-                description => "Hydra build #" . $b->id . " of $jobName",
-                context => "Hydra " . $b->get_column('job'),
+                target_url => "$baseurl/build/" . $build->id,
+                description => "Hydra build #" . $build->id . " of $jobName",
+                context => "Hydra " . $build->get_column('job'),
             });
 
         while (my $eval = $evals->next) {

--- a/src/lib/Hydra/Plugin/GithubStatus.pm
+++ b/src/lib/Hydra/Plugin/GithubStatus.pm
@@ -25,32 +25,32 @@ sub toGithubState {
 }
 
 sub common {
-    my ($self, $build, $dependents, $finished) = @_;
+    my ($self, $topbuild, $dependents, $finished) = @_;
     my $cfg = $self->{config}->{githubstatus};
     my @config = defined $cfg ? ref $cfg eq "ARRAY" ? @$cfg : ($cfg) : ();
     my $baseurl = $self->{config}->{'base_uri'} || "http://localhost:3000";
 
     # Find matching configs
-    foreach my $b ($build, @{$dependents}) {
-        my $jobName = showJobName $b;
-        my $evals = $build->jobsetevals;
+    foreach my $build ($topbuild, @{$dependents}) {
+        my $jobName = showJobName $build;
+        my $evals = $topbuild->jobsetevals;
         my $ua = LWP::UserAgent->new();
 
         foreach my $conf (@config) {
             next unless $jobName =~ /^$conf->{jobs}$/;
             # Don't send out "pending" status updates if the build is already finished
-            next if !$finished && $b->finished == 1;
+            next if !$finished && $build->finished == 1;
 
-            my $contextTrailer = $conf->{excludeBuildFromContext} ? "" : (":" . $b->id);
+            my $contextTrailer = $conf->{excludeBuildFromContext} ? "" : (":" . $build->id);
             my $github_job_name = $jobName =~ s/-pr-\d+//r;
             my $extendedContext = $conf->{context} // "continuous-integration/hydra:" . $jobName . $contextTrailer;
             my $shortContext = $conf->{context} // "ci/hydra:" . $github_job_name . $contextTrailer;
             my $context = $conf->{useShortContext} ? $shortContext : $extendedContext;
             my $body = encode_json(
                 {
-                    state => $finished ? toGithubState($b->buildstatus) : "pending",
-                    target_url => "$baseurl/build/" . $b->id,
-                    description => $conf->{description} // "Hydra build #" . $b->id . " of $jobName",
+                    state => $finished ? toGithubState($build->buildstatus) : "pending",
+                    target_url => "$baseurl/build/" . $build->id,
+                    description => $conf->{description} // "Hydra build #" . $build->id . " of $jobName",
                     context => $context
                 });
             my $inputs_cfg = $conf->{inputs};

--- a/src/lib/Hydra/Plugin/GitlabStatus.pm
+++ b/src/lib/Hydra/Plugin/GitlabStatus.pm
@@ -37,25 +37,25 @@ sub toGitlabState {
 }
 
 sub common {
-    my ($self, $build, $dependents, $status) = @_;
+    my ($self, $topbuild, $dependents, $status) = @_;
     my $baseurl = $self->{config}->{'base_uri'} || "http://localhost:3000";
 
     # Find matching configs
-    foreach my $b ($build, @{$dependents}) {
-        my $jobName = showJobName $b;
-        my $evals = $build->jobsetevals;
+    foreach my $build ($topbuild, @{$dependents}) {
+        my $jobName = showJobName $build;
+        my $evals = $topbuild->jobsetevals;
         my $ua = LWP::UserAgent->new();
 
         # Don't send out "pending/running" status updates if the build is already finished
-        next if $status < 2 && $b->finished == 1;
+        next if $status < 2 && $build->finished == 1;
 
-        my $state = toGitlabState($status, $b->buildstatus);
+        my $state = toGitlabState($status, $build->buildstatus);
         my $body = encode_json(
             {
                 state => $state,
-                target_url => "$baseurl/build/" . $b->id,
-                description => "Hydra build #" . $b->id . " of $jobName",
-                name => "Hydra " . $b->get_column('job'),
+                target_url => "$baseurl/build/" . $build->id,
+                description => "Hydra build #" . $build->id . " of $jobName",
+                name => "Hydra " . $build->get_column('job'),
             });
         while (my $eval = $evals->next) {
             my $gitlabstatusInput = $eval->jobsetevalinputs->find({ name => "gitlab_status_repo" });


### PR DESCRIPTION
Implementing part of #1003: 

> Using $a or $b outside sort() at line 45, column 16.  $a and $b are special package variables for use in sort() and related functions. Declaring them as lexicals like "my $a" may break sort(). Use different variable names.  (Severity: 4)

Care should be taken to verify each commit doesn't stomp on existing variables in scope.