### PR TITLE
Hydra::Helper::Nix::getMachines: add a test

### DIFF
--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -344,11 +344,19 @@ sub getMachines {
         next unless -e $machinesFile;
         open(my $conf, "<", $machinesFile) or die;
         while (my $line = <$conf>) {
-            chomp;
-            s/\#.*$//g;
-            next if /^\s*$/;
+            chomp($line);
+            $line =~ s/\#.*$//g;
+            next if $line =~ /^\s*$/;
             my @tokens = split /\s/, $line;
+
+            if (!defined($tokens[5]) || $tokens[5] eq "-") {
+                $tokens[5] = "";
+            }
             my @supportedFeatures = split(/,/, $tokens[5] || "");
+
+            if (!defined($tokens[6]) || $tokens[6] eq "-") {
+                $tokens[6] = "";
+            }
             my @mandatoryFeatures = split(/,/, $tokens[6] || "");
             $machines{$tokens[0]} =
                 { systemTypes => [ split(/,/, $tokens[1]) ]

--- a/t/Helper/Nix.t
+++ b/t/Helper/Nix.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+use Setup;
+use File::Temp;
+
+my %ctx = test_init();
+
+require Hydra::Helper::Nix;
+
+use Test2::V0;
+
+my $dir = File::Temp->newdir();
+my $machines = "$dir/machines";
+
+$ENV{'NIX_REMOTE_SYSTEMS'} = $machines;
+
+open(my $fh, '>', $machines) or die "Could not open file '$machines' $!";
+print $fh q|
+# foobar
+root@ip x86_64-darwin /sshkey 15 15 big-parallel,kvm,nixos-test - base64key
+
+# Macs
+# root@bar x86_64-darwin /sshkey 6 1 big-parallel
+root@baz aarch64-darwin /sshkey 4 1 big-parallel
+
+root@bux i686-linux,x86_64-linux /var/sshkey 1 1 kvm,nixos-test benchmark
+
+|;
+close $fh;
+
+is(Hydra::Helper::Nix::getMachines(), {
+    'root@ip' => {
+        'systemTypes' => ["x86_64-darwin"],
+        'sshKeys' => '/sshkey',
+        'maxJobs' => 15,
+        'speedFactor' => 15,
+        'supportedFeatures' => ["big-parallel", "kvm", "nixos-test" ],
+        'mandatoryFeatures' => [ ],
+    },
+    'root@baz' => {
+        'systemTypes' => [ "aarch64-darwin" ],
+        'sshKeys' => '/sshkey',
+        'maxJobs' => 4,
+        'speedFactor' => 1,
+        'supportedFeatures' => ["big-parallel"],
+        'mandatoryFeatures' => [],
+    },
+    'root@bux' => {
+        'systemTypes' => [ "i686-linux", "x86_64-linux" ],
+        'sshKeys' => '/var/sshkey',
+        'maxJobs' => 1,
+        'speedFactor' => 1,
+        'supportedFeatures' => [ "kvm", "nixos-test", "benchmark" ],
+        'mandatoryFeatures' => [ "benchmark" ],
+    },
+
+}, ":)");
+
+done_testing;


### PR DESCRIPTION
Fix parsing breakage from #1003: assigning the lines to $lines broke chomp and the filters.

This test validates the parsing works as expected, and also fixes
a minor bug where '-' in features isn't pruned, like in the C++
repo.