### PR TITLE
Fix building $(srcdir)/static

### DIFF
--- a/src/root/Makefile.am
+++ b/src/root/Makefile.am
@@ -22,9 +22,11 @@ nobase_hydra_DATA = $(EXTRA_DIST)
 all:
 	mkdir -p $(srcdir)/static/js
 	unzip -u -d $(srcdir)/static $(BOOTSTRAP)
+	rm -rf $(srcdir)/static/bootstrap
 	mv $(srcdir)/static/$(basename $(BOOTSTRAP)) $(srcdir)/static/bootstrap
 	unzip -u -d $(srcdir)/static/js $(FLOT)
 	unzip -u -d $(srcdir)/static $(FONTAWESOME)
+	rm -rf $(srcdir)/static/fontawesome
 	mv $(srcdir)/static/$(basename $(FONTAWESOME)) $(srcdir)/static/fontawesome
 
 install-data-local: $(ZIPS)


### PR DESCRIPTION
Fixes

```
mv: cannot move './static/bootstrap-4.3.1-dist' to './static/bootstrap/bootstrap-4.3.1-dist': Directory not empty
```

when 'make' is called more than once.