### PR TITLE
HydraTestContext: prefix names with t

### DIFF
--- a/t/lib/HydraTestContext.pm
+++ b/t/lib/HydraTestContext.pm
@@ -189,7 +189,7 @@ sub write_file {
 }
 
 sub rand_chars {
-    return sprintf("%08X", rand(0xFFFFFFFF));
+    return sprintf("t%08X", rand(0xFFFFFFFF));
 }
 
 1;


### PR DESCRIPTION
This is necessary because jobset and project names are not allowed to
begin with a digit, and yet the generated jobset and project names would
do just that.

Not the most elegant solution, but it works.