### PR TITLE
HydraTestContext: init a context object for helpers

### DIFF
--- a/t/View/TT.t
+++ b/t/View/TT.t
@@ -2,31 +2,25 @@ use feature 'unicode_strings';
 use strict;
 use warnings;
 use Setup;
-
-my %ctx = test_init();
-
-require Hydra::Schema;
-require Hydra::Model::DB;
-
 use Test2::V0;
 
+my $ctx = test_context();
+
 require Hydra; # calls setup()
-
-
-my $db = Hydra::Model::DB->new;
-hydra_setup($db);
-
 require Hydra::View::TT;
+require Catalyst::Test;
+
+my $db = $ctx->db;
+
 
 # The following lines are a cheap and hacky trick to get $c,
 # there is no other reason to call /.
-require Catalyst::Test;
 Catalyst::Test->import('Hydra');
 my ($_request, $c) = ctx_request('/');
 
 
 my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
-my $jobset = createBaseJobset("example", "bogus.nix", $ctx{jobsdir});
+my $jobset = createBaseJobset("example", "bogus.nix", $ctx->jobsdir);
 my $job = "myjob";
 
 

--- a/t/build-products.t
+++ b/t/build-products.t
@@ -1,43 +1,36 @@
 use strict;
 use warnings;
 use Setup;
-
-my %ctx = test_init();
-
-require Hydra::Schema;
-require Hydra::Model::DB;
-
 use Test2::V0;
 
-my $db = Hydra::Model::DB->new;
-hydra_setup($db);
-
+my $ctx = test_context();
 
 # Test build products
 
-my $jobset = createBaseJobset("build-products", "build-products.nix", $ctx{jobsdir});
+my $builds = $ctx->makeAndEvaluateJobset(
+    expression => "build-products.nix",
+    build => 1
+);
 
-ok(evalSucceeds($jobset),               "Evaluating jobs/build-products.nix should exit with return code 0");
-is(nrQueuedBuildsForJobset($jobset), 2, "Evaluating jobs/build-products.nix should result in 2 builds");
+subtest "For the build job 'simple'" => sub {
+    my $build = $builds->{"simple"};
 
-for my $build (queuedBuildsForJobset($jobset)) {
-    subtest "For the build job '" . $build->job . "'" => sub {
-        ok(runBuild($build), "Build should exit with return code 0");
-        my $newbuild = $db->resultset('Builds')->find($build->id);
+    is($build->finished, 1, "Build should have finished");
+    is($build->buildstatus, 0, "Build should have buildstatus 0");
 
-        is($newbuild->finished, 1, "Build should have finished");
-        is($newbuild->buildstatus, 0, "Build should have buildstatus 0");
+    my $buildproduct = $build->buildproducts->next;
+    is($buildproduct->name, "text.txt", "We should have \"text.txt\"");
+};
 
-        my $buildproducts = $db->resultset('BuildProducts')->search({ build => $build->id });
-        my $buildproduct = $buildproducts->next;
+subtest "For the build job 'with_spaces'" => sub {
+    my $build = $builds->{"with_spaces"};
 
-        if($build->job eq "simple") {
-            is($buildproduct->name, "text.txt", "We should have \"text.txt\"");
-        } elsif ($build->job eq "with_spaces") {
-            is($buildproduct->name, "some text.txt", "We should have: \"some text.txt\"");
-        }
-    };
+    is($build->finished, 1, "Build should have finished");
+    is($build->buildstatus, 0, "Build should have buildstatus 0");
 
-}
+    my $buildproduct = $build->buildproducts->next;
+    is($buildproduct->name, "some text.txt", "We should have: \"some text.txt\"");
+};
+
 
 done_testing;

--- a/t/evaluate-basic.t
+++ b/t/evaluate-basic.t
@@ -2,21 +2,15 @@ use feature 'unicode_strings';
 use strict;
 use warnings;
 use Setup;
-
-my %ctx = test_init();
-
-require Hydra::Schema;
-require Hydra::Model::DB;
-
 use Test2::V0;
 
-my $db = Hydra::Model::DB->new;
-hydra_setup($db);
+my $ctx = test_context();
+my $db = $ctx->db;
 
 my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
 
 # Most basic test case, no parameters
-my $jobset = createBaseJobset("basic", "basic.nix", $ctx{jobsdir});
+my $jobset = createBaseJobset("basic", "basic.nix", $ctx->jobsdir);
 
 ok(evalSucceeds($jobset),               "Evaluating jobs/basic.nix should exit with return code 0");
 is(nrQueuedBuildsForJobset($jobset), 3, "Evaluating jobs/basic.nix should result in 3 builds");

--- a/t/evaluate-basic.t
+++ b/t/evaluate-basic.t
@@ -5,22 +5,31 @@ use Setup;
 use Test2::V0;
 
 my $ctx = test_context();
-my $db = $ctx->db;
 
-my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+my $builds = $ctx->makeAndEvaluateJobset(
+    expression => "basic.nix",
+    build => 1
+);
 
-# Most basic test case, no parameters
-my $jobset = createBaseJobset("basic", "basic.nix", $ctx->jobsdir);
+subtest "Build: succeed_with_failed" => sub {
+    my $build = $builds->{"succeed_with_failed"};
 
-ok(evalSucceeds($jobset),               "Evaluating jobs/basic.nix should exit with return code 0");
-is(nrQueuedBuildsForJobset($jobset), 3, "Evaluating jobs/basic.nix should result in 3 builds");
+    is($build->finished, 1, "Build should be finished.");
+    is($build->buildstatus, 6, "succeeeded-but-failed should have buildstatus 6.");
+};
 
-for my $build (queuedBuildsForJobset($jobset)) {
-    ok(runBuild($build), "Build '".$build->job."' from jobs/basic.nix should exit with return code 0");
-    my $newbuild = $db->resultset('Builds')->find($build->id);
-    is($newbuild->finished, 1, "Build '".$build->job."' from jobs/basic.nix should be finished.");
-    my $expected = $build->job eq "fails" ? 1 : $build->job =~ /with_failed/ ? 6 : 0;
-    is($newbuild->buildstatus, $expected, "Build '".$build->job."' from jobs/basic.nix should have buildstatus $expected.");
-}
+subtest "Build: empty_dir" => sub {
+    my $build = $builds->{"empty_dir"};
+
+    is($build->finished, 1, "Build should be finished.");
+    is($build->buildstatus, 0, "Should have succeeded.");
+};
+
+subtest "Build: fails" => sub {
+    my $build = $builds->{"fails"};
+
+    is($build->finished, 1, "Build should be finished.");
+    is($build->buildstatus, 1, "Should have failed.");
+};
 
 done_testing;

--- a/t/lib/CliRunners.pm
+++ b/t/lib/CliRunners.pm
@@ -1,0 +1,50 @@
+use warnings;
+use strict;
+
+package CliRunners;
+our @ISA = qw(Exporter);
+our @EXPORT = qw(
+                 evalSucceeds runBuild sendNotifications
+                 captureStdoutStderr);
+
+
+sub captureStdoutStderr {
+    # "Lazy"-load Hydra::Helper::Nix to avoid the compile-time
+    # import of Hydra::Model::DB. Early loading of the DB class
+    # causes fixation of the DSN, and we need to fixate it after
+    # the temporary DB is setup.
+    require Hydra::Helper::Nix;
+    return Hydra::Helper::Nix::captureStdoutStderr(@_)
+}
+
+sub evalSucceeds {
+    my ($jobset) = @_;
+    my ($res, $stdout, $stderr) = captureStdoutStderr(60, ("hydra-eval-jobset", $jobset->project->name, $jobset->name));
+    $jobset->discard_changes;  # refresh from DB
+    chomp $stdout; chomp $stderr;
+    print STDERR "Evaluation errors for jobset ".$jobset->project->name.":".$jobset->name.": \n".$jobset->errormsg."\n" if $jobset->errormsg;
+    print STDERR "STDOUT: $stdout\n" if $stdout ne "";
+    print STDERR "STDERR: $stderr\n" if $stderr ne "";
+    return !$res;
+}
+
+sub runBuild {
+    my ($build) = @_;
+    my ($res, $stdout, $stderr) = captureStdoutStderr(60, ("hydra-queue-runner", "-vvvv", "--build-one", $build->id));
+    if ($res) {
+        print STDERR "Queue runner stdout: $stdout\n" if $stdout ne "";
+        print STDERR "Queue runner stderr: $stderr\n" if $stderr ne "";
+    }
+    return !$res;
+}
+
+sub sendNotifications() {
+    my ($res, $stdout, $stderr) = captureStdoutStderr(60, ("hydra-notify", "--queued-only"));
+    if ($res) {
+        print STDERR "hydra notify stdout: $stdout\n" if $stdout ne "";
+        print STDERR "hydra notify stderr: $stderr\n" if $stderr ne "";
+    }
+    return !$res;
+}
+
+1;

--- a/t/lib/HydraTestContext.pm
+++ b/t/lib/HydraTestContext.pm
@@ -118,6 +118,7 @@ sub DESTROY
 {
     my ($self) = @_;
     $self->db(0)->schema->storage->disconnect();
+    $self->{db_handle}->stop();
 }
 
 sub write_file {

--- a/t/lib/HydraTestContext.pm
+++ b/t/lib/HydraTestContext.pm
@@ -133,11 +133,18 @@ sub makeAndEvaluateJobset {
     my $should_build = $opts{'build'} // 0;
 
 
+    # Create a new user for this test
+    my $user = $self->db()->resultset('Users')->create({
+        username => rand_chars(),
+        emailaddress => rand_chars() . '@example.org',
+        password => ''
+    });
+
     # Create a new project for this test
     my $project = $self->db()->resultset('Projects')->create({
         name => rand_chars(),
         displayname => rand_chars(),
-        owner => "root"
+        owner => $user->username
     });
 
     # Create a new jobset for this test and set up the inputs

--- a/t/lib/HydraTestContext.pm
+++ b/t/lib/HydraTestContext.pm
@@ -1,0 +1,130 @@
+use strict;
+use warnings;
+
+package HydraTestContext;
+use File::Path qw(make_path);
+use File::Basename;
+use Cwd qw(abs_path getcwd);
+
+# Set up the environment for running tests.
+#
+# Hash Parameters:
+#
+#  * hydra_config: configuration for the Hydra processes for your test.
+#  * nix_config: text to include in the test's nix.conf
+#  * use_external_destination_store: Boolean indicating whether hydra should
+#       use a destination store different from the evaluation store.
+#       True by default.
+#
+# This clears several environment variables and sets them to ephemeral
+# values: a temporary database, temporary Nix store, temporary Hydra
+# data directory, etc.
+#
+# Note: This function must run _very_ early, before nearly any Hydra
+# libraries are loaded. To use this, you very likely need to `use Setup`
+# and then run `test_init`, and then `require` the Hydra libraries you
+# need.
+#
+# It returns a tuple: a handle to a temporary directory and a handle to
+# the postgres service. If either of these variables go out of scope,
+# those resources are released and the test environment becomes invalid.
+#
+# Look at the top of an existing `.t` file to see how this should be used
+# in practice.
+sub new {
+    my ($class, %opts) = @_;
+
+    my $dir = File::Temp->newdir();
+
+    $ENV{'HYDRA_DATA'} = "$dir/hydra-data";
+    mkdir $ENV{'HYDRA_DATA'};
+    $ENV{'NIX_CONF_DIR'} = "$dir/nix/etc/nix";
+    make_path($ENV{'NIX_CONF_DIR'});
+    my $nixconf = "$ENV{'NIX_CONF_DIR'}/nix.conf";
+    my $nix_config = "sandbox = false\n" . ($opts{'nix_config'} || "");
+    write_file($nixconf, $nix_config);
+    $ENV{'HYDRA_CONFIG'} = "$dir/hydra.conf";
+
+    my $hydra_config = $opts{'hydra_config'} || "";
+    if ($opts{'use_external_destination_store'} // 1) {
+        $hydra_config = "store_uri = file:$dir/nix/dest-store\n" . $hydra_config;
+    }
+
+    write_file($ENV{'HYDRA_CONFIG'}, $hydra_config);
+
+    $ENV{'NIX_LOG_DIR'} = "$dir/nix/var/log/nix";
+    $ENV{'NIX_REMOTE_SYSTEMS'} = '';
+    $ENV{'NIX_REMOTE'} = '';
+    $ENV{'NIX_STATE_DIR'} = "$dir/nix/var/nix";
+    $ENV{'NIX_STORE_DIR'} = "$dir/nix/store";
+
+    my $pgsql = Test::PostgreSQL->new(
+        extra_initdb_args => "--locale C.UTF-8"
+    );
+    $ENV{'HYDRA_DBI'} = $pgsql->dsn;
+    system("hydra-init") == 0 or die;
+
+    my $self = {
+        _db => undef,
+        db_handle => $pgsql,
+        tmpdir => $dir,
+        testdir => abs_path(dirname(__FILE__) . "/.."),
+        jobsdir => abs_path(dirname(__FILE__) . "/../jobs")
+    };
+
+    return bless $self, $class;
+}
+
+sub db {
+    my ($self, $setup) = @_;
+
+
+    if (!defined $self->{_db}) {
+        require Hydra::Schema;
+        require Hydra::Model::DB;
+        $self->{_db} = Hydra::Model::DB->new();
+
+        if (!(defined $setup && $setup == 0)) {
+            $self->{_db}->resultset('Users')->create({
+                username => "root",
+                emailaddress => 'root@invalid.org',
+                password => ''
+            });
+        }
+    }
+
+    return $self->{_db};
+}
+
+sub tmpdir {
+    my ($self) = @_;
+
+    return $self->{tmpdir};
+}
+
+sub testdir {
+    my ($self) = @_;
+
+    return $self->{testdir};
+}
+
+sub jobsdir {
+    my ($self) = @_;
+
+    return $self->{jobsdir};
+}
+
+sub DESTROY
+{
+    my ($self) = @_;
+    $self->db(0)->schema->storage->disconnect();
+}
+
+sub write_file {
+    my ($path, $text) = @_;
+    open(my $fh, '>', $path) or die "Could not open file '$path' $!";
+    print $fh $text || "";
+    close $fh;
+}
+
+1;

--- a/t/lib/Setup.pm
+++ b/t/lib/Setup.pm
@@ -10,74 +10,32 @@ use File::Basename;
 use Cwd qw(abs_path getcwd);
 
 our @ISA = qw(Exporter);
-our @EXPORT = qw(test_init hydra_setup write_file nrBuildsForJobset queuedBuildsForJobset
+our @EXPORT = qw(test_context test_init hydra_setup write_file nrBuildsForJobset queuedBuildsForJobset
                  nrQueuedBuildsForJobset createBaseJobset createJobsetWithOneInput
                  evalSucceeds runBuild sendNotifications updateRepository
                  captureStdoutStderr);
 
 # Set up the environment for running tests.
 #
-# Hash Parameters:
+# See HydraTestContext::new for documentation
+sub test_context {
+    require HydraTestContext;
+    return HydraTestContext->new(@_);
+}
+
+# Set up the environment for running tests.
 #
-#  * hydra_config: configuration for the Hydra processes for your test.
-#  * nix_config: text to include in the test's nix.conf
-#  * use_external_destination_store: Boolean indicating whether hydra should
-#       use a destination store different from the evaluation store.
-#       True by default.
-#
-# This clears several environment variables and sets them to ephemeral
-# values: a temporary database, temporary Nix store, temporary Hydra
-# data directory, etc.
-#
-# Note: This function must run _very_ early, before nearly any Hydra
-# libraries are loaded. To use this, you very likely need to `use Setup`
-# and then run `test_init`, and then `require` the Hydra libraries you
-# need.
-#
-# It returns a tuple: a handle to a temporary directory and a handle to
-# the postgres service. If either of these variables go out of scope,
-# those resources are released and the test environment becomes invalid.
-#
-# Look at the top of an existing `.t` file to see how this should be used
-# in practice.
+# See HydraTestContext::new for documentation
 sub test_init {
-    my %opts = @_;
+    require HydraTestContext;
+    my $ctx = HydraTestContext->new(@_);
 
-    my $dir = File::Temp->newdir();
-
-    $ENV{'HYDRA_DATA'} = "$dir/hydra-data";
-    mkdir $ENV{'HYDRA_DATA'};
-    $ENV{'NIX_CONF_DIR'} = "$dir/nix/etc/nix";
-    make_path($ENV{'NIX_CONF_DIR'});
-    my $nixconf = "$ENV{'NIX_CONF_DIR'}/nix.conf";
-    my $nix_config = "sandbox = false\n" . ($opts{'nix_config'} || "");
-    write_file($nixconf, $nix_config);
-    $ENV{'HYDRA_CONFIG'} = "$dir/hydra.conf";
-
-    my $hydra_config = $opts{'hydra_config'} || "";
-    if ($opts{'use_external_destination_store'} // 1) {
-        $hydra_config = "store_uri = file:$dir/nix/dest-store\n" . $hydra_config;
-    }
-
-    write_file($ENV{'HYDRA_CONFIG'}, $hydra_config);
-
-    $ENV{'NIX_LOG_DIR'} = "$dir/nix/var/log/nix";
-    $ENV{'NIX_REMOTE_SYSTEMS'} = '';
-    $ENV{'NIX_REMOTE'} = '';
-    $ENV{'NIX_STATE_DIR'} = "$dir/nix/var/nix";
-    $ENV{'NIX_STORE_DIR'} = "$dir/nix/store";
-
-    my $pgsql = Test::PostgreSQL->new(
-        extra_initdb_args => "--locale C.UTF-8"
-    );
-    $ENV{'HYDRA_DBI'} = $pgsql->dsn;
-    system("hydra-init") == 0 or die;
     return (
-        db => $pgsql,
-        tmpdir => $dir,
-        testdir => abs_path(dirname(__FILE__) . "/.."),
-        jobsdir => abs_path(dirname(__FILE__) . "/../jobs")
-    );
+        context => $ctx,
+        tmpdir => $ctx->tmpdir,
+        testdir => $ctx->testdir,
+        jobsdir => $ctx->jobsdir
+    )
 }
 
 sub write_file {

--- a/t/queue-runner/default-machine-file.t
+++ b/t/queue-runner/default-machine-file.t
@@ -2,34 +2,21 @@ use feature 'unicode_strings';
 use strict;
 use warnings;
 use Setup;
+use Test2::V0;
 
-my %ctx = test_init(
+my $ctx = test_context(
   nix_config => q|
     system-features = test-system-feature
   |
 );
 
-require Hydra::Schema;
-require Hydra::Model::DB;
+my $builds = $ctx->makeAndEvaluateJobset(
+  expression => "default-machine-file.nix",
+  build => 1,
+);
 
-use Test2::V0;
-
-my $db = Hydra::Model::DB->new;
-hydra_setup($db);
-
-my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
-
-my $jobset = createBaseJobset("default-machine-file", "default-machine-file.nix", $ctx{jobsdir});
-
-ok(evalSucceeds($jobset),               "Evaluating jobs/default-machine-file.nix should exit with return code 0");
-is(nrQueuedBuildsForJobset($jobset), 1, "Evaluating jobs/default-machine-file.nix should result in 1 build");
-
-for my $build (queuedBuildsForJobset($jobset)) {
-    ok(runBuild($build), "Build '".$build->job."' from jobs/default-machine-file.nix should exit with return code 0");
-    my $newbuild = $db->resultset('Builds')->find($build->id);
-    is($newbuild->finished, 1, "Build '".$build->job."' from jobs/default-machine-file.nix should be finished.");
-    my $expected = $build->job eq "fails" ? 1 : $build->job =~ /with_failed/ ? 6 : 0;
-    is($newbuild->buildstatus, $expected, "Build '".$build->job."' from jobs/default-machine-file.nix should have buildstatus $expected.");
-}
+my $build = $builds->{"requireExperimentalFeatures"};
+is($build->finished, 1, "Build should be finished.");
+is($build->buildstatus, 0, "Build status should be zero");
 
 done_testing;

--- a/t/queue-runner/notifications.t
+++ b/t/queue-runner/notifications.t
@@ -37,30 +37,30 @@ subtest "Pre-build the job, upload to the cache, and then delete locally" => sub
     $ENV{'NIX_LOG_DIR'} = "$scratchlogdir";
 
     my $outlink = $ctx->tmpdir . "/basic-canbesubstituted";
-    is(system("nix-build '" . $ctx->jobsdir . "/notifications.nix' -A canbesubstituted --out-link '${outlink}'"), 0, "Building notifications.nix succeeded");
-    is(system("nix copy --to 'file://${binarycachedir}' '${outlink}'"), 0, "Copying the closure to the binary cache succeeded");
+    is(system('nix-build', $ctx->jobsdir . '/notifications.nix', '-A', 'canbesubstituted', '--out-link', $outlink), 0, "Building notifications.nix succeeded");
+    is(system('nix', 'copy', '--to', "file://${binarycachedir}", $outlink), 0, "Copying the closure to the binary cache succeeded");
     my $outpath = readlink($outlink);
 
     # Delete the store path and all of the system's garbage
     is(unlink($outlink), 1, "Deleting the GC root succeeds");
-    is(system("nix log '$outpath'"), 0, "Reading the output's log succeeds");
-    is(system("nix-store --delete '$outpath'"), 0, "Deleting the notifications.nix output succeeded");
+    is(system('nix', 'log', $outpath), 0, "Reading the output's log succeeds");
+    is(system('nix-store', '--delete', $outpath), 0, "Deleting the notifications.nix output succeeded");
     is(system("nix-collect-garbage"), 0, "Delete all the system's garbage");
 };
 
 subtest "Ensure substituting the job works, but reading the log fails" => sub {
     # Build the store path, with --max-jobs 0 to prevent builds
     my $outlink = $ctx->tmpdir . "/basic-canbesubstituted";
-    is(system("nix-build '" . $ctx->jobsdir . "/notifications.nix' -A canbesubstituted --max-jobs 0 --out-link '${outlink}'"), 0, "Building notifications.nix succeeded");
+    is(system('nix-build', $ctx->jobsdir . '/notifications.nix', '-A', 'canbesubstituted', '--max-jobs', '0', '--out-link', $outlink), 0, "Building notifications.nix succeeded");
     my $outpath = readlink($outlink);
 
     # Verify trying to read this path's log fails, since we substituted it
-    isnt(system("nix log '$outpath'"), 0, "Reading the deleted output's log fails");
+    isnt(system('nix', 'log', $outpath), 0, "Reading the deleted output's log fails");
 
     # Delete the store path again and all of the store's garbage, ensuring
     # Hydra will try to build it.
     is(unlink($outlink), 1, "Deleting the GC root succeeds");
-    is(system("nix-store --delete '$outpath'"), 0, "Deleting the basic output succeeded");
+    is(system('nix-store', '--delete', $outpath), 0, "Deleting the notifications.nix output succeeded");
     is(system("nix-collect-garbage"), 0, "Delete all the system's garbage");
 };
 


### PR DESCRIPTION
Instead of passing a bunch of arguments and hashes around everywhere, let's try a test context object.

Initially I hoped making a test context object would help reduce confusing errors from the test harness while the database shuts down. This work does help with that but doesn't fully solve the problem.

While I was at it, I noticed a very common pattern of:

```perl
my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});

my $jobset = createBaseJobset("default-machine-file", "default-machine-file.nix", $ctx{jobsdir});

ok(evalSucceeds($jobset),               "Evaluating jobs/default-machine-file.nix should exit with return code 0");
is(nrQueuedBuildsForJobset($jobset), 1, "Evaluating jobs/default-machine-file.nix should result in 1 build");

for my $build (queuedBuildsForJobset($jobset)) {
    ok(runBuild($build), "Build '".$build->job."' from jobs/default-machine-file.nix should exit with return code 0");
    my $newbuild = $db->resultset('Builds')->find($build->id);
 
    ... my test here ...
}
```

This pattern has been annoying to me for a long time. For example, I've done things like:

```
my ($build) = grep { $_->nixname eq "unsubstitutable" } @builds;
```

In this patch I added a helper, makeAndEvaluateJobset which returns a hash of the builds keyed by the Nix attribute name:

```
my $build = $builds->{"unsubstitutable"};
```

I think the utility of this is most effectively demonstrated by this test whose function was not clear before, but is now very clear: https://github.com/NixOS/hydra/commit/fbce3b6ed1fa9f136ec53729c81449f1ae84aa4e?diff=split

This refactor in to a "context" also solves a very annoying and challenging "use loop" problem. We'd need to _very carefully_ bootstrap the database to avoid it, using something like:

```perl
use warnings;
use Setup;

my %ctx = test_init();

require Hydra::Schema;
require Hydra::Model::DB;

use Test2::V0;

my $db = Hydra::Model::DB->new;
hydra_setup($db);
```

where now we can be much more direct:

```perl
use strict;
use warnings;
use Setup;
use Test2::V0;

my $ctx = test_context();
```