### PR TITLE
Retryable notifications

### DIFF
--- a/src/lib/Hydra/Math.pm
+++ b/src/lib/Hydra/Math.pm
@@ -1,0 +1,30 @@
+package Hydra::Math;
+
+use strict;
+use warnings;
+use List::Util qw(min);
+use Exporter 'import';
+our @EXPORT_OK = qw(exponential_backoff);
+
+=head2 exponential_backoff
+
+Calculates a number of seconds to wait before reattempting something.
+
+Arguments:
+
+=over 1
+
+=item C<$attempts>
+
+Integer number of attempts made.
+
+=back
+
+=cut
+sub exponential_backoff {
+    my ($attempt) = @_;
+    my $clamp = min(10, $attempt);
+    return 2 ** $clamp;
+}
+
+1;

--- a/src/lib/Hydra/Schema/Result/TaskRetries.pm
+++ b/src/lib/Hydra/Schema/Result/TaskRetries.pm
@@ -1,0 +1,110 @@
+use utf8;
+package Hydra::Schema::Result::TaskRetries;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Hydra::Schema::Result::TaskRetries
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
+=head1 TABLE: C<taskretries>
+
+=cut
+
+__PACKAGE__->table("taskretries");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'integer'
+  is_auto_increment: 1
+  is_nullable: 0
+  sequence: 'taskretries_id_seq'
+
+=head2 channel
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 pluginname
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 payload
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 attempts
+
+  data_type: 'integer'
+  is_nullable: 0
+
+=head2 retry_at
+
+  data_type: 'integer'
+  is_nullable: 0
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "taskretries_id_seq",
+  },
+  "channel",
+  { data_type => "text", is_nullable => 0 },
+  "pluginname",
+  { data_type => "text", is_nullable => 0 },
+  "payload",
+  { data_type => "text", is_nullable => 0 },
+  "attempts",
+  { data_type => "integer", is_nullable => 0 },
+  "retry_at",
+  { data_type => "integer", is_nullable => 0 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-08-26 16:30:59
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4MC8UnsgrvJVRrIURvSH5A
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/src/lib/Hydra/Schema/Result/TaskRetries.pm
+++ b/src/lib/Hydra/Schema/Result/TaskRetries.pm
@@ -105,6 +105,16 @@ __PACKAGE__->set_primary_key("id");
 # Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-08-26 16:30:59
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4MC8UnsgrvJVRrIURvSH5A
 
+use Hydra::Math qw(exponential_backoff);
 
-# You can replace this text with custom code or comments, and it will be preserved on regeneration
+sub requeue {
+  my ($self) = @_;
+
+  $self->update({
+    attempts => $self->attempts + 1,
+    retry_at => time() + exponential_backoff($self->attempts + 1),
+  });
+
+}
+
 1;

--- a/src/lib/Hydra/Schema/ResultSet/TaskRetries.pm
+++ b/src/lib/Hydra/Schema/ResultSet/TaskRetries.pm
@@ -6,6 +6,7 @@ use utf8;
 use base 'DBIx::Class::ResultSet';
 use List::Util qw(max);
 use Hydra::Math qw(exponential_backoff);
+use Hydra::Task;
 
 =head2 get_seconds_to_next_retry
 

--- a/src/lib/Hydra/Schema/ResultSet/TaskRetries.pm
+++ b/src/lib/Hydra/Schema/ResultSet/TaskRetries.pm
@@ -13,11 +13,11 @@ use Hydra::Task;
 Query the database to identify how soon the next retryable task is due
 for being attempted again.
 
-If there are no tasks to be reattempted it returns undef.
+If there are no tasks to be reattempted, it returns undef.
 
 If a task's scheduled retry has passed, it returns 0.
 
-Otherwise, returns the number of seconds from now to look for work.
+Otherwise, returns the number of seconds to wait before looking for more work.
 
 =cut
 sub get_seconds_to_next_retry {

--- a/src/lib/Hydra/Schema/ResultSet/TaskRetries.pm
+++ b/src/lib/Hydra/Schema/ResultSet/TaskRetries.pm
@@ -1,0 +1,41 @@
+package Hydra::Schema::ResultSet::TaskRetries;
+
+use strict;
+use warnings;
+use utf8;
+use base 'DBIx::Class::ResultSet';
+use List::Util qw(max);
+
+=head2 get_seconds_to_next_retry
+
+Query the database to identify how soon the next retryable task is due
+for being attempted again.
+
+If there are no tasks to be reattempted it returns undef.
+
+If a task's scheduled retry has passed, it returns 0.
+
+Otherwise, returns the number of seconds from now to look for work.
+
+=cut
+sub get_seconds_to_next_retry {
+    my ($self) = @_;
+
+    my $next_retry = $self->search(
+        {}, # any task
+        {
+            order_by => {
+                -asc => 'retry_at'
+            },
+            rows => 1,
+        }
+    )->get_column('retry_at')->first;
+
+    if (defined($next_retry)) {
+        return max(0, $next_retry - time());
+    } else {
+        return undef;
+    }
+}
+
+1;

--- a/src/lib/Hydra/Task.pm
+++ b/src/lib/Hydra/Task.pm
@@ -1,0 +1,15 @@
+package Hydra::Task;
+
+use strict;
+use warnings;
+
+sub new {
+    my ($self, $event, $plugin_name) = @_;
+
+    return bless {
+        "event" => $event,
+        "plugin_name" => $plugin_name,
+    }, $self;
+}
+
+1;

--- a/src/lib/Hydra/TaskDispatcher.pm
+++ b/src/lib/Hydra/TaskDispatcher.pm
@@ -254,7 +254,7 @@ sub failure {
     my $event_labels = $self->prom_labels_for_task($task);
 
     if (defined($task->{"record"})) {
-        if ($task->{"record"}->{"attempts"} > 100) {
+        if ($task->{"record"}->attempts > 100) {
             $self->{"prometheus"}->inc("notify_plugin_drop", $event_labels);
             $task->{"record"}->delete();
         } else {

--- a/src/lib/Hydra/TaskDispatcher.pm
+++ b/src/lib/Hydra/TaskDispatcher.pm
@@ -1,0 +1,157 @@
+package Hydra::TaskDispatcher;
+
+use strict;
+use warnings;
+use Hydra::Task;
+use Time::HiRes qw( gettimeofday tv_interval );
+
+=head1 Hydra::TaskDispatcher
+
+Excecute many plugins with Hydra::Event as its input.
+
+The TaskDispatcher is responsible for dealing with fanout
+from one incoming Event being executed across many plugins,
+or one Event being executed against a single plugin by first
+wrapping it in a Task.
+
+Its execution model is based on creating a Hydra::Task for
+each plugin's execution. The task represents the name of
+the plugin to run and the Event to process.
+
+=cut
+
+=head2 new
+
+Arguments:
+
+=over 1
+
+=item C<$dbh>
+L<DBI::db> The database connection.
+
+=back
+
+=item C<$prometheus>
+L<Prometheus::Tiny> A Promethues implementation, either Prometheus::Tiny
+or Prometheus::Tiny::Shared. Not compatible with Net::Prometheus.
+
+=back
+
+=item C<%plugins>
+L<Hydra::Plugin> A list of Hydra plugins to execute events and tasks against.
+
+=back
+
+=cut
+
+sub new {
+    my ($self, $db, $prometheus, $plugins) = @_;
+
+    $prometheus->declare(
+        "notify_plugin_executions",
+        type => "counter",
+        help => "Number of times each plugin has been called by channel."
+    );
+    $prometheus->declare(
+        "notify_plugin_runtime",
+        type => "histogram",
+        help => "Number of seconds spent executing each plugin by channel."
+    );
+    $prometheus->declare(
+        "notify_plugin_success",
+        type => "counter",
+        help => "Number of successful executions of this plugin on this channel."
+    );
+    $prometheus->declare(
+        "notify_plugin_error",
+        type => "counter",
+        help => "Number of failed executions of this plugin on this channel."
+    );
+
+    my %plugins_by_name = map { ref $_ => $_ } @{$plugins};
+
+    my $obj = bless {
+        "db" => $db,
+        "prometheus" => $prometheus,
+        "plugins_by_name" => \%plugins_by_name,
+    }, $self;
+}
+
+=head2 dispatch_event
+
+Execute each configured plugin against the provided L<Hydra::Event>.
+
+Arguments:
+
+=over 1
+
+=item C<$event>
+
+L<Hydra::Event> the event, usually from L<Hydra::PostgresListener>.
+
+=back
+
+=cut
+
+sub dispatch_event {
+    my ($self, $event) = @_;
+
+    foreach my $plugin_name (keys %{$self->{"plugins_by_name"}}) {
+        my $task = Hydra::Task->new($event, $plugin_name);
+        $self->dispatch_task($task);
+    }
+}
+
+=head2 dispatch_task
+
+Execute a specifi plugin against the provided L<Hydra::Task>.
+The Task includes information about what plugin should be executed.
+If the provided plugin does not exist, an error logged is logged and the
+function returns falsey.
+
+Arguments:
+
+=over 1
+
+=item C<$task>
+
+L<Hydra::Task> the task, usually from L<Hydra::Shema::Result::TaskRetries>.
+
+=back
+
+=cut
+sub dispatch_task {
+    my ($self, $task) = @_;
+
+    my $channel_name = $task->{"event"}->{'channel_name'};
+    my $plugin_name = $task->{"plugin_name"};
+    my $event_labels = {
+        channel => $channel_name,
+        plugin => $plugin_name,
+    };
+
+    my $plugin = $self->{"plugins_by_name"}->{$plugin_name};
+
+    if (!defined($plugin)) {
+        $self->{"prometheus"}->inc("notify_plugin_no_such_plugin", $event_labels);
+        print STDERR "No plugin named $plugin_name\n";
+        return 0;
+    }
+
+    $self->{"prometheus"}->inc("notify_plugin_executions", $event_labels);
+    eval {
+        my $start_time = [gettimeofday()];
+
+        $task->{"event"}->execute($self->{"db"}, $plugin);
+
+        $self->{"prometheus"}->histogram_observe("notify_plugin_runtime", tv_interval($start_time), $event_labels);
+        $self->{"prometheus"}->inc("notify_plugin_success", $event_labels);
+        1;
+    } or do {
+        $self->{"prometheus"}->inc("notify_plugin_error", $event_labels);
+        print STDERR "error running $channel_name hooks: $@\n";
+        return 0;
+    }
+}
+
+1;

--- a/src/lib/Hydra/TaskDispatcher.pm
+++ b/src/lib/Hydra/TaskDispatcher.pm
@@ -137,7 +137,7 @@ Arguments:
 
 =item C<$event>
 
-L<Hydra::Event> the event, usually from L<Hydra::PostgresListener>.
+L<Hydra::Event> The event, usually from L<Hydra::PostgresListener>.
 
 =back
 
@@ -154,7 +154,7 @@ sub dispatch_event {
 
 =head2 dispatch_task
 
-Execute a specifi plugin against the provided L<Hydra::Task>.
+Execute a specific plugin against the provided L<Hydra::Task>.
 The Task includes information about what plugin should be executed.
 If the provided plugin does not exist, an error logged is logged and the
 function returns falsey.
@@ -165,7 +165,7 @@ Arguments:
 
 =item C<$task>
 
-L<Hydra::Task> the task, usually from L<Hydra::Shema::Result::TaskRetries>.
+L<Hydra::Task> The task, usually from L<Hydra::Shema::Result::TaskRetries>.
 
 =back
 
@@ -215,7 +215,7 @@ Arguments:
 
 =item C<$task>
 
-L<Hydra::Task> the task to mark as successful.
+L<Hydra::Task> The task to mark as successful.
 
 =back
 
@@ -243,7 +243,7 @@ Arguments:
 
 =item C<$task>
 
-L<Hydra::Task> the task to mark as successful.
+L<Hydra::Task> The task to mark as successful.
 
 =back
 
@@ -278,7 +278,7 @@ Arguments:
 
 =item C<$task>
 
-L<Hydra::Task> the task to return labels for.
+L<Hydra::Task> The task to return labels for.
 
 =back
 

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -101,10 +101,12 @@ for my $build ($db->resultset('Builds')->search(
     $task_dispatcher->dispatch_event($event);
 }
 
+my $taskretries = $db->resultset('TaskRetries');
+
 # Process incoming notifications.
 while (!$queued_only) {
     $prom->inc("event_loop_iterations");
-    my $messages = $listener->block_for_messages();
+    my $messages = $listener->block_for_messages($taskretries->get_seconds_to_next_retry());
     while (my $message = $messages->()) {
         $prom->set("event_received", time());
         my $channelName = $message->{"channel"};
@@ -128,4 +130,10 @@ while (!$queued_only) {
             print STDERR "error processing message '$payload' on channel '$channelName': $@\n";
         }
     }
+
+    my $task = $taskretries->getRetryableTask();
+    if (defined($task)) {
+        $task_dispatcher->dispatchTask($task);
+    }
+
 }

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -73,7 +73,15 @@ GetOptions(
 my $db = Hydra::Model::DB->new();
 
 my @plugins = Hydra::Plugin->instantiate(db => $db, config => $config);
-my $task_dispatcher = Hydra::TaskDispatcher->new($db, $prom, [@plugins]);
+my $task_dispatcher = Hydra::TaskDispatcher->new(
+    $db,
+    $prom,
+    [@plugins],
+    sub {
+        my ($task) = @_;
+        $db->resultset("TaskRetries")->save_task($task);
+    }
+);
 
 my $dbh = $db->storage->dbh;
 

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -10,9 +10,9 @@ use Hydra::Helper::AddBuilds;
 use Hydra::Helper::Nix;
 use Hydra::Plugin;
 use Hydra::PostgresListener;
+use Hydra::TaskDispatcher;
 use Parallel::ForkManager;
 use Prometheus::Tiny::Shared;
-use Time::HiRes qw( gettimeofday tv_interval );
 
 STDERR->autoflush(1);
 STDOUT->autoflush(1);
@@ -25,26 +25,6 @@ my $prom = Prometheus::Tiny::Shared->new;
 # Add a new declaration for any new metrics you create. Metrics which are
 # not pre-declared disappear when their value is null. See:
 # https://metacpan.org/pod/Prometheus::Tiny#declare
-$prom->declare(
-    "notify_plugin_executions",
-    type => "counter",
-    help => "Number of times each plugin has been called by channel."
-);
-$prom->declare(
-    "notify_plugin_runtime",
-    type => "histogram",
-    help => "Number of seconds spent executing each plugin by channel."
-);
-$prom->declare(
-    "notify_plugin_success",
-    type => "counter",
-    help => "Number of successful executions of this plugin on this channel."
-);
-$prom->declare(
-    "notify_plugin_error",
-    type => "counter",
-    help => "Number of failed executions of this plugin on this channel."
-);
 $prom->declare(
     "event_loop_iterations",
     type => "counter",
@@ -93,6 +73,7 @@ GetOptions(
 my $db = Hydra::Model::DB->new();
 
 my @plugins = Hydra::Plugin->instantiate(db => $db, config => $config);
+my $task_dispatcher = Hydra::TaskDispatcher->new($db, $prom, [@plugins]);
 
 my $dbh = $db->storage->dbh;
 
@@ -102,38 +83,15 @@ $listener->subscribe("build_finished");
 $listener->subscribe("step_finished");
 $listener->subscribe("hydra_notify_dump_metrics");
 
-sub runPluginsForEvent {
-    my ($event) = @_;
-
-    my $channelName = $event->{'channel_name'};
-
-    foreach my $plugin (@plugins) {
-        $prom->inc("notify_plugin_executions", { channel => $channelName, plugin => ref $plugin });
-        eval {
-            my $startTime = [gettimeofday()];
-            $event->execute($db, $plugin);
-
-            $prom->histogram_observe("notify_plugin_runtime", tv_interval($startTime), { channel => $channelName, plugin => ref $plugin });
-            $prom->inc("notify_plugin_success", { channel => $channelName, plugin => ref $plugin });
-            1;
-        } or do {
-            $prom->inc("notify_plugin_error", { channel => $channelName, plugin => ref $plugin });
-            print STDERR "error running $event->{'channel_name'} hooks: $@\n";
-        }
-    }
-}
-
 # Process builds that finished while hydra-notify wasn't running.
 for my $build ($db->resultset('Builds')->search(
                    { notificationpendingsince => { '!=', undef } }))
 {
     print STDERR "sending notifications for build ${\$build->id}...\n";
 
-
-    my $event = Hydra::Event::BuildFinished->new($build->id);
-    runPluginsForEvent($event);
+    my $event = Hydra::Event->new_event("build_finished", $build->id);
+    $task_dispatcher->dispatch_event($event);
 }
-
 
 # Process incoming notifications.
 while (!$queued_only) {
@@ -154,7 +112,7 @@ while (!$queued_only) {
 
         eval {
             my $event = Hydra::Event->new_event($channelName, $message->{"payload"});
-            runPluginsForEvent($event);
+            $task_dispatcher->dispatch_event($event);
 
             1;
         } or do {

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -553,6 +553,21 @@ create table StarredJobs (
     foreign key   (project, jobset) references Jobsets(project, name) on update cascade on delete cascade
 );
 
+-- Events processed by hydra-notify which have failed at least once
+--
+-- The payload field contains the original, unparsed payload.
+--
+-- One row is created for each plugin which fails to process the event,
+-- with an increasing retry_at and attempts field.
+create table TaskRetries (
+    id            serial primary key not null,
+    channel       text not null,
+    pluginname    text not null,
+    payload       text not null,
+    attempts      integer not null,
+    retry_at      integer not null
+);
+create index IndexTaskRetriesOrdered on TaskRetries(retry_at asc);
 
 -- The output paths that have permanently failed.
 create table FailedPaths (

--- a/src/sql/update-dbix.pl
+++ b/src/sql/update-dbix.pl
@@ -39,6 +39,7 @@ make_schema_at("Hydra::Schema", {
         "starredjobs" => "StarredJobs",
         "systemstatus" => "SystemStatus",
         "systemtypes" => "SystemTypes",
+        "taskretries" => "TaskRetries",
         "urirevmapper" => "UriRevMapper",
         "userroles" => "UserRoles",
         "users" => "Users",

--- a/src/sql/upgrade-77.sql
+++ b/src/sql/upgrade-77.sql
@@ -1,0 +1,15 @@
+-- Events processed by hydra-notify which have failed at least once
+--
+-- The payload field contains the original, unparsed payload.
+--
+-- One row is created for each plugin which fails to process the event,
+-- with an increasing retry_at and attempts field.
+create table TaskRetries (
+    id            serial primary key not null,
+    channel       text not null,
+    pluginname    text not null,
+    payload       text not null,
+    attempts      integer not null,
+    retry_at      integer not null
+);
+create index IndexTaskRetriesOrdered on TaskRetries(retry_at asc);

--- a/t/Math.t
+++ b/t/Math.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Setup;
+
+use Hydra::Math qw(exponential_backoff);
+
+use Test2::V0;
+
+subtest "exponential_backoff" => sub {
+    is(exponential_backoff(0), 1);
+    is(exponential_backoff(1), 2);
+    is(exponential_backoff(2), 4);
+    is(exponential_backoff(9), 512);
+    is(exponential_backoff(10), 1024);
+    is(exponential_backoff(11), 1024, "we're clamped to 1024 seconds");
+    is(exponential_backoff(11000), 1024, "we're clamped to 1024 seconds");
+};
+
+done_testing;

--- a/t/Schema/Result/TaskRetries.t
+++ b/t/Schema/Result/TaskRetries.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Setup;
+
+my %ctx = test_init();
+
+require Hydra::Schema;
+require Hydra::Model::DB;
+
+use Test2::V0;
+
+my $db = Hydra::Model::DB->new;
+hydra_setup($db);
+
+my $taskretries = $db->resultset('TaskRetries');
+
+subtest "requeue" => sub {
+    my $task = $taskretries->create({
+        channel => "bogus",
+        pluginname => "bogus",
+        payload => "bogus",
+        attempts => 1,
+        retry_at => time(),
+    });
+
+    $task->requeue();
+    is($task->attempts, 2, "We should have stored a second retry");
+    is($task->retry_at, within(time() + 4, 2), "Delayed two exponential backoff step");
+
+    $task->requeue();
+    is($task->attempts, 3, "We should have stored a third retry");
+    is($task->retry_at, within(time() + 8, 2), "Delayed a third exponential backoff step");
+};
+
+done_testing;

--- a/t/Schema/ResultSet/TaskRetries.t
+++ b/t/Schema/ResultSet/TaskRetries.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Setup;
+
+my %ctx = test_init();
+
+require Hydra::Schema;
+require Hydra::Model::DB;
+
+use Test2::V0;
+
+my $db = Hydra::Model::DB->new;
+hydra_setup($db);
+
+my $taskretries = $db->resultset('TaskRetries');
+
+subtest "get_seconds_to_next_retry" => sub {
+    subtest "Without any records in the database" => sub {
+        is($taskretries->get_seconds_to_next_retry(), undef, "Without any records our next retry moment is forever away.");
+    };
+
+    subtest "With only tasks whose retry timestamps are in the future" => sub {
+        $taskretries->create({
+            channel => "bogus",
+            pluginname => "bogus",
+            payload => "bogus",
+            attempts => 1,
+            retry_at => time() + 100,
+        });
+        is($taskretries->get_seconds_to_next_retry(), within(100, 2), "We should retry in roughly 100 seconds");
+    };
+
+    subtest "With tasks whose retry timestamp are in the past" => sub {
+        $taskretries->create({
+            channel => "bogus",
+            pluginname => "bogus",
+            payload => "bogus",
+            attempts => 1,
+            retry_at => time() - 100,
+        });
+        is($taskretries->get_seconds_to_next_retry(), 0, "We should retry immediately");
+    }
+};
+
+done_testing;

--- a/t/TaskDispatcher.t
+++ b/t/TaskDispatcher.t
@@ -1,0 +1,122 @@
+use strict;
+use warnings;
+use Setup;
+
+use Hydra::TaskDispatcher;
+use Prometheus::Tiny::Shared;
+
+use Test2::V0;
+use Test2::Tools::Mock qw(mock_obj);
+
+my $db = "bogus db";
+my $prometheus  = Prometheus::Tiny::Shared->new;
+
+sub make_noop_plugin {
+    my ($name) = @_;
+    my $plugin = {
+        "name" => $name,
+    };
+    my $mock_plugin = mock_obj $plugin => ();
+
+    return $mock_plugin;
+}
+
+sub make_fake_event {
+    my ($channel_name) = @_;
+
+    my $event = {
+        channel_name => $channel_name,
+        called_with => [],
+    };
+    my $mock_event = mock_obj $event => (
+        add => [
+            "execute" => sub {
+                my ($self, $db, $plugin) = @_;
+                push @{$self->{"called_with"}}, $plugin;
+            }
+        ]
+    );
+
+    return $mock_event;
+}
+
+sub make_failing_event {
+    my ($channel_name) = @_;
+
+    my $event = {
+        channel_name => $channel_name,
+        called_with => [],
+    };
+    my $mock_event = mock_obj $event => (
+        add => [
+            "execute" => sub {
+                my ($self, $db, $plugin) = @_;
+                push @{$self->{"called_with"}}, $plugin;
+                die "Failing plugin."
+            }
+        ]
+    );
+
+    return $mock_event;
+}
+
+subtest "dispatch_event" => sub {
+    subtest "every plugin gets called once, even if it fails all of them." => sub {
+        my @plugins = [make_noop_plugin("bogus-1"), make_noop_plugin("bogus-2")];
+
+        my $dispatcher = Hydra::TaskDispatcher->new($db, $prometheus, @plugins);
+
+        my $event = make_failing_event("bogus-channel");
+        $dispatcher->dispatch_event($event);
+
+        is(@{$event->{"called_with"}}, 2, "Both plugins should be called");
+
+        my @expected_names = [ "bogus-1", "bogus-2" ];
+        my @actual_names = sort([
+                $event->{"called_with"}[0]->name,
+                $event->{"called_with"}[1]->name
+        ]);
+
+        is(
+            @actual_names,
+            @expected_names,
+            "Both plugins should be executed, but not in any particular order."
+        );
+    };
+};
+
+subtest "dispatch_task" => sub {
+    subtest "every plugin gets called once" => sub {
+        my $bogus_plugin = make_noop_plugin("bogus-1");
+        my @plugins = [$bogus_plugin, make_noop_plugin("bogus-2")];
+
+        my $dispatcher = Hydra::TaskDispatcher->new($db, $prometheus, @plugins);
+
+        my $event = make_fake_event("bogus-channel");
+        my $task = Hydra::Task->new($event, ref $bogus_plugin);
+        is($dispatcher->dispatch_task($task), 1, "Calling dispatch_task returns truthy.");
+
+        is(@{$event->{"called_with"}}, 1, "Just one plugin should be called");
+
+        is(
+            $event->{"called_with"}[0]->name,
+            "bogus-1",
+            "Just bogus-1 should be executed."
+        );
+    };
+    subtest "a task with an invalid plugin is not fatal" => sub {
+        my $bogus_plugin = make_noop_plugin("bogus-1");
+        my @plugins = [$bogus_plugin, make_noop_plugin("bogus-2")];
+
+        my $dispatcher = Hydra::TaskDispatcher->new($db, $prometheus, @plugins);
+
+        my $event = make_fake_event("bogus-channel");
+        my $task = Hydra::Task->new($event, "this-plugin-does-not-exist");
+        is($dispatcher->dispatch_task($task), 0, "Calling dispatch_task returns falsey.");
+
+        is(@{$event->{"called_with"}}, 0, "No plugins are called");
+    };
+};
+
+
+done_testing;


### PR DESCRIPTION
Hydra's `hydra-notify` process is currently fire-and-forget.
This is troublesome for plugins that implement important behaviors
for Hydra as the result of plugins. For example, declarative jobsets
can mysteriously fail to update if its plugin misbehaves and fails
during its execution.

This pull request adds an element of retries to `hydra-notify`.

Every event that comes from Postgres's LISTEN/NOTIFY channel is turned
in to an Event: a parsed version of the data, plus the original raw
payload. The status quo is every Plugin is then executed with this 
Event.

This pull request adds an additional step. The Event is turned in to a
Task, which is an Event with an attached Plugin name. The Task is then
executed by the TaskDispatcher. If the Task fails, the dispatcher saves
the Task in a Postgres table called TaskRetries with a specified delay.

After 100 retries, the task is deleted and never retried again.

This PR adds new counters to hydra-notify's prometheus exporter to track
retries:

* `notify_plugin_retry_success` - Number of successful executions of
  retried tasks.
* `notify_plugin_drop` - Number of tasks that have been dropped after
  too many retries.
* `notify_plugin_requeue` - Number of tasks that have been requeued after
  a failure.

Administrators monitoring their Hydra should watch for
`notify_plugin_requeue` increasing and examine the logs for more
information.

Previous PRs that came from this project:

- https://github.com/NixOS/hydra/pull/995
- https://github.com/NixOS/hydra/pull/996
- https://github.com/NixOS/hydra/pull/997
- https://github.com/NixOS/hydra/pull/998
- https://github.com/NixOS/hydra/pull/1001
- https://github.com/NixOS/hydra/pull/1007

Remaining todo:

- [x] write and test a migration