### PR TITLE
Project jobset: update search

### DIFF
--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -471,8 +471,10 @@ sub search :Local Args(0) {
             , "jobset.hidden" => 0
             , iscurrent => 1
             },
-            { order_by => ["project", "jobset", "job"], join => ["project", "jobset"]
-            , rows => $c->stash->{limit} + 1
+            {
+                order_by => ["jobset.project", "jobset.name", "job"],
+                join => { "jobset" => "project" },
+                rows => $c->stash->{limit} + 1
             } )
         ];
 

--- a/src/root/search.tt
+++ b/src/root/search.tt
@@ -67,7 +67,7 @@
     <tbody>
       [% FOREACH j IN jobs %]
         <tr>
-          <td><span>[% INCLUDE renderFullJobName project=j.get_column('project') jobset=j.get_column('jobset') job=j.job inRow=1 %]</span></td>
+          <td><span>[% INCLUDE renderFullJobName project=j.jobset.get_column('project') jobset=j.jobset.get_column('name') job=j.job inRow=1 %]</span></td>
         </tr>
       [% END %]
     </tbody>


### PR DESCRIPTION
Extracted from #1093.

My methodology here is to:

1. Pick a commit from #1093
2. Check out the parent commit
3. Run the test suite and identify failing tests
4. Check out the picked commit and run those failing tests
5. Verify the picked commit fixed at least one test.

If it didn't, write a test and verify it is broken before / fixed after the picked commit.

The picked commit in this case was `search: fix references to jobset / project info`.