### PR TITLE
update-dbix: overwrite modifications

### DIFF
--- a/src/sql/update-dbix.pl
+++ b/src/sql/update-dbix.pl
@@ -8,6 +8,7 @@ make_schema_at("Hydra::Schema", {
     naming => { ALL => "v5" },
     relationships => 1,
     use_namespaces => 1,
+    overwrite_modifications => 1,
     moniker_map => {
         "aggregateconstituents" => "AggregateConstituents",
         "buildinputs" => "BuildInputs",


### PR DESCRIPTION
Prevents authors from mistakenly corrupting the hashes. This won't delete custom code at the end of the files, but it will overwrite the "protected" section that authors should not change.