### PR TITLE
build-remote: copy missing paths from the binary cache to localhost

### DIFF
--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -271,7 +271,11 @@ void State::buildRemote(ref<Store> destStore,
         }
 
         /* Copy the input closure. */
-        if (!machine->isLocalhost()) {
+        if (machine->isLocalhost()) {
+            StorePathSet closure;
+            destStore->computeFSClosure(inputs, closure);
+            copyPaths(*destStore, *localStore, closure, NoRepair, NoCheckSigs, NoSubstitute);
+        } else {
             auto mc1 = std::make_shared<MaintainCount<counter>>(nrStepsWaiting);
             mc1.reset();
             MaintainCount<counter> mc2(nrStepsCopyingTo);

--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -270,21 +270,24 @@ void State::buildRemote(ref<Store> destStore,
             copyPaths(*localStore, *destStore, closure, NoRepair, NoCheckSigs, NoSubstitute);
         }
 
-        /* Copy the input closure. */
-        if (machine->isLocalhost()) {
-            StorePathSet closure;
-            destStore->computeFSClosure(inputs, closure);
-            copyPaths(*destStore, *localStore, closure, NoRepair, NoCheckSigs, NoSubstitute);
-        } else {
+        {
             auto mc1 = std::make_shared<MaintainCount<counter>>(nrStepsWaiting);
             mc1.reset();
             MaintainCount<counter> mc2(nrStepsCopyingTo);
+
             printMsg(lvlDebug, "sending closure of ‘%s’ to ‘%s’",
                 localStore->printStorePath(step->drvPath), machine->sshName);
 
             auto now1 = std::chrono::steady_clock::now();
 
-            copyClosureTo(machine->state->sendLock, destStore, from, to, inputs, true);
+            /* Copy the input closure. */
+            if (machine->isLocalhost()) {
+                StorePathSet closure;
+                destStore->computeFSClosure(inputs, closure);
+                copyPaths(*destStore, *localStore, closure, NoRepair, NoCheckSigs, NoSubstitute);
+            } else {
+                copyClosureTo(machine->state->sendLock, destStore, from, to, inputs, true);
+            }
 
             auto now2 = std::chrono::steady_clock::now();
 

--- a/t/jobs/dependencies/dependency.nix
+++ b/t/jobs/dependencies/dependency.nix
@@ -1,0 +1,17 @@
+{ exposeUnderlyingJob, exposeDependentJob }:
+with import ../config.nix;
+let
+  underlyingJob = mkDerivation {
+    name = "underlying-job";
+    builder = ../empty-dir-builder.sh;
+  };
+
+  dependentJob = mkDerivation {
+    name = "dependent-job";
+    builder = ../empty-dir-builder.sh;
+    inherit underlyingJob;
+  };
+in
+(if exposeUnderlyingJob then { inherit underlyingJob; } else { }) //
+(if exposeDependentJob then { inherit dependentJob; } else { }) //
+{ }

--- a/t/jobs/dependencies/dependentOnly.nix
+++ b/t/jobs/dependencies/dependentOnly.nix
@@ -1,0 +1,4 @@
+import ./dependency.nix {
+  exposeUnderlyingJob = false;
+  exposeDependentJob = true;
+}

--- a/t/jobs/dependencies/underlyingOnly.nix
+++ b/t/jobs/dependencies/underlyingOnly.nix
@@ -1,0 +1,4 @@
+import ./dependency.nix {
+  exposeUnderlyingJob = true;
+  exposeDependentJob = false;
+}

--- a/t/lib/CliRunners.pm
+++ b/t/lib/CliRunners.pm
@@ -27,6 +27,8 @@ sub evalSucceeds {
     $jobset->discard_changes;  # refresh from DB
     if ($res) {
         chomp $stdout; chomp $stderr;
+        utf8::decode($stdout) or die "Invalid unicode in stdout.";
+        utf8::decode($stderr) or die "Invalid unicode in stderr.";
         print STDERR "Evaluation unexpectedly failed for jobset ".$jobset->project->name.":".$jobset->name.": \n".$jobset->errormsg."\n" if $jobset->errormsg;
         print STDERR "STDOUT: $stdout\n" if $stdout ne "";
         print STDERR "STDERR: $stderr\n" if $stderr ne "";
@@ -40,6 +42,8 @@ sub evalFails {
     $jobset->discard_changes;  # refresh from DB
     if (!$res) {
         chomp $stdout; chomp $stderr;
+        utf8::decode($stdout) or die "Invalid unicode in stdout.";
+        utf8::decode($stderr) or die "Invalid unicode in stderr.";
         print STDERR "Evaluation unexpectedly succeeded for jobset ".$jobset->project->name.":".$jobset->name.": \n".$jobset->errormsg."\n" if $jobset->errormsg;
         print STDERR "STDOUT: $stdout\n" if $stdout ne "";
         print STDERR "STDERR: $stderr\n" if $stderr ne "";
@@ -51,6 +55,8 @@ sub runBuild {
     my ($build) = @_;
     my ($res, $stdout, $stderr) = captureStdoutStderr(60, ("hydra-queue-runner", "-vvvv", "--build-one", $build->id));
     if ($res) {
+        utf8::decode($stdout) or die "Invalid unicode in stdout.";
+        utf8::decode($stderr) or die "Invalid unicode in stderr.";
         print STDERR "Queue runner stdout: $stdout\n" if $stdout ne "";
         print STDERR "Queue runner stderr: $stderr\n" if $stderr ne "";
     }
@@ -60,6 +66,8 @@ sub runBuild {
 sub sendNotifications() {
     my ($res, $stdout, $stderr) = captureStdoutStderr(60, ("hydra-notify", "--queued-only"));
     if ($res) {
+        utf8::decode($stdout) or die "Invalid unicode in stdout.";
+        utf8::decode($stderr) or die "Invalid unicode in stderr.";
         print STDERR "hydra notify stdout: $stdout\n" if $stdout ne "";
         print STDERR "hydra notify stderr: $stderr\n" if $stderr ne "";
     }

--- a/t/lib/HydraTestContext.pm
+++ b/t/lib/HydraTestContext.pm
@@ -69,6 +69,7 @@ sub new {
         _db => undef,
         db_handle => $pgsql,
         tmpdir => $dir,
+        nix_state_dir => "$dir/nix/var/nix",
         testdir => abs_path(dirname(__FILE__) . "/.."),
         jobsdir => abs_path(dirname(__FILE__) . "/../jobs")
     };
@@ -113,6 +114,12 @@ sub jobsdir {
     my ($self) = @_;
 
     return $self->{jobsdir};
+}
+
+sub nix_state_dir {
+    my ($self) = @_;
+
+    return $self->{nix_state_dir};
 }
 
 # Create a jobset, evaluate it, and optionally build the jobs.

--- a/t/queue-runner/build-locally-with-substitutable-path.t
+++ b/t/queue-runner/build-locally-with-substitutable-path.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use Setup;
+use Data::Dumper;
+use Test2::V0;
+my $ctx = test_context(
+    use_external_destination_store => 1
+);
+
+# This test is regarding https://github.com/NixOS/hydra/pull/1126
+#
+# A hydra instance was regularly failing to build derivations with:
+#
+#     possibly transient failure building ‘/nix/store/X.drv’ on ‘localhost’:
+#     dependency '/nix/store/Y' of '/nix/store/Y.drv' does not exist,
+#     and substitution is disabled
+#
+# However it would only fail when building on localhost, and it would only
+# fail if the build output was already in the binary cache.
+#
+# This test replicates this scenario by having two jobs, underlyingJob and
+# dependentJob. dependentJob depends on underlyingJob. We first build
+# underlyingJob and copy it to an external cache. Then forcefully delete
+# the output of underlyingJob, and build dependentJob. In order to pass
+# it must either rebuild underlyingJob or fetch it from the cache.
+
+
+subtest "Building, caching, and then garbage collecting the underlying job" => sub {
+    my $builds = $ctx->makeAndEvaluateJobset(
+        expression => "dependencies/underlyingOnly.nix",
+        build => 1
+    );
+
+    my $path = $builds->{"underlyingJob"}->buildoutputs->find({ name => "out" })->path;
+
+    ok(unlink(Hydra::Helper::Nix::gcRootFor($path)), "Unlinking the GC root for underlying Dependency succeeds");
+
+    (my $ret, my $stdout, my $stderr) = captureStdoutStderr(1, "nix-store", "--delete", $path);
+    is($ret, 0, "Deleting the underlying dependency should succeed");
+};
+
+subtest "Building the dependent job should now succeed, even though we're missing a local dependency" => sub {
+    my $builds = $ctx->makeAndEvaluateJobset(
+        expression => "dependencies/dependentOnly.nix"
+    );
+
+    ok(runBuild($builds->{"dependentJob"}), "building the job should succeed");
+};
+
+
+done_testing;


### PR DESCRIPTION
In a Hydra instance I saw:

    possibly transient failure building ‘/nix/store/X.drv’ on ‘localhost’:
      dependency '/nix/store/Y' of '/nix/store/Y.drv' does not exist,
      and substitution is disabled

This is confusing because the Hydra in question does have substitution enabled.

This instance uses:

  keep-outputs = true
  keep-derivations = true

and an S3 binary cache which is not configured as a substituter in the nix.conf.

It appears this instance encountered a situation where store path Y was built
and present in the binary cache, and Y.drv was GC rooted on the instance,
however Y was not on the host.

When Hydra would try to build this path locally, it would look in the binary
cache to see if it was cached:

    (nix)
    439      bool valid = isValidPathUncached(storePath);
    440
    441      if (diskCache && !valid)
    442          // FIXME: handle valid = true case.
    443          diskCache->upsertNarInfo(getUri(), hashPart, 0);
    444
    445      return valid;

Since it was cached, the store path was considered Valid.

The queue monitor would then not put this input in for substitution, because
the path is valid:

    (hydra)
    470          if (!destStore->isValidPath(*i.second.path(*localStore, step->drv->name, i.first))) {
    471              valid = false;
    472              missing.insert_or_assign(i.first, i.second);
    473          }

Hydra appears to correctly handle the case of missing paths that need
to be substituted from the binary cache already, but since most
Hydra instances use `keep-outputs` *and* all paths in the binary cache
originate from that machine, it is not common for a path to be cached
and not GC rooted locally.

I'll run Hydra with this patch for a while and see if we run in to the
problem again.

A big thanks to John Ericson who helped debug this particular issue.