### PR TITLE
gitea-plugin: fix test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -797,7 +797,7 @@
               machine.wait_for_open_port(3001)
 
               machine.succeed(
-                  "su -l gitea -c 'GITEA_WORK_DIR=/var/lib/gitea gitea admin create-user "
+                  "su -l gitea -c 'GITEA_WORK_DIR=/var/lib/gitea gitea admin user create "
                   + "--username root --password root --email test@localhost'"
               )
               machine.succeed("su -l postgres -c 'psql gitea < ${scripts.mktoken}'")


### PR DESCRIPTION
The test seems to be broken for a while[1]. The cause for this is that
in gitea 1.14 the `create-user` command got renamed to `user create`.

[1] https://hydra.nixos.org/build/151092299

cc @grahamc 