### PR TITLE
Fix 'Error loading tab: 0 error' with uBlock Origin

### DIFF
--- a/src/lib/Hydra/Controller/Job.pm
+++ b/src/lib/Hydra/Controller/Job.pm
@@ -144,7 +144,7 @@ sub overview : Chained('job') PathPart('') Args(0) {
 }
 
 
-sub metrics_tab : Chained('job') PathPart('metrics-tab') Args(0) {
+sub metrics_tab : Chained('job') PathPart('metric-tab') Args(0) {
     my ($self, $c) = @_;
     $c->stash->{template} = 'job-metrics-tab.tt';
     $c->stash->{metrics} = [ $c->stash->{jobset}->buildmetrics->search(

--- a/src/root/job.tt
+++ b/src/root/job.tt
@@ -84,7 +84,7 @@ removed or had an evaluation error.</div>
 
   [% END %]
 
-  [% INCLUDE makeLazyTab tabName="tabs-charts" uri=c.uri_for('/job' project.name jobset.name job 'metrics-tab') %]
+  [% INCLUDE makeLazyTab tabName="tabs-charts" uri=c.uri_for('/job' project.name jobset.name job 'metric-tab') %]
 
   <div id="tabs-links" class="tab-pane">
     <ul>


### PR DESCRIPTION
/metrics-tab matches a rule in one of uBlock Origin's default blocklists, so let's name it something else.

This can be seen on https://hydra.nixos.org/job/nixpkgs/trunk/metrics#tabs-charts.