### PR TITLE
Builds: drop the jobset and project columns

### DIFF
--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -200,7 +200,7 @@ sub machines :Local Args(0) {
 
     $c->stash->{machines} = $machines;
     $c->stash->{steps} = dbh($c)->selectall_arrayref(
-        "select build, stepnr, s.system as system, s.drvpath as drvpath, machine, s.starttime as starttime, jobsets.project, jobsets.name, job, s.busy as busy " .
+        "select build, stepnr, s.system as system, s.drvpath as drvpath, machine, s.starttime as starttime, jobsets.project as project, jobsets.name as jobset, job, s.busy as busy " .
         "from BuildSteps s " .
         "join Builds b on s.build = b.id " .
         "join Jobsets jobsets on jobsets.id = b.jobset_id " .

--- a/src/lib/Hydra/Plugin/EmailNotification.pm
+++ b/src/lib/Hydra/Plugin/EmailNotification.pm
@@ -120,8 +120,8 @@ sub buildFinished {
 
         sendEmail(
             $self->{config}, $to, $subject, $body,
-            [ 'X-Hydra-Project'  => $topbuild->get_column('project'),
-            , 'X-Hydra-Jobset'   => $topbuild->get_column('jobset'),
+            [ 'X-Hydra-Project'  => $topbuild->jobset->get_column('project'),
+            , 'X-Hydra-Jobset'   => $topbuild->jobset->get_column('name'),
             , 'X-Hydra-Job'      => $topbuild->get_column('job'),
             , 'X-Hydra-System'   => $topbuild->system
             ]);

--- a/src/lib/Hydra/Plugin/HipChatNotification.pm
+++ b/src/lib/Hydra/Plugin/HipChatNotification.pm
@@ -59,7 +59,7 @@ sub buildFinished {
 
         my $msg = "";
         $msg .= "<img src='$img'/> ";
-        $msg .= "Job <a href='$baseurl/job/${\$topbuild->get_column('project')}/${\$topbuild->get_column('jobset')}/${\$topbuild->get_column('job')}'>${\showJobName($topbuild)}</a>";
+        $msg .= "Job <a href='$baseurl/job/${\$topbuild->jobset->get_column('project')}/${\$topbuild->jobset->get_column('name')}/${\$topbuild->get_column('job')}'>${\showJobName($topbuild)}</a>";
         $msg .= " (and ${\scalar @deps} others)" if scalar @deps > 0;
         $msg .= ": <a href='$baseurl/build/${\$topbuild->id}'>" . showStatus($topbuild) . "</a>";
 

--- a/src/lib/Hydra/Plugin/InfluxDBNotification.pm
+++ b/src/lib/Hydra/Plugin/InfluxDBNotification.pm
@@ -111,9 +111,9 @@ sub buildFinished {
         my $tagSet = {
             status  => toBuildStatusClass($b->buildstatus),
             result  => toBuildStatusDetailed($b->buildstatus),
-            project => $b->get_column('project'),
-            jobset  => $b->get_column('jobset'),
-            repo    => ($b->get_column('jobset') =~ /^(.*)\.pr-/) ? $1 : $b->get_column('jobset'),
+            project => $b->jobset->get_column('project'),
+            jobset  => $b->jobset->get_column('name'),
+            repo    => ($b->jobset->get_column('name') =~ /^(.*)\.pr-/) ? $1 : $b->jobset->get_column('name'),
             job     => $b->get_column('job'),
             system  => $b->system,
             cached  => $b->iscachedbuild ? "true" : "false",

--- a/src/lib/Hydra/Plugin/SlackNotification.pm
+++ b/src/lib/Hydra/Plugin/SlackNotification.pm
@@ -140,7 +140,7 @@ sub buildFinished {
             "danger";
 
         my $text = "";
-        $text .= "Job <$baseurl/job/${\$topbuild->get_column('project')}/${\$topbuild->get_column('jobset')}/${\$topbuild->get_column('job')}|${\showJobName($topbuild)}>";
+        $text .= "Job <$baseurl/job/${\$topbuild->jobset->get_column('project')}/${\$topbuild->jobset->get_column('name')}/${\$topbuild->get_column('job')}|${\showJobName($topbuild)}>";
         $text .= " (and ${\scalar @deps} others)" if scalar @deps > 0;
         $text .= ": <$baseurl/build/${\$topbuild->id}|" . showStatus($topbuild) . ">". " in " . renderDuration($topbuild);
 

--- a/src/lib/Hydra/Schema/Result/Builds.pm
+++ b/src/lib/Hydra/Schema/Result/Builds.pm
@@ -597,4 +597,9 @@ sub as_json {
   return $json;
 }
 
+sub project {
+  my ($self) = @_;
+  return $self->jobset->project;
+}
+
 1;

--- a/src/lib/Hydra/Schema/Result/Builds.pm
+++ b/src/lib/Hydra/Schema/Result/Builds.pm
@@ -52,18 +52,6 @@ __PACKAGE__->table("builds");
   data_type: 'integer'
   is_nullable: 0
 
-=head2 project
-
-  data_type: 'text'
-  is_foreign_key: 1
-  is_nullable: 0
-
-=head2 jobset
-
-  data_type: 'text'
-  is_foreign_key: 1
-  is_nullable: 0
-
 =head2 jobset_id
 
   data_type: 'integer'
@@ -206,10 +194,6 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_nullable => 0 },
   "timestamp",
   { data_type => "integer", is_nullable => 0 },
-  "project",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
-  "jobset",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "jobset_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "job",
@@ -439,21 +423,6 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
 );
 
-=head2 jobset_project_jobset
-
-Type: belongs_to
-
-Related object: L<Hydra::Schema::Result::Jobsets>
-
-=cut
-
-__PACKAGE__->belongs_to(
-  "jobset_project_jobset",
-  "Hydra::Schema::Result::Jobsets",
-  { name => "jobset", project => "project" },
-  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "CASCADE" },
-);
-
 =head2 jobsetevalinputs
 
 Type: has_many
@@ -482,21 +451,6 @@ __PACKAGE__->has_many(
   "Hydra::Schema::Result::JobsetEvalMembers",
   { "foreign.build" => "self.id" },
   undef,
-);
-
-=head2 project
-
-Type: belongs_to
-
-Related object: L<Hydra::Schema::Result::Projects>
-
-=cut
-
-__PACKAGE__->belongs_to(
-  "project",
-  "Hydra::Schema::Result::Projects",
-  { name => "project" },
-  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "CASCADE" },
 );
 
 =head2 runcommandlogs
@@ -543,8 +497,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-11-17 12:42:34
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ylttv/NTMDcSZumBXRCOCw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2022-01-10 09:43:38
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:DQF8KRinnf0imJOP+lvH9Q
 
 __PACKAGE__->has_many(
   "dependents",

--- a/src/lib/Hydra/Schema/Result/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Result/Jobsets.pm
@@ -257,7 +257,7 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 builds_jobset_ids
+=head2 builds
 
 Type: has_many
 
@@ -266,27 +266,9 @@ Related object: L<Hydra::Schema::Result::Builds>
 =cut
 
 __PACKAGE__->has_many(
-  "builds_jobset_ids",
+  "builds",
   "Hydra::Schema::Result::Builds",
   { "foreign.jobset_id" => "self.id" },
-  undef,
-);
-
-=head2 builds_project_jobsets
-
-Type: has_many
-
-Related object: L<Hydra::Schema::Result::Builds>
-
-=cut
-
-__PACKAGE__->has_many(
-  "builds_project_jobsets",
-  "Hydra::Schema::Result::Builds",
-  {
-    "foreign.jobset"  => "self.name",
-    "foreign.project" => "self.project",
-  },
   undef,
 );
 
@@ -372,8 +354,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-08-26 12:02:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:iI44C3BFTo6IsS1tBwWYsg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2022-01-08 22:24:10
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:cQOnMitrWGMoJX6kZGNW+w
 
 use JSON::MaybeXS;
 

--- a/src/lib/Hydra/Schema/Result/Projects.pm
+++ b/src/lib/Hydra/Schema/Result/Projects.pm
@@ -142,21 +142,6 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 builds
-
-Type: has_many
-
-Related object: L<Hydra::Schema::Result::Builds>
-
-=cut
-
-__PACKAGE__->has_many(
-  "builds",
-  "Hydra::Schema::Result::Builds",
-  { "foreign.project" => "self.name" },
-  undef,
-);
-
 =head2 jobsetrenames
 
 Type: has_many
@@ -243,8 +228,8 @@ Composing rels: L</projectmembers> -> username
 __PACKAGE__->many_to_many("usernames", "projectmembers", "username");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-08-26 12:02:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:nKVZ8ZNCZQQ52zbpDAaoQQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2022-01-08 22:24:10
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:r/wbX3FAm5/OFrrwOQL5fA
 
 use JSON::MaybeXS;
 

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -476,8 +476,6 @@ sub checkBuild {
         # Add the build to the database.
         $build = $jobset->builds->create(
             { timestamp => $time
-            , project => $jobset->project
-            , jobset => $jobset->name
             , jobset_id => $jobset->id
             , job => $jobName
             , description => null($buildInfo->{description})

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -162,8 +162,6 @@ create table Builds (
     timestamp     integer not null, -- time this build was added
 
     -- Info about the inputs.
-    project       text not null,
-    jobset        text not null,
     jobset_id     integer not null,
     job           text not null,
 
@@ -224,9 +222,7 @@ create table Builds (
     check (finished = 0 or (stoptime is not null and stoptime != 0)),
     check (finished = 0 or (starttime is not null and starttime != 0)),
 
-    foreign key (jobset_id) references Jobsets(id) on delete cascade,
-    foreign key (project) references Projects(name) on update cascade,
-    foreign key (project, jobset) references Jobsets(project, name) on update cascade
+    foreign key (jobset_id) references Jobsets(id) on delete cascade
 );
 
 
@@ -672,16 +668,11 @@ create index IndexBuildStepsOnStopTime on BuildSteps(stopTime desc) where startT
 create index IndexBuildStepOutputsOnPath on BuildStepOutputs(path);
 create index IndexBuildsOnFinished on Builds(finished) where finished = 0;
 create index IndexBuildsOnIsCurrent on Builds(isCurrent) where isCurrent = 1;
-create index IndexBuildsOnJobsetIsCurrent on Builds(project, jobset, isCurrent) where isCurrent = 1;
-create index IndexBuildsOnJobIsCurrent on Builds(project, jobset, job, isCurrent) where isCurrent = 1;
 create index IndexBuildsJobsetIdCurrentUnfinished on Builds(jobset_id) where isCurrent = 1 and finished = 0;
 create index IndexBuildsJobsetIdCurrentFinishedStatus on Builds(jobset_id, buildstatus) where isCurrent = 1 and finished = 1;
 create index IndexBuildsJobsetIdCurrent on Builds(jobset_id) where isCurrent = 1;
-create index IndexBuildsOnJobset on Builds(project, jobset);
-create index IndexBuildsOnProject on Builds(project);
 create index IndexBuildsOnTimestamp on Builds(timestamp);
 create index IndexBuildsOnFinishedStopTime on Builds(finished, stoptime DESC);
-create index IndexBuildsOnJobFinishedId on builds(project, jobset, job, system, finished, id DESC);
 create index IndexBuildsOnJobsetIdFinishedId on Builds(jobset_id, job, finished, id DESC);
 create index IndexFinishedSuccessfulBuilds on Builds(jobset_id, job, finished, buildstatus, id DESC) where buildstatus = 0 and finished = 1;
 create index IndexBuildsOnDrvPath on Builds(drvPath);

--- a/src/sql/upgrade-80.sql
+++ b/src/sql/upgrade-80.sql
@@ -1,0 +1,9 @@
+drop index IndexBuildsOnJobsetIsCurrent;
+drop index IndexBuildsOnJobIsCurrent;
+drop index IndexBuildsOnJobset;
+drop index IndexBuildsOnProject;
+drop index IndexBuildsOnJobFinishedId;
+
+alter table Builds
+    drop column project,
+    drop column jobset;


### PR DESCRIPTION
This is a work in progress PR which is not carefully validated. The tests do pass which is nice to see. However, I've barely even started the webserver or clicked around.

The project and jobset columns were the only foreign key to a jobset and project. #969 added a jobset_id as a replacement, but didn't go all the way to dropping the now duplicate columns. This PR finishes that.

I think a good way to apply this PR is to pull out individual commits, updating individual systems and merging / deploying them one at a time, validating in production that the change didn't break anything. This way, we can easily revert changes if it is the easiest solution.

Several commits in this PR implemented the easiest possible solution to make a test pass. Those patches should be undone, and reimplemented. One good example of this is the json_hints change which critically breaks the API. Another example is the dropping of several indexes without consideration for how it impacts the performance properties of Hydra.

--

before this PR:

```
hydra=> select pg_table_size('builds');
 pg_table_size 
---------------
   72219074560
(1 row)
```

after this PR followed by a `vacuum full builds` (which took 3734085.204 ms):

```
hydra=> select pg_table_size('builds');
 pg_table_size 
---------------
   56651767808
(1 row)
```

a reduction of 14GB.