### PR TITLE
Builds refs: showjobname: use project / jobset from relations, not the bulids table

### DIFF
--- a/src/lib/Hydra/Helper/CatalystUtils.pm
+++ b/src/lib/Hydra/Helper/CatalystUtils.pm
@@ -337,7 +337,8 @@ sub parseJobsetName {
 
 sub showJobName {
     my ($build) = @_;
-    return $build->get_column('project') . ":" . $build->get_column('jobset') . ":" . $build->get_column('job');
+    my $jobset = $build->jobset;
+    return $jobset->get_column('project') . ":" . $jobset->get_column('name') . ":" . $build->get_column('job');
 }
 
 

--- a/src/lib/Hydra/Helper/CatalystUtils.pm
+++ b/src/lib/Hydra/Helper/CatalystUtils.pm
@@ -6,7 +6,6 @@ use warnings;
 use Exporter;
 use ReadonlyX;
 use Nix::Store;
-use Hydra::Helper::Nix;
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
@@ -414,6 +413,7 @@ sub approxTableSize {
 
 sub requireLocalStore {
     my ($c) = @_;
+    require Hydra::Helper::Nix;
     notFound($c, "Nix channels are not supported by this Hydra server.") if !Hydra::Helper::Nix::isLocalStore();
 }
 

--- a/t/Hydra/Helper/CatalystUtils.t
+++ b/t/Hydra/Helper/CatalystUtils.t
@@ -4,6 +4,13 @@ use Setup;
 use Test2::V0;
 use Hydra::Helper::CatalystUtils;
 
+my $ctx = test_context();
+
+my $builds = $ctx->makeAndEvaluateJobset(
+    expression => "basic.nix",
+    build => 1
+);
+
 subtest "trim" => sub {
     my %values = (
         "" => "",
@@ -23,6 +30,10 @@ subtest "trim" => sub {
     my $uninitialized;
 
     is(trim($uninitialized), '', "Trimming an uninitialized value");
+};
+
+subtest "showJobName" => sub {
+    ok(showJobName($builds->{"empty_dir"}), "showJobName succeeds");
 };
 
 done_testing;


### PR DESCRIPTION
Taken from #1093.