### PR TITLE
Project jobset: Update DeclarativeJobsets to not use the project or jobsets columns on Bulids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Makefile.in
 /t/nix
 /t/data
 /t/jobs/config.nix
+t/jobs/declarative/project.json
 /inst
 hydra-config.h
 hydra-config.h.in

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ then
     NIX_STATE_DIR="$TMPDIR"
     export NIX_STATE_DIR
 fi
-if NIX_REMOTE=daemon PAGER=cat "$NIX_STORE_PROGRAM" --timeout 123 -q; then 
+if NIX_REMOTE=daemon PAGER=cat "$NIX_STORE_PROGRAM" --timeout 123 -q; then
     AC_MSG_RESULT([yes])
 else
     AC_MSG_RESULT([no])
@@ -54,6 +54,9 @@ PKG_CHECK_MODULES([NIX], [nix-main nix-expr nix-store])
 
 testPath="$(dirname $(type -p expr))"
 AC_SUBST(testPath)
+
+jobsPath="$(realpath ./t/jobs)"
+AC_SUBST(jobsPath)
 
 CXXFLAGS+=" -include nix/config.h"
 
@@ -72,6 +75,7 @@ AC_CONFIG_FILES([
   src/script/Makefile
   t/Makefile
   t/jobs/config.nix
+  t/jobs/declarative/project.json
 ])
 
 AC_CONFIG_COMMANDS([executable-scripts], [])

--- a/src/lib/Hydra/Controller/Project.pm
+++ b/src/lib/Hydra/Controller/Project.pm
@@ -162,6 +162,8 @@ sub updateProject {
         , declvalue => trim($c->stash->{params}->{declarative}->{value})
         });
     if (length($project->declfile)) {
+        # This logic also exists in the DeclarativeJobets tests.
+        # TODO: refactor and deduplicate.
         $project->jobsets->update_or_create(
             { name=> ".jobsets"
             , nixexprinput => ""

--- a/src/lib/Hydra/Plugin/DeclarativeJobsets.pm
+++ b/src/lib/Hydra/Plugin/DeclarativeJobsets.pm
@@ -9,7 +9,7 @@ sub buildFinished {
     my ($self, $build, $dependents) = @_;
 
     my $project = $build->project;
-    my $jobsetName = $build->get_column('jobset');
+    my $jobsetName = $build->jobset->get_column('name');
     if (length($project->declfile) && $jobsetName eq ".jobsets" && $build->iscurrent) {
         handleDeclarativeJobsetBuild($self->{"db"}, $project, $build);
     }

--- a/t/Hydra/Plugin/DeclarativeJobsets/basic.t
+++ b/t/Hydra/Plugin/DeclarativeJobsets/basic.t
@@ -1,0 +1,63 @@
+use feature 'unicode_strings';
+use strict;
+use warnings;
+use Test2::V0;
+use Setup;
+
+my $ctx = test_context();
+my $db = $ctx->db;
+
+my $project = $db->resultset('Projects')->create({
+    name => "tests",
+    displayname => "",
+    owner => "root",
+    declfile => "declarative/project.json",
+    decltype => "path",
+    declvalue => $ctx->jobsdir,
+});
+
+subtest "Evaluating and building the top .jobsets jobset" => sub {
+    # This logic lives in the Project controller.
+    # Not great to duplicate it here.
+    # TODO: refactor and deduplicate.
+    my $jobset = $project->jobsets->create({
+        name=> ".jobsets",
+        nixexprinput => "",
+        nixexprpath => "",
+        emailoverride => "",
+        triggertime => time,
+    });
+
+    ok(evalSucceeds($jobset), "Evaluating the declarative jobsets with return code 0");
+    is(nrQueuedBuildsForJobset($jobset), 1, "We should have exactly 1 build queued, to build the jobsets data");
+
+    (my $build) = queuedBuildsForJobset($jobset);
+
+    is($build->job, "jobsets", "The only job should be jobsets");
+    ok(runBuild($build), "Build should exit with return code 0");
+    my $newbuild = $db->resultset('Builds')->find($build->id);
+    is($newbuild->finished, 1, "Build should be finished.");
+    is($newbuild->buildstatus, 0, "Build should have buildstatus 0.");
+
+    ok(sendNotifications(), "Notifications execute successfully.");
+};
+
+subtest "Validating a new jobset appears" => sub {
+    my $jobset = $project->jobsets->find({ name => "my-jobset" });
+    ok($jobset, "We have a jobset");
+    is($jobset->description, "my-declarative-jobset", "The jobset's description matches");
+
+    subtest "Evaluating and building that jobset works" => sub {
+        ok(evalSucceeds($jobset), "Evaluating the new jobset with return code 0");
+        is(nrQueuedBuildsForJobset($jobset), 1, "We should have exactly 1 build queued");
+
+        (my $build) = queuedBuildsForJobset($jobset);
+
+        is($build->job, "one_job", "The only job should be jobsets");
+        ok(runBuild($build), "Build should exit with return code 0");
+        my $newbuild = $db->resultset('Builds')->find($build->id);
+        is($newbuild->finished, 1, "Build should be finished.");
+        is($newbuild->buildstatus, 0, "Build should have buildstatus 0.");
+    };
+};
+done_testing;

--- a/t/jobs/declarative/generator.nix
+++ b/t/jobs/declarative/generator.nix
@@ -1,0 +1,29 @@
+{ jobspath, ... }:
+with import ../config.nix;
+{
+  jobsets = mkDerivation {
+    name = "jobsets";
+    builder = ./generator.sh;
+    jobsets = builtins.toJSON {
+      my-jobset = {
+        enabled = 1;
+        hidden = false;
+        description = "my-declarative-jobset";
+        nixexprinput = "src";
+        nixexprpath = "one-job.nix";
+        checkinterval = 300;
+        schedulingshares = 100;
+        enableemail = false;
+        emailoverride = "";
+        keepnr = 3;
+        inputs = {
+          src = {
+            type = "path";
+            value = jobspath;
+            emailresponsible = false;
+          };
+        };
+      };
+    };
+  };
+}

--- a/t/jobs/declarative/generator.sh
+++ b/t/jobs/declarative/generator.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+echo "$jobsets" > $out

--- a/t/jobs/declarative/project.json.in
+++ b/t/jobs/declarative/project.json.in
@@ -1,0 +1,24 @@
+{
+    "enabled": 1,
+    "hidden": false,
+    "description": "declarative-jobset-example",
+    "nixexprinput": "src",
+    "nixexprpath": "declarative/generator.nix",
+    "checkinterval": 300,
+    "schedulingshares": 100,
+    "enableemail": false,
+    "emailoverride": "",
+    "keepnr": 3,
+    "inputs": {
+        "src": {
+            "type": "path",
+            "value": "@jobsPath@",
+            "emailresponsible": false
+        },
+        "jobspath": {
+            "type": "string",
+            "value": "@jobsPath@",
+            "emailresponsible": false
+        }
+    }
+}


### PR DESCRIPTION
Extracted from #1093.

My methodology here is to:

1. Pick a commit from #1093
2. Check out the parent commit
3. Run the test suite and identify failing tests
4. Check out the picked commit and run those failing tests
5. Verify the picked commit fixed at least one test.

If it didn't, write a test and verify it is broken before / fixed after the picked commit.

In this case there was no failing test so I wrote one, and extracted the "get the jobset name from the jobset table" commit.