### PR TITLE
queue-runner: track jobsets by ID

### DIFF
--- a/src/hydra-queue-runner/state.hh
+++ b/src/hydra-queue-runner/state.hh
@@ -19,6 +19,8 @@
 
 typedef unsigned int BuildID;
 
+typedef unsigned int JobsetID;
+
 typedef std::chrono::time_point<std::chrono::system_clock> system_time;
 
 typedef std::atomic<unsigned long> counter;
@@ -123,6 +125,7 @@ struct Build
     BuildID id;
     nix::StorePath drvPath;
     std::map<std::string, nix::StorePath> outputs;
+    JobsetID jobsetId;
     std::string projectName, jobsetName, jobName;
     time_t timestamp;
     unsigned int maxSilentTime, buildTimeout;
@@ -489,7 +492,7 @@ private:
         bool & stepFinished);
 
     Jobset::ptr createJobset(pqxx::work & txn,
-        const std::string & projectName, const std::string & jobsetName);
+        const std::string & projectName, const std::string & jobsetName, const JobsetID);
 
     void processJobsetSharesChange(Connection & conn);
 


### PR DESCRIPTION
Extracted from #1093.

My methodology here is to:

1. Pick a commit from #1093
2. Check out the parent commit
3. Run the test suite and identify failing tests
4. Check out the picked commit and run those failing tests
5. Verify the picked commit fixed at least one test.

If it didn't, write a test and verify it is broken before / fixed after the picked commit.

In this case, a lot of tests failed before, and they all pass now. However, as little as I know Perl, I know C++ even less. I'd love to have actual C++-level tests if possible. I'd also like it if someone who knows C++ reviewed this.