### PR TITLE
ResultSet::TaskRetries: add missing method, get_retryable_task

### DIFF
--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -131,9 +131,8 @@ while (!$queued_only) {
         }
     }
 
-    my $task = $taskretries->getRetryableTask();
+    my $task = $taskretries->get_retryable_task();
     if (defined($task)) {
-        $task_dispatcher->dispatchTask($task);
+        $task_dispatcher->dispatch_task($task);
     }
-
 }


### PR DESCRIPTION
Yet again, manual testing is proving to be insufficient. I'm pretty
sure I wrote this code but lost it in a rebase, or perhaps the switch
to result classes.

At any rate, this implements the actual "fetch a retry row and run it"
for the hydra-notify daemon.

Tested by hand.