### PR TITLE
Fix invalid YAML in documentation

### DIFF
--- a/doc/manual/src/configuration.md
+++ b/doc/manual/src/configuration.md
@@ -126,7 +126,7 @@ general any LDAP group of the form *hydra\_some\_role* (notice the
       binddn: "cn=root,dc=example"
       bindpw: notapassword
       start_tls: 0
-      start_tls_options
+      start_tls_options:
         verify:  none
       user_basedn: "ou=users,dc=example"
       user_filter: "(&(objectClass=inetOrgPerson)(cn=%s))"


### PR DESCRIPTION
When trying to get LDAP integration to work I naively copied the example YAML config file, but later saw that there was a typo, making it invalid. This adds the missing colon.