### PR TITLE
GithubStatus: relax regex to support aliased names

### DIFF
--- a/src/lib/Hydra/Plugin/GithubStatus.pm
+++ b/src/lib/Hydra/Plugin/GithubStatus.pm
@@ -94,7 +94,7 @@ sub common {
                 if (defined $eval->flake) {
                     my $fl = $eval->flake;
                     print STDERR "Flake is $fl\n";
-                    if ($eval->flake =~ m!github:([^/]+)/([^/]+)/([[:xdigit:]]{40})$! or $eval->flake =~ m!git\+ssh://git\@github.com/([^/]+)/([^/]+)\?.*rev=([[:xdigit:]]{40})$!) {
+                    if ($eval->flake =~ m!github:([^/]+)/([^/]+)/([[:xdigit:]]{40})$! or $eval->flake =~ m!git\+ssh://git\@github[^/]+/([^/]+)/([^/]+)\?.*rev=([[:xdigit:]]{40})$!) {
                         $sendStatus->("src", $1, $2, $3);
                     } else {
                         print STDERR "Can't parse flake, skipping GitHub status update\n";


### PR DESCRIPTION
This lets you name multiple versions of GitHub in your .ssh/config for
the hydra user and still send GitHub status events. For example, you
could have multiple SSH keys, used depending on which GitHub repository
you're fetching from.