### PR TITLE
Project jobset: update input type "build"

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -106,9 +106,17 @@ sub fetchInputBuild {
         $projectName ||= $project->name;
         $jobsetName ||= $jobset->name;
 
+        my $jobset = $db->resultset('Jobsets')->search(
+            {
+                name => $jobsetName,
+                project => $projectName,
+            },
+            {}
+        )->single;
+
         # Pick the most recent successful build of the specified job.
         $prevBuild = $db->resultset('Builds')->search(
-            { finished => 1, project => $projectName, jobset => $jobsetName
+            { finished => 1, jobset_id => $jobset->get_column('id')
             , job => $jobName, buildStatus => 0 },
             { order_by => "me.id DESC", rows => 1
             , where => \ attrsToSQL($attrs, "me.id") })->single;


### PR DESCRIPTION
Extracted from #1093.

My methodology here is to:

1. Pick a commit from #1093
2. Check out the parent commit
3. Run the test suite and identify failing tests
4. Check out the picked commit and run those failing tests
5. Verify the picked commit fixed at least one test.

If it didn't, write a test and verify it is broken before / fixed after the picked commit.

The picked commit in this case was `hydra-eval-jobset: fixup old reference to project / jobset columns`.