### PR TITLE
Project jobset: api: update endpoints to stop using build.{project,jobset}

### DIFF
--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -254,8 +254,10 @@ sub push : Chained('api') PathPart('push') Args(0) {
     foreach my $r (@repos) {
         triggerJobset($self, $c, $_, $force) foreach $c->model('DB::Jobsets')->search(
             { 'project.enabled' => 1, 'me.enabled' => 1 },
-            { join => 'project'
-            , where => \ [ 'exists (select 1 from JobsetInputAlts where project = me.project and jobset = me.name and value = ?)', [ 'value', $r ] ]
+            {
+                join => 'project',
+                where => \ [ 'exists (select 1 from JobsetInputAlts where project = me.project and jobset = me.name and value = ?)', [ 'value', $r ] ],
+                order_by => 'me.id DESC'
             });
     }
 

--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -24,8 +24,8 @@ sub buildToHash {
     my ($build) = @_;
     my $result = {
         id => $build->id,
-        project => $build->get_column("project"),
-        jobset => $build->get_column("jobset"),
+        project => $build->jobset->get_column("project"),
+        jobset => $build->jobset->get_column("name"),
         job => $build->get_column("job"),
         system => $build->system,
         nixname => $build->nixname,

--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -54,12 +54,18 @@ sub latestbuilds : Chained('api') PathPart('latestbuilds') Args(0) {
     my $system = $c->request->params->{system};
 
     my $filter = {finished => 1};
-    $filter->{project} = $project if ! $project eq "";
-    $filter->{jobset} = $jobset if ! $jobset eq "";
+    $filter->{"jobset.project"} = $project if ! $project eq "";
+    $filter->{"jobset.name"} = $jobset if ! $jobset eq "";
     $filter->{job} = $job if !$job eq "";
     $filter->{system} = $system if !$system eq "";
 
-    my @latest = $c->model('DB::Builds')->search($filter, {rows => $nr, order_by => ["id DESC"] });
+    my @latest = $c->model('DB::Builds')->search(
+        $filter,
+        {
+            rows => $nr,
+            order_by => ["id DESC"],
+            join => [ "jobset" ]
+        });
 
     my @list;
     push @list, buildToHash($_) foreach @latest;

--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -267,7 +267,6 @@ sub push : Chained('api') PathPart('push') Args(0) {
     );
 }
 
-
 sub push_github : Chained('api') PathPart('push-github') Args(0) {
     my ($self, $c) = @_;
 

--- a/t/Hydra/Controller/API/checks.t
+++ b/t/Hydra/Controller/API/checks.t
@@ -77,4 +77,27 @@ subtest "/api/latestbuilds" => sub {
     };
 };
 
+subtest "/api/nrbuilds" => sub {
+    subtest "with no specific parameters" => sub {
+        my $response = request(GET '/api/nrbuilds?nr=1&period=hour');
+        ok($response->is_success, "The API enpdoint showing the latest builds returns 200.");
+
+        my $data = is_json($response);
+        is($data, [1]);
+    };
+
+    subtest "with very specific parameters" => sub {
+        my $build = $finishedBuilds->{"one_job"};
+        my $projectName = $build->project->name;
+        my $jobsetName = $build->jobset->name;
+        my $jobName = $build->job;
+        my $system = $build->system;
+        my $response = request(GET "/api/nrbuilds?nr=1&period=hour&project=$projectName&jobset=$jobsetName&job=$jobName&system=$system");
+        ok($response->is_success, "The API enpdoint showing the latest builds returns 200.");
+
+        my $data = is_json($response);
+        is($data, [1]);
+    };
+};
+
 done_testing;

--- a/t/Hydra/Controller/API/checks.t
+++ b/t/Hydra/Controller/API/checks.t
@@ -1,0 +1,80 @@
+use strict;
+use warnings;
+use Setup;
+use Test2::V0;
+use Catalyst::Test ();
+use HTTP::Request::Common;
+use JSON::MaybeXS qw(decode_json);
+
+sub is_json {
+    my ($response, $message) = @_;
+
+    my $data;
+    my $valid_json = lives { $data = decode_json($response->content); };
+    ok($valid_json, $message // "We get back valid JSON.");
+    if (!$valid_json) {
+        use Data::Dumper;
+        print STDERR Dumper $response->content;
+    }
+
+    return $data;
+}
+
+my $ctx = test_context();
+
+Catalyst::Test->import('Hydra');
+
+my $finishedBuilds = $ctx->makeAndEvaluateJobset(
+    expression => "one-job.nix",
+    build => 1
+);
+
+my $queuedBuilds = $ctx->makeAndEvaluateJobset(
+    expression => "one-job.nix",
+    build => 0
+);
+
+subtest "/api/queue" => sub {
+    my $response = request(GET '/api/queue?nr=1');
+    ok($response->is_success, "The API enpdoint showing the queue returns 200.");
+
+    my $data = is_json($response);
+    my $build = $queuedBuilds->{"one_job"};
+    like($data, [{
+        priority => $build->priority,
+        id => $build->id,
+    }]);
+};
+
+subtest "/api/latestbuilds" => sub {
+    subtest "with no specific parameters" => sub {
+        my $response = request(GET '/api/latestbuilds?nr=1');
+        ok($response->is_success, "The API enpdoint showing the latest builds returns 200.");
+
+        my $data = is_json($response);
+        my $build = $finishedBuilds->{"one_job"};
+        like($data, [{
+            buildstatus => $build->buildstatus,
+            id => $build->id,
+        }]);
+    };
+
+    subtest "with very specific parameters" => sub {
+        my $build = $finishedBuilds->{"one_job"};
+        my $projectName = $build->project->name;
+        my $jobsetName = $build->jobset->name;
+        my $jobName = $build->job;
+        my $system = $build->system;
+        my $response = request(GET "/api/latestbuilds?nr=1&project=$projectName&jobset=$jobsetName&job=$jobName&system=$system");
+        ok($response->is_success, "The API enpdoint showing the latest builds returns 200.");
+
+        my $data = is_json($response);
+
+        like($data, [{
+            buildstatus => $build->buildstatus,
+            id => $build->id,
+        }]);
+    };
+};
+
+done_testing;

--- a/t/jobs/one-job.nix
+++ b/t/jobs/one-job.nix
@@ -1,0 +1,8 @@
+with import ./config.nix;
+{
+  one_job =
+    mkDerivation {
+      name = "empty-dir";
+      builder = ./empty-dir-builder.sh;
+    };
+}


### PR DESCRIPTION
Extracted from #1093.

My methodology here is to:

1. Pick a commit from #1093
2. Check out the parent commit
3. Run the test suite and identify failing tests
4. Check out the picked commit and run those failing tests
5. Verify the picked commit fixed at least one test.

If it didn't, write a test and verify it is broken before / fixed after the picked commit.

The picked commit in this case was `Fixup project name, jobset name, in buildToHash`. After implementing a test for that behavior I noticed a handful of other codepaths that used project and jobset, so I fixed those too. I thought the `push*` APIs used them, but they don't.