### PR TITLE
Projects: delete: delete all builds first

### DIFF
--- a/src/lib/Hydra/Controller/Project.pm
+++ b/src/lib/Hydra/Controller/Project.pm
@@ -78,8 +78,8 @@ sub project_DELETE {
     requireProjectOwner($c, $c->stash->{project});
 
     $c->model('DB')->schema->txn_do(sub {
-        $c->stash->{project}->jobsets->delete;
         $c->stash->{project}->builds->delete;
+        $c->stash->{project}->jobsets->delete;
         $c->stash->{project}->delete;
     });
 

--- a/t/Hydra/Controller/Project/delete.t
+++ b/t/Hydra/Controller/Project/delete.t
@@ -55,4 +55,21 @@ subtest "Deleting a simple project" => sub {
     );
 };
 
+subtest "Deleting a project with metrics" => sub {
+    my $builds = $ctx->makeAndEvaluateJobset(
+        expression => "runcommand.nix",
+        build => 1
+    );
+    my $project = $builds->{"metrics"}->project;
+
+    my $responseAuthed = request(DELETE "/project/${\$project->name}",
+        Cookie => $cookie,
+        Accept => "application/json"
+    );
+    is($responseAuthed->code, 200, "Deleting a project with auth returns a 200");
+
+    my $response = request(GET "/project/${\$project->name}");
+    is($response->code, 404, "Then getting the project returns a 404");
+};
+
 done_testing;

--- a/t/Hydra/Controller/Project/delete.t
+++ b/t/Hydra/Controller/Project/delete.t
@@ -1,0 +1,58 @@
+use strict;
+use warnings;
+use Setup;
+use Test2::V0;
+use Catalyst::Test ();
+use HTTP::Request;
+use HTTP::Request::Common qw(GET POST DELETE);
+use JSON::MaybeXS qw(decode_json encode_json);
+
+my $ctx = test_context();
+
+Catalyst::Test->import('Hydra');
+
+my $user = $ctx->db()->resultset('Users')->create({
+    username => 'alice',
+    emailaddress => 'root@invalid.org',
+    password => '!'
+});
+$user->setPassword('foobar');
+$user->userroles->update_or_create({ role => 'admin' });
+
+# Login and save cookie for future requests
+my $req = request(POST '/login',
+    Referer => 'http://localhost/',
+    Content => {
+        username => 'alice',
+        password => 'foobar'
+    }
+);
+is($req->code, 302, "Logging in gets a 302");
+my $cookie = $req->header("set-cookie");
+
+subtest "Deleting a simple project" => sub {
+    my $builds = $ctx->makeAndEvaluateJobset(
+        expression => "basic.nix"
+    );
+    my $project = $builds->{"empty_dir"}->project;
+
+    my $responseNoAuth = request(DELETE "/project/${\$project->name}");
+    is($responseNoAuth->code, 403, "Deleting a project without auth returns a 403");
+
+    my $responseAuthed = request(DELETE "/project/${\$project->name}",
+        Cookie => $cookie,
+        Accept => "application/json"
+    );
+    is($responseAuthed->code, 200, "Deleting a project with auth returns a 200");
+
+    my $response = request(GET "/project/${\$project->name}");
+    is($response->code, 404, "Then getting the project returns a 404");
+
+    is(
+        $ctx->db->resultset('Builds')->find({ id => $builds->{"empty_dir"}->id }),
+        undef,
+        "The build isn't in the database anymore"
+    );
+};
+
+done_testing;


### PR DESCRIPTION
Deleting jobsets first would fail because buildmetrics has an FK
to the jobset. However, the jobset / project relationship is not
marked as CASCADE.

Deleting all the builds automatically cascades to delete
buildmetrics, so deleting the relevant builds first, then deleting
the jobset solves it.

Closes #1081 

cc @dasJ @ajs124 @cole-h 