### PR TITLE
hydra-create-user: support prompting for password

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Once the Hydra service has been configured as above and activate you should alre
 ```
 $ su - hydra
 $ hydra-create-user <USER> --full-name '<NAME>' \
-    --email-address '<EMAIL>' --password <PASSWORD> --role admin
+    --email-address '<EMAIL>' --password-prompt --role admin
 ```
 
 Afterwards you should be able to log by clicking on "_Sign In_" on the top right of the web interface using the credentials specified by `hydra-create-user`. Once you are logged in you can click "_Admin -> Create Project_" to configure your first project.

--- a/doc/dev-notes.txt
+++ b/doc/dev-notes.txt
@@ -13,7 +13,7 @@
 * Creating a user:
 
   $ hydra-create-user root --email-address 'e.dolstra@tudelft.nl' \
-      --password-hash "$(echo -n foobar | sha1sum | cut -c1-40)"
+      --password-prompt
 
   (Replace "foobar" with the desired password.)
 

--- a/doc/manual/src/installation.md
+++ b/doc/manual/src/installation.md
@@ -114,7 +114,7 @@ This can be done using the command `hydra-create-user`:
 
 ```console
 $ hydra-create-user alice --full-name 'Alice Q. User' \
-    --email-address 'alice@example.org' --password foobar --role admin
+    --email-address 'alice@example.org' --password-prompt --role admin
 ```
 
 Additional users can be created through the web interface.

--- a/flake.nix
+++ b/flake.nix
@@ -495,6 +495,7 @@
                 StringCompareConstantTime
                 SysHostnameLong
                 TermSizeAny
+                TermReadKey
                 Test2Harness
                 TestMore
                 TestPostgreSQL

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -18,6 +18,7 @@ our @ISA = qw(Exporter);
 our @EXPORT = qw(
     cancelBuilds
     captureStdoutStderr
+    captureStdoutStderrWithStdin
     findLog
     gcRootFor
     getBaseUrl
@@ -428,14 +429,19 @@ sub pathIsInsidePrefix {
 
 sub captureStdoutStderr {
     my ($timeout, @cmd) = @_;
-    my $stdin = "";
+
+    return captureStdoutStderrWithStdin($timeout, \@cmd, "");
+}
+
+sub captureStdoutStderrWithStdin {
+    my ($timeout, $cmd, $stdin) = @_;
     my $stdout;
     my $stderr;
 
     eval {
         local $SIG{ALRM} = sub { die "timeout\n" }; # NB: \n required
         alarm $timeout;
-        IPC::Run::run(\@cmd, \$stdin, \$stdout, \$stderr);
+        IPC::Run::run($cmd, \$stdin, \$stdout, \$stderr);
         alarm 0;
         1;
     } or do {

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -16,20 +16,31 @@ use IPC::Run;
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
-    getHydraHome getHydraConfig getBaseUrl
-    getSCMCacheDir getStatsdConfig
-    registerRoot getGCRootsDir gcRootFor
-    jobsetOverview jobsetOverview_
-    getDrvLogPath findLog
-    getMainOutput
+    cancelBuilds
+    captureStdoutStderr
+    findLog
+    gcRootFor
+    getBaseUrl
+    getDrvLogPath
     getEvals getMachines
-    pathIsInsidePrefix
-    captureStdoutStderr run grab
-    getTotalShares
+    getGCRootsDir
+    getHydraConfig
+    getHydraHome
+    getMainOutput
+    getSCMCacheDir
+    getStatsdConfig
     getStoreUri
-    readNixFile
+    getTotalShares
+    grab
     isLocalStore
-    cancelBuilds restartBuilds);
+    jobsetOverview
+    jobsetOverview_
+    pathIsInsidePrefix
+    readNixFile
+    registerRoot
+    restartBuilds
+    run
+    );
 
 
 sub getHydraHome {

--- a/src/script/hydra-create-user
+++ b/src/script/hydra-create-user
@@ -5,6 +5,7 @@ use warnings;
 use Hydra::Schema;
 use Hydra::Helper::Nix;
 use Hydra::Model::DB;
+use Term::ReadKey;
 use Getopt::Long qw(:config gnu_getopt);
 
 sub showHelp {
@@ -143,13 +144,17 @@ $db->txn_do(sub {
         }
 
         if (defined $passwordPrompt) {
+            ReadMode 2;
             print STDERR "Password: ";
             my $password = <STDIN> // "";
             chomp $password;
 
-            print STDERR "Password Confirmation: ";
+            print STDERR "\nPassword Confirmation: ";
             my $passwordConfirm = <STDIN> // "";
             chomp $passwordConfirm;
+            ReadMode 0;
+
+            print STDERR "\n";
 
             if ($password ne $passwordConfirm) {
                 die "Passwords don't match."

--- a/src/script/hydra-create-user
+++ b/src/script/hydra-create-user
@@ -14,6 +14,7 @@ Usage: hydra-create-user NAME
   [--type hydra|google|github]
   [--full-name FULLNAME]
   [--email-address EMAIL-ADDRESS]
+  [--password-prompt]
   [--password-hash HASH]
   [--password PASSWORD (dangerous)]
   [--wipe-roles]
@@ -26,6 +27,14 @@ specified.  If --rename-from is given, the specified account is
 renamed.
 
 * Specifying Passwords
+
+** Interactively
+
+Pass `--password-prompt` to collect the password on stdin.
+
+Example:
+
+  $ hydra-create-user alice --password-prompt --role admin
 
 ** Specifying a Hash
 
@@ -63,7 +72,7 @@ Example:
     exit 0;
 }
 
-my ($renameFrom, $type, $fullName, $emailAddress, $password, $passwordHash);
+my ($renameFrom, $type, $fullName, $emailAddress, $password, $passwordHash, $passwordPrompt);
 my $wipeRoles = 0;
 my @roles;
 
@@ -72,6 +81,7 @@ GetOptions("rename-from=s" => \$renameFrom,
            "full-name=s" => \$fullName,
            "email-address=s" => \$emailAddress,
            "password=s" => \$password,
+           "password-prompt" => \$passwordPrompt,
            "password-hash=s" => \$passwordHash,
            "wipe-roles" => \$wipeRoles,
            "role=s" => \@roles,
@@ -81,9 +91,9 @@ GetOptions("rename-from=s" => \$renameFrom,
 die "$0: one user name required\n" if scalar @ARGV != 1;
 my $userName = $ARGV[0];
 
-my $chosenPasswordOptions = grep { defined($_) }  ($passwordHash, $password);
+my $chosenPasswordOptions = grep { defined($_) }  ($passwordPrompt, $passwordHash, $password);
 if ($chosenPasswordOptions > 1) {
-    die "$0: please specify only one --password* option. See --help for more information.\n";
+    die "$0: please specify one of --password-prompt or --password-hash. See --help for more information.\n";
 }
 
 die "$0: type must be `hydra', `google' or `github'\n"
@@ -118,6 +128,8 @@ $db->txn_do(sub {
             if defined $password;
         die "$0: Google and GitHub accounts do not have a password.\n"
             if defined $passwordHash;
+        die "$0: Google and GitHub accounts do not have a password.\n"
+            if defined $passwordPrompt;
         $user->update({ emailaddress => $userName, password => "!" });
     } else {
         $user->update({ emailaddress => $emailAddress }) if defined $emailAddress;
@@ -128,6 +140,24 @@ $db->txn_do(sub {
 
         if (defined $passwordHash) {
             $user->setPasswordHash($passwordHash);
+        }
+
+        if (defined $passwordPrompt) {
+            print STDERR "Password: ";
+            my $password = <STDIN> // "";
+            chomp $password;
+
+            print STDERR "Password Confirmation: ";
+            my $passwordConfirm = <STDIN> // "";
+            chomp $passwordConfirm;
+
+            if ($password ne $passwordConfirm) {
+                die "Passwords don't match."
+            } elsif ($password eq "") {
+                die "Password cannot be empty."
+            }
+
+            $user->setPassword($password);
         }
     }
 

--- a/src/script/hydra-create-user
+++ b/src/script/hydra-create-user
@@ -33,6 +33,8 @@ renamed.
 
 Pass `--password-prompt` to collect the password on stdin.
 
+The password will be hashed with Argon2id when stored.
+
 Example:
 
   $ hydra-create-user alice --password-prompt --role admin
@@ -94,7 +96,7 @@ my $userName = $ARGV[0];
 
 my $chosenPasswordOptions = grep { defined($_) }  ($passwordPrompt, $passwordHash, $password);
 if ($chosenPasswordOptions > 1) {
-    die "$0: please specify one of --password-prompt or --password-hash. See --help for more information.\n";
+    die "$0: please specify only one of --password-prompt or --password-hash. See --help for more information.\n";
 }
 
 die "$0: type must be `hydra', `google' or `github'\n"
@@ -135,7 +137,7 @@ $db->txn_do(sub {
     } else {
         $user->update({ emailaddress => $emailAddress }) if defined $emailAddress;
 
-        if (defined $password && !(defined $passwordHash)) {
+        if (defined $password) {
             $user->setPassword($password);
         }
 

--- a/src/script/hydra-create-user
+++ b/src/script/hydra-create-user
@@ -14,8 +14,8 @@ Usage: hydra-create-user NAME
   [--type hydra|google|github]
   [--full-name FULLNAME]
   [--email-address EMAIL-ADDRESS]
-  [--password PASSWORD]
   [--password-hash HASH]
+  [--password PASSWORD (dangerous)]
   [--wipe-roles]
   [--role ROLE]...
 
@@ -25,27 +25,37 @@ exists, roles are added to the existing roles unless --wipe-roles is
 specified.  If --rename-from is given, the specified account is
 renamed.
 
-* PASSWORD HASH
-The password hash should be an Argon2id hash, which can be generated
-via:
+* Specifying Passwords
+
+** Specifying a Hash
+
+You can generate a password hash and provide the hash as well. This
+is useful so a user can send the administrator their password pre-hashed,
+allowing the user to get their preferred password without exposing it
+to the administrator.
+
+Hydra uses Argon2id hashes, which can be generated like so:
 
     $ nix-shell -p libargon2
-    [nix-shell]$ argon2 "$(LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c16)" -id -t 3 -k 262144 -p 1 -l 16 -e
+    [nix-shell]$ tr -d \\\\n | argon2 "$(LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c16)" -id -t 3 -k 262144 -p 1 -l 16 -e
     foobar
     Ctrl^D
     $argon2id$v=19$m=262144,t=3,p=1$NFU1QXJRNnc4V1BhQ0NJQg$6GHqjqv5cNDDwZqrqUD0zQ
 
-SHA1 is also accepted, but SHA1 support is deprecated and the user's
-password will be upgraded to Argon2id on first login.
-
-
-Examples:
-
-Create a user with an argon2 password:
+Example:
 
   $ hydra-create-user alice --password-hash '$argon2id$v=19$m=262144,t=3,p=1$NFU1QXJRNnc4V1BhQ0NJQg$6GHqjqv5cNDDwZqrqUD0zQ' --role admin
 
-Create a user with a password insecurely provided on the commandline:
+SHA1 is also accepted, but SHA1 support is deprecated and the user's
+password will be upgraded to Argon2id on first login.
+
+** Specifying a plain-text password as an argument (dangerous)
+
+This option is dangerous and should not be used: it exposes passwords to
+other users on the system. This option only exists for backwards
+compatibility.
+
+Example:
 
   $ hydra-create-user alice --password foobar --role admin
 
@@ -70,6 +80,11 @@ GetOptions("rename-from=s" => \$renameFrom,
 
 die "$0: one user name required\n" if scalar @ARGV != 1;
 my $userName = $ARGV[0];
+
+my $chosenPasswordOptions = grep { defined($_) }  ($passwordHash, $password);
+if ($chosenPasswordOptions > 1) {
+    die "$0: please specify only one --password* option. See --help for more information.\n";
+}
 
 die "$0: type must be `hydra', `google' or `github'\n"
     if defined $type && $type ne "hydra" && $type ne "google" && $type ne "github";

--- a/src/script/hydra-create-user
+++ b/src/script/hydra-create-user
@@ -138,6 +138,8 @@ $db->txn_do(sub {
         $user->update({ emailaddress => $emailAddress }) if defined $emailAddress;
 
         if (defined $password) {
+            # !!! TODO: Remove support for plaintext passwords in 2023.
+            print STDERR "Submitting plaintext passwords as arguments is deprecated and will be removed. See --help for alternatives.\n";
             $user->setPassword($password);
         }
 

--- a/t/lib/CliRunners.pm
+++ b/t/lib/CliRunners.pm
@@ -5,6 +5,7 @@ package CliRunners;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
     captureStdoutStderr
+    captureStdoutStderrWithStdin
     evalFails
     evalSucceeds
     runBuild
@@ -19,6 +20,15 @@ sub captureStdoutStderr {
     # the temporary DB is setup.
     require Hydra::Helper::Nix;
     return Hydra::Helper::Nix::captureStdoutStderr(@_)
+}
+
+sub captureStdoutStderrWithStdin {
+    # "Lazy"-load Hydra::Helper::Nix to avoid the compile-time
+    # import of Hydra::Model::DB. Early loading of the DB class
+    # causes fixation of the DSN, and we need to fixate it after
+    # the temporary DB is setup.
+    require Hydra::Helper::Nix;
+    return Hydra::Helper::Nix::captureStdoutStderrWithStdin(@_)
 }
 
 sub evalSucceeds {

--- a/t/lib/Setup.pm
+++ b/t/lib/Setup.pm
@@ -13,6 +13,7 @@ use CliRunners;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
     captureStdoutStderr
+    captureStdoutStderrWithStdin
     createBaseJobset
     createJobsetWithOneInput
     evalFails

--- a/t/scripts/hydra-create-user.t
+++ b/t/scripts/hydra-create-user.t
@@ -76,7 +76,7 @@ subtest "Handling password and password hash creation" => sub {
         for my $case (@cases) {
             my ($res, $stdout, $stderr) = captureStdoutStderr(5, (
                 "hydra-create-user", "bogus-password-options", @{$case}));
-            like($stderr, qr/please specify one of --password-prompt or --password-hash/, "We get an error about specifying the password");
+            like($stderr, qr/please specify only one of --password-prompt or --password-hash/, "We get an error about specifying the password");
             isnt($res, 0, "hydra-create-user should exit non-zero with conflicting " . join(" ", @{$case}));
         }
     };

--- a/t/scripts/hydra-create-user.t
+++ b/t/scripts/hydra-create-user.t
@@ -1,17 +1,10 @@
-use feature 'unicode_strings';
 use strict;
 use warnings;
 use Setup;
-
-my %ctx = test_init();
-
-require Hydra::Schema;
-require Hydra::Model::DB;
-
 use Test2::V0;
 
-my $db = Hydra::Model::DB->new;
-hydra_setup($db);
+my $ctx = test_context();
+my $db = $ctx->db();
 
 subtest "Handling password and password hash creation" => sub {
     subtest "Creating a user with a plain text password (insecure) stores the password securely" => sub {

--- a/t/scripts/hydra-create-user.t
+++ b/t/scripts/hydra-create-user.t
@@ -45,6 +45,25 @@ subtest "Handling password and password hash creation" => sub {
         ok($user->check_password("foobar"), "Their password validates");
         is($storedPassword, $user->password, "The password was not upgraded.");
     };
+
+    subtest "Specifying conflicting password options fails" => sub {
+        my @cases = (
+            [ "--password=foo", "--password-hash=8843d7f92416211de9ebb963ff4ce28125932878" ],
+        );
+
+        for my $case (@cases) {
+            my ($res, $stdout, $stderr) = captureStdoutStderr(5, (
+                "hydra-create-user", "bogus-password-options", @{$case}));
+            like($stderr, qr/please specify only one --password\* option/, "We get an error about specifying the password");
+            isnt($res, 0, "hydra-create-user should exit non-zero with conflicting " . join(" ", @{$case}));
+        }
+    };
+
+    subtest "A password is not required for creating a Google-based account" => sub {
+        my ($res, $stdout, $stderr) = captureStdoutStderr(5, (
+            "hydra-create-user", "google-account", "--type", "google"));
+        is($res, 0, "hydra-create-user should exit zero");
+    };
 };
 
 done_testing;

--- a/t/scripts/hydra-create-user.t
+++ b/t/scripts/hydra-create-user.t
@@ -28,10 +28,10 @@ subtest "Handling password and password hash creation" => sub {
     };
 
     subtest "Creating a user with a sha1 password (still insecure) stores the password as a hashed sha1" => sub {
-        my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-create-user", "plain-text-user", "--password-hash", "8843d7f92416211de9ebb963ff4ce28125932878"));
+        my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-create-user", "old-password-hash-user", "--password-hash", "8843d7f92416211de9ebb963ff4ce28125932878"));
         is($res, 0, "hydra-create-user should exit zero");
 
-        my $user = $db->resultset('Users')->find({ username => "plain-text-user" });
+        my $user = $db->resultset('Users')->find({ username => "old-password-hash-user" });
         isnt($user, undef, "The user exists");
         isnt($user->password, "8843d7f92416211de9ebb963ff4ce28125932878", "The password was not saved in plain text.");
 
@@ -41,10 +41,10 @@ subtest "Handling password and password hash creation" => sub {
     };
 
     subtest "Creating a user with an argon2 password stores the password as given" => sub {
-        my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-create-user", "plain-text-user", "--password-hash", '$argon2id$v=19$m=262144,t=3,p=1$tMnV5paYjmIrUIb6hylaNA$M8/e0i3NGrjhOliVLa5LqQ'));
+        my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-create-user", "argon2-hash-user", "--password-hash", '$argon2id$v=19$m=262144,t=3,p=1$tMnV5paYjmIrUIb6hylaNA$M8/e0i3NGrjhOliVLa5LqQ'));
         is($res, 0, "hydra-create-user should exit zero");
 
-        my $user = $db->resultset('Users')->find({ username => "plain-text-user" });
+        my $user = $db->resultset('Users')->find({ username => "argon2-hash-user" });
         isnt($user, undef, "The user exists");
         is($user->password, '$argon2id$v=19$m=262144,t=3,p=1$tMnV5paYjmIrUIb6hylaNA$M8/e0i3NGrjhOliVLa5LqQ', "The password was saved as-is.");
 

--- a/t/scripts/hydra-create-user.t
+++ b/t/scripts/hydra-create-user.t
@@ -10,6 +10,7 @@ subtest "Handling password and password hash creation" => sub {
     subtest "Creating a user with a plain text password (insecure) stores the password securely" => sub {
         my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-create-user", "plain-text-user", "--password", "foobar"));
         is($res, 0, "hydra-create-user should exit zero");
+        like($stderr, qr/Submitting plaintext passwords as arguments is deprecated and will be removed/, "Submitting a plain text password is deprecated.");
 
         my $user = $db->resultset('Users')->find({ username => "plain-text-user" });
         isnt($user, undef, "The user exists");

--- a/t/scripts/hydra-create-user.t
+++ b/t/scripts/hydra-create-user.t
@@ -46,15 +46,37 @@ subtest "Handling password and password hash creation" => sub {
         is($storedPassword, $user->password, "The password was not upgraded.");
     };
 
+    subtest "Creating a user by prompting for the password" => sub {
+        subtest "with the same password twice" => sub {
+            my ($res, $stdout, $stderr) = captureStdoutStderrWithStdin(5, ["hydra-create-user", "prompted-pass-user", "--password-prompt"], "my-password\nmy-password\n");
+            is($res, 0, "hydra-create-user should exit zero");
+
+            my $user = $db->resultset('Users')->find({ username => "prompted-pass-user" });
+            isnt($user, undef, "The user exists");
+            like($user->password, qr/^\$argon2id\$v=/, "The password was saved, hashed with argon2id.");
+
+            my $storedPassword = $user->password;
+            ok($user->check_password("my-password"), "Their password validates");
+        };
+
+        subtest "With mismatched password confirmation" => sub {
+            my ($res, $stdout, $stderr) = captureStdoutStderrWithStdin(5, ["hydra-create-user", "prompted-pass-user", "--password-prompt"], "my-password\nnot-my-password\n");
+            isnt($res, 0, "hydra-create-user should exit non-zero");
+        };
+    };
+
     subtest "Specifying conflicting password options fails" => sub {
         my @cases = (
+            [ "--password=foo", "--password-hash=8843d7f92416211de9ebb963ff4ce28125932878", "--password-prompt" ],
+            [ "--password=foo", "--password-prompt" ],
             [ "--password=foo", "--password-hash=8843d7f92416211de9ebb963ff4ce28125932878" ],
+            [ "--password-hash=8843d7f92416211de9ebb963ff4ce28125932878", "--password-prompt" ],
         );
 
         for my $case (@cases) {
             my ($res, $stdout, $stderr) = captureStdoutStderr(5, (
                 "hydra-create-user", "bogus-password-options", @{$case}));
-            like($stderr, qr/please specify only one --password\* option/, "We get an error about specifying the password");
+            like($stderr, qr/please specify one of --password-prompt or --password-hash/, "We get an error about specifying the password");
             isnt($res, 0, "hydra-create-user should exit non-zero with conflicting " . join(" ", @{$case}));
         }
     };


### PR DESCRIPTION

Original body:

> I'm not sure this is a good implementation as-is. It does work,
> but the password gets echo'd to the screen. I tried to use IO::Prompt
> but IO::Prompt really seems to want to read the password from ARGV.

but now it is noecho, so I think it should be good to go.