### PR TITLE
Add test for creating blank username

### DIFF
--- a/t/scripts/hydra-create-user.t
+++ b/t/scripts/hydra-create-user.t
@@ -51,6 +51,11 @@ subtest "Handling password and password hash creation" => sub {
         ok($user->check_password("foobar"), "Their password validates");
         is($storedPassword, $user->password, "The password was not upgraded.");
     };
+
+    subtest "Creating a user with a blank username should fail" => sub {
+        my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-create-user", "", "--password", "foobar"));
+        is($res, 1, "hydra-create-user should exit one");
+    };
 };
 
 done_testing;


### PR DESCRIPTION
Perhaps a different exit code. But this should fail. Preferably enforced in DB, not just a hydra-create-user check.