### PR TITLE
Fetch the tracker HTML from the config file, remove HYDRA_TRACKER

### DIFF
--- a/doc/manual/src/configuration.md
+++ b/doc/manual/src/configuration.md
@@ -142,3 +142,12 @@ general any LDAP group of the form *hydra\_some\_role* (notice the
       role_value: dn
       role_search_options:
         deref: always
+
+Embedding Extra HTML
+--------------------
+
+Embed an analytics widget or other HTML in the `<head>` of each HTML document via:
+
+```conf
+tracker = <script src="...">
+```

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -26,7 +26,7 @@ let
     } // hydraEnv // cfg.extraEnv;
 
   serverEnv = env //
-    { HYDRA_TRACKER = cfg.tracker;
+    {
       COLUMNS = "80";
       PGPASSFILE = "${baseDir}/pgpass-www"; # grrr
       XDG_CACHE_HOME = "${baseDir}/www/.cache";
@@ -240,6 +240,14 @@ in
         ''}
         gc_roots_dir = ${cfg.gcRootsDir}
         use-substitutes = ${if cfg.useSubstitutes then "1" else "0"}
+
+        ${optionalString (cfg.tracker != null) (let
+            indentedTrackerData = lib.concatMapStringsSep "\n" (line: "    ${line}") (lib.splitString "\n" cfg.tracker);
+          in ''
+          tracker = <<TRACKER
+          ${indentedTrackerData}
+            TRACKER
+        '')}
       '';
 
     environment.systemPackages = [ cfg.package ];

--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -49,7 +49,7 @@ sub begin :Private {
     $c->stash->{nixVersion} = $ENV{"NIX_RELEASE"} || "<devel>";
     $c->stash->{curTime} = time;
     $c->stash->{logo} = defined $c->config->{hydra_logo} ? "/logo" : "";
-    $c->stash->{tracker} = $ENV{"HYDRA_TRACKER"};
+    $c->stash->{tracker} = defined $c->config->{tracker} ? $c->config->{tracker} : "";
     $c->stash->{flashMsg} = $c->flash->{flashMsg};
     $c->stash->{successMsg} = $c->flash->{successMsg};
 


### PR DESCRIPTION
The indentation in the hydra.conf makes it possible to include multi-line
strings without it being likely that the contents of the tracker
is mis-parsed or interrupts tho config parser.

It isn't impossible / foolproof probably, but it shouldn't be likely.