### PR TITLE
Add cache_control header when saving NARs to S3

### DIFF
--- a/src/lib/Hydra/Plugin/S3Backup.pm
+++ b/src/lib/Hydra/Plugin/S3Backup.pm
@@ -137,7 +137,8 @@ sub buildFinished {
                 my $prefix = exists $bucket_config->{prefix} ? $bucket_config->{prefix} : "";
                 my $nar_object = $bucket->object(
                     key => $prefix . "$hash.nar",
-                    content_type => "application/x-nix-archive"
+                    content_type => "application/x-nix-archive",
+                    cache_control => "public, max-age=31536000, immutable"
                 );
                 $nar_object->put_filename("$tempdir/nar");
             }


### PR DESCRIPTION
Otherwise S3 will set no cache headers at all.

The max-age is quite generous (1 year) and the content is marked as
immutable (so clients doesn't not have to revalidate).

