### PR TITLE
hydra-eval-jobset: log fetches and evaluations

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -235,6 +235,8 @@ sub fetchInput {
     my ($plugins, $db, $project, $jobset, $name, $type, $value, $emailresponsible) = @_;
     my @inputs;
 
+    print STDERR "(" . $project->name . ":" . $jobset->name . ") Fetching input `$name` ($type) $value\n";
+
     if ($type eq "build") {
         @inputs = fetchInputBuild($db, $project, $jobset, $name, $value);
     }
@@ -339,6 +341,8 @@ sub inputsToArgs {
 
 sub evalJobs {
     my ($inputInfo, $nixExprInputName, $nixExprPath, $flakeRef) = @_;
+
+    print STDERR "Evaluating...\n";
 
     my @cmd;
 


### PR DESCRIPTION
Sometimes evaluations will print errors about fetches. These can be hard to diagnose if you have many inputs. These log lines should help.