### PR TITLE
queue-runner-status: fixup from perlcritic-level-2

### DIFF
--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -168,7 +168,7 @@ sub queue_runner_status_GET {
     my ($self, $c) = @_;
 
     #my $status = from_json($c->model('DB::SystemStatus')->find('queue-runner')->status);
-    my $status = from_json(`hydra-queue-runner --status`);
+    my $status = decode_json(`hydra-queue-runner --status`);
     if ($?) { $status->{status} = "unknown"; }
     my $json = JSON->new->pretty()->canonical();
 

--- a/t/Controller/Root/queue-runner-status.t
+++ b/t/Controller/Root/queue-runner-status.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Setup;
+use Data::Dumper;
+my %ctx = test_init();
+
+require Hydra::Schema;
+require Hydra::Model::DB;
+require Hydra::Helper::Nix;
+
+use Test2::V0;
+require Catalyst::Test;
+use HTTP::Request::Common;
+Catalyst::Test->import('Hydra');
+
+my $db = Hydra::Model::DB->new;
+hydra_setup($db);
+
+my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+
+my $jobset = createBaseJobset("basic", "basic.nix", $ctx{jobsdir});
+
+ok(evalSucceeds($jobset), "Evaluating jobs/basic.nix should exit with return code 0");
+
+subtest "/queue-runner-status" => sub {
+    my $global = request(GET '/queue-runner-status');
+    ok($global->is_success, "The page showing the the queue runner status 200's.");
+};
+
+done_testing;


### PR DESCRIPTION
from_json was legacy / deprecated. This was the only use.