### PR TITLE
PathInput: make the hash part of the revision

### DIFF
--- a/src/lib/Hydra/Plugin/PathInput.pm
+++ b/src/lib/Hydra/Plugin/PathInput.pm
@@ -78,7 +78,7 @@ sub fetchInput {
         { uri => $uri
         , storePath => $storePath
         , sha256hash => $sha256
-        , revision => strftime "%Y%m%d%H%M%S", gmtime($timestamp)
+        , revision => (strftime "%Y%m%d%H%M%S", gmtime($timestamp))  . ':' .  $sha256
         };
 }
 


### PR DESCRIPTION
Periodically the api-test.t would fail, complaining that the second evaluation would not have a different input revision. It turns out this is very easy to happen, because the revision is just the timestamp down to seconds. This isn't a very reasonable revision, I think. Adding the hash to the revision makes it different if the content changes.

As far as I can tell this is a reasonable change and doesn't break any assumptions in Hydra.

I ran api-test.t a few hundred times and didn't get it to fail after this.