### PR TITLE
GitlabPulls plugin rework

### DIFF
--- a/doc/manual/src/plugins/README.md
+++ b/doc/manual/src/plugins/README.md
@@ -162,7 +162,51 @@ Create jobs based on open gitlab pull requests.
 
 ### Configuration options
 
-- `gitlab_authorization.<projectId>`
+Gitlab need you to authenticate to call the Gitalb API (even if the repository is public).
+
+Access token can be specified as global for all Gitlab call or for a specific project or group.
+
+- `gitlab_authorization.access_token`
+- `gitlab_authorization.projects.<projectId>.access_token`
+
+How to get the token at [Gitlab API Authorization](https://docs.gitlab.com/ee/api/#authentication).
+
+Example:
+
+```xml
+<gitlab_authorization>
+  access_token = "<gitlab_secret_token>"
+  <projects>
+    <31319625>
+      access_token = "<project_secret_token>"
+    </31319625>
+  </projects>
+</gitlab_authorization>
+```
+
+### Project configuration
+
+The declarative project has to be cofigured with:
+
+1. Declarative spec file: `gitlab-pulls.json`
+2. Declarative input type: "Open Gitlab Merger Requests"
+
+The decalrative input type argument is interpeted as a json string with the following field:
+
+  - "base_url": as the url or your Gitlab instance (default: "https://gitlab.com")
+  - "project_id": the id or you progect (required)
+  - "clone_type": the type of git source for each merge request (`http` or `ssh`, default: `http`)
+  - "access_token": override global `access_token` configuration, useful to quick test authorization (optional)
+
+Example:
+
+```json
+{ "base_url":"https://gitlab.com"
+, "project_id":"31319625"
+, "clone_type":"http"
+, "access_token":"<secret_token>"
+}
+```
 
 ## Gitlab status
 


### PR DESCRIPTION
I have done a bit of rework on the plugin because
- it doesn't work out of the box, even for public repositories.
- it was not clear where to overlay without deep knowledge of Hydra and GitLab API.

I know that the change is pretty big, any feedback is really welcome.

- fixes #655
- allow cloning with ssh for private repositories as noted in #606
- improves towards a full integration as asked in #606