### PR TITLE
constituents test: add use warnings

### DIFF
--- a/t/Controller/Build/constituents.t
+++ b/t/Controller/Build/constituents.t
@@ -1,4 +1,5 @@
 use strict;
+use warnings;
 use Setup;
 use JSON qw(decode_json encode_json);
 use Data::Dumper;


### PR DESCRIPTION
This is causing CI to fail after #1026 merged. #1026 had a green
bill of health, but #1003 increased perlcritic to level 4. #1003
was not part of #1026 so it was not checked at perlcritic level 4.