### PR TITLE
`eval_*` events: change the API to include IDs and use \t separators

### DIFF
--- a/doc/manual/src/notifications.md
+++ b/doc/manual/src/notifications.md
@@ -75,7 +75,7 @@ It is possible for subsequent deliveries of the same `build_finished` data to im
 
 ### `eval_failed`
 
-* **Payload:** Exactly one value: an opaque trace ID representing this evaluation.
+* **Payload:** Exactly two values: an opaque trace ID representing this evaluation, and the ID of the jobset.
 * **When:** After any fetching any input fails, or any other evaluation error occurs.
 * **Delivery Semantics:** Ephemeral. `hydra-notify` must be running to react to this event. No record of this event is stored.
 

--- a/doc/manual/src/notifications.md
+++ b/doc/manual/src/notifications.md
@@ -57,7 +57,7 @@ It is possible for subsequent deliveries of the same `build_finished` data to im
 
 ### `eval_started`
 
-* **Payload:** Exactly three values, separated by the two-character string `\t` (ie: not a tab): an opaque trace ID representing this evaluation, the name of the project, and the name of the jobset.
+* **Payload:** Exactly two values, tab separated: an opaque trace ID representing this evaluation, and the ID of the jobset.
 * **When:** At the beginning of the evaluation phase for the jobset, before any work is done.
 * **Delivery Semantics:** Ephemeral. `hydra-notify` must be running to react to this event. No record of this event is stored.
 

--- a/doc/manual/src/notifications.md
+++ b/doc/manual/src/notifications.md
@@ -63,7 +63,7 @@ It is possible for subsequent deliveries of the same `build_finished` data to im
 
 ### `eval_added`
 
-* **Payload:** Exactly two values, separated by the two-character string `\t` (ie: not a tab): an opaque trace ID representing this evaluation, and the ID of the JobsetEval record.
+* **Payload:** Exactly three values, tab separated: an opaque trace ID representing this evaluation, the ID of the jobset, and the ID of the JobsetEval record.
 * **When:** After the evaluator fetches inputs and completes the evaluation successfully.
 * **Delivery Semantics:** Ephemeral. `hydra-notify` must be running to react to this event. No record of this event is stored.
 

--- a/doc/manual/src/notifications.md
+++ b/doc/manual/src/notifications.md
@@ -69,7 +69,7 @@ It is possible for subsequent deliveries of the same `build_finished` data to im
 
 ### `eval_cached`
 
-* **Payload:** Exactly one value: an opaque trace ID representing this evaluation.
+* **Payload:** Exactly three values: an opaque trace ID representing this evaluation, the ID of the jobset, and the ID of the previous identical evaluation.
 * **When:** After the evaluator fetches inputs, if none of the inputs changed.
 * **Delivery Semantics:** Ephemeral. `hydra-notify` must be running to react to this event. No record of this event is stored.
 

--- a/src/lib/Hydra/Event.pm
+++ b/src/lib/Hydra/Event.pm
@@ -7,6 +7,7 @@ use Hydra::Event::BuildQueued;
 use Hydra::Event::BuildStarted;
 use Hydra::Event::CachedBuildFinished;
 use Hydra::Event::CachedBuildQueued;
+use Hydra::Event::EvalStarted;
 use Hydra::Event::StepFinished;
 
 my %channels_to_events = (
@@ -15,6 +16,7 @@ my %channels_to_events = (
   build_started => \&Hydra::Event::BuildStarted::parse,
   cached_build_finished => \&Hydra::Event::CachedBuildFinished::parse,
   cached_build_queued => \&Hydra::Event::CachedBuildQueued::parse,
+  eval_started => \&Hydra::Event::EvalStarted::parse,
   step_finished => \&Hydra::Event::StepFinished::parse,
 );
 

--- a/src/lib/Hydra/Event.pm
+++ b/src/lib/Hydra/Event.pm
@@ -7,6 +7,7 @@ use Hydra::Event::BuildQueued;
 use Hydra::Event::BuildStarted;
 use Hydra::Event::CachedBuildFinished;
 use Hydra::Event::CachedBuildQueued;
+use Hydra::Event::EvalAdded;
 use Hydra::Event::EvalCached;
 use Hydra::Event::EvalFailed;
 use Hydra::Event::EvalStarted;
@@ -18,6 +19,7 @@ my %channels_to_events = (
   build_started => \&Hydra::Event::BuildStarted::parse,
   cached_build_finished => \&Hydra::Event::CachedBuildFinished::parse,
   cached_build_queued => \&Hydra::Event::CachedBuildQueued::parse,
+  eval_added => \&Hydra::Event::EvalAdded::parse,
   eval_cached => \&Hydra::Event::EvalCached::parse,
   eval_failed => \&Hydra::Event::EvalFailed::parse,
   eval_started => \&Hydra::Event::EvalStarted::parse,

--- a/src/lib/Hydra/Event.pm
+++ b/src/lib/Hydra/Event.pm
@@ -7,6 +7,7 @@ use Hydra::Event::BuildQueued;
 use Hydra::Event::BuildStarted;
 use Hydra::Event::CachedBuildFinished;
 use Hydra::Event::CachedBuildQueued;
+use Hydra::Event::EvalCached;
 use Hydra::Event::EvalStarted;
 use Hydra::Event::StepFinished;
 
@@ -16,6 +17,7 @@ my %channels_to_events = (
   build_started => \&Hydra::Event::BuildStarted::parse,
   cached_build_finished => \&Hydra::Event::CachedBuildFinished::parse,
   cached_build_queued => \&Hydra::Event::CachedBuildQueued::parse,
+  eval_cached => \&Hydra::Event::EvalCached::parse,
   eval_started => \&Hydra::Event::EvalStarted::parse,
   step_finished => \&Hydra::Event::StepFinished::parse,
 );

--- a/src/lib/Hydra/Event.pm
+++ b/src/lib/Hydra/Event.pm
@@ -8,6 +8,7 @@ use Hydra::Event::BuildStarted;
 use Hydra::Event::CachedBuildFinished;
 use Hydra::Event::CachedBuildQueued;
 use Hydra::Event::EvalCached;
+use Hydra::Event::EvalFailed;
 use Hydra::Event::EvalStarted;
 use Hydra::Event::StepFinished;
 
@@ -18,6 +19,7 @@ my %channels_to_events = (
   cached_build_finished => \&Hydra::Event::CachedBuildFinished::parse,
   cached_build_queued => \&Hydra::Event::CachedBuildQueued::parse,
   eval_cached => \&Hydra::Event::EvalCached::parse,
+  eval_failed => \&Hydra::Event::EvalFailed::parse,
   eval_started => \&Hydra::Event::EvalStarted::parse,
   step_finished => \&Hydra::Event::StepFinished::parse,
 );

--- a/src/lib/Hydra/Event/EvalAdded.pm
+++ b/src/lib/Hydra/Event/EvalAdded.pm
@@ -1,0 +1,63 @@
+package Hydra::Event::EvalAdded;
+
+use strict;
+use warnings;
+
+sub parse :prototype(@) {
+    unless (@_ == 3) {
+        die "eval_added: payload takes exactly three arguments, but ", scalar(@_), " were given";
+    }
+
+    my ($trace_id, $jobset_id, $evaluation_id) = @_;
+
+    unless ($jobset_id =~ /^\d+$/) {
+        die "eval_added: payload argument jobset_id should be an integer, but '", $jobset_id, "' was given"
+    }
+    unless ($evaluation_id =~ /^\d+$/) {
+        die "eval_added: payload argument evaluation_id should be an integer, but '", $evaluation_id, "' was given"
+    }
+
+    return Hydra::Event::EvalAdded->new($trace_id, int($jobset_id), int($evaluation_id));
+}
+
+sub new {
+    my ($self, $trace_id, $jobset_id, $evaluation_id) = @_;
+    return bless {
+        "trace_id" => $trace_id,
+        "jobset_id" => $jobset_id,
+        "evaluation_id" => $evaluation_id,
+        "jobset" => undef,
+        "evaluation" => undef
+    }, $self;
+}
+
+sub interestedIn {
+    my ($self, $plugin) = @_;
+    return int(defined($plugin->can('evalAdded')));
+}
+
+sub load {
+    my ($self, $db) = @_;
+
+    if (!defined($self->{"jobset"})) {
+        $self->{"jobset"} = $db->resultset('Jobsets')->find({ id => $self->{"jobset_id"}})
+            or die "Jobset $self->{'jobset_id'} does not exist\n";
+    }
+
+    if (!defined($self->{"evaluation"})) {
+        $self->{"evaluation"} = $db->resultset('JobsetEvals')->find({ id => $self->{"evaluation_id"}})
+            or die "Jobset $self->{'jobset_id'} does not exist\n";
+    }
+}
+
+sub execute {
+    my ($self, $db, $plugin) = @_;
+
+    $self->load($db);
+
+    $plugin->evalAdded($self->{"trace_id"}, $self->{"jobset"}, $self->{"evaluation"});
+
+    return 1;
+}
+
+1;

--- a/src/lib/Hydra/Event/EvalCached.pm
+++ b/src/lib/Hydra/Event/EvalCached.pm
@@ -1,0 +1,63 @@
+package Hydra::Event::EvalCached;
+
+use strict;
+use warnings;
+
+sub parse :prototype(@) {
+    unless (@_ == 3) {
+        die "eval_cached: payload takes exactly three arguments, but ", scalar(@_), " were given";
+    }
+
+    my ($trace_id, $jobset_id, $evaluation_id) = @_;
+
+    unless ($jobset_id =~ /^\d+$/) {
+        die "eval_cached: payload argument jobset_id should be an integer, but '", $jobset_id, "' was given"
+    }
+    unless ($evaluation_id =~ /^\d+$/) {
+        die "eval_cached: payload argument evaluation_id should be an integer, but '", $evaluation_id, "' was given"
+    }
+
+    return Hydra::Event::EvalCached->new($trace_id, int($jobset_id), int($evaluation_id));
+}
+
+sub new {
+    my ($self, $trace_id, $jobset_id, $evaluation_id) = @_;
+    return bless {
+        "trace_id" => $trace_id,
+        "jobset_id" => $jobset_id,
+        "evaluation_id" => $evaluation_id,
+        "jobset" => undef,
+        "evaluation" => undef
+    }, $self;
+}
+
+sub interestedIn {
+    my ($self, $plugin) = @_;
+    return int(defined($plugin->can('evalCached')));
+}
+
+sub load {
+    my ($self, $db) = @_;
+
+    if (!defined($self->{"jobset"})) {
+        $self->{"jobset"} = $db->resultset('Jobsets')->find({ id => $self->{"jobset_id"}})
+            or die "Jobset $self->{'jobset_id'} does not exist\n";
+    }
+
+    if (!defined($self->{"evaluation"})) {
+        $self->{"evaluation"} = $db->resultset('JobsetEvals')->find({ id => $self->{"evaluation_id"}})
+            or die "Jobset $self->{'jobset_id'} does not exist\n";
+    }
+}
+
+sub execute {
+    my ($self, $db, $plugin) = @_;
+
+    $self->load($db);
+
+    $plugin->evalCached($self->{"trace_id"}, $self->{"jobset"}, $self->{"evaluation"});
+
+    return 1;
+}
+
+1;

--- a/src/lib/Hydra/Event/EvalFailed.pm
+++ b/src/lib/Hydra/Event/EvalFailed.pm
@@ -1,0 +1,53 @@
+package Hydra::Event::EvalFailed;
+
+use strict;
+use warnings;
+
+sub parse :prototype(@) {
+    unless (@_ == 2) {
+        die "eval_failed: payload takes two arguments, but ", scalar(@_), " were given";
+    }
+
+    my ($trace_id, $jobset_id) = @_;
+
+    unless ($jobset_id =~ /^\d+$/) {
+        die "eval_failed: payload argument should be an integer, but '", $jobset_id, "' was given"
+    }
+
+    return Hydra::Event::EvalFailed->new($trace_id, int($jobset_id));
+}
+
+sub new {
+    my ($self, $trace_id, $jobset_id) = @_;
+    return bless {
+        "trace_id" => $trace_id,
+        "jobset_id" => $jobset_id,
+        "jobset" => undef
+    }, $self;
+}
+
+sub interestedIn {
+    my ($self, $plugin) = @_;
+    return int(defined($plugin->can('evalFailed')));
+}
+
+sub load {
+    my ($self, $db) = @_;
+
+    if (!defined($self->{"jobset"})) {
+        $self->{"jobset"} = $db->resultset('Jobsets')->find({ id => $self->{"jobset_id"}})
+            or die "Jobset $self->{'jobset_id'} does not exist\n";
+    }
+}
+
+sub execute {
+    my ($self, $db, $plugin) = @_;
+
+    $self->load($db);
+
+    $plugin->evalFailed($self->{"trace_id"}, $self->{"jobset"});
+
+    return 1;
+}
+
+1;

--- a/src/lib/Hydra/Event/EvalStarted.pm
+++ b/src/lib/Hydra/Event/EvalStarted.pm
@@ -1,0 +1,53 @@
+package Hydra::Event::EvalStarted;
+
+use strict;
+use warnings;
+
+sub parse :prototype(@) {
+    unless (@_ == 2) {
+        die "eval_started: payload takes two arguments, but ", scalar(@_), " were given";
+    }
+
+    my ($trace_id, $jobset_id) = @_;
+
+    unless ($jobset_id =~ /^\d+$/) {
+        die "eval_started: payload argument should be an integer, but '", $jobset_id, "' was given"
+    }
+
+    return Hydra::Event::EvalStarted->new($trace_id, int($jobset_id));
+}
+
+sub new {
+    my ($self, $trace_id, $jobset_id) = @_;
+    return bless {
+        "trace_id" => $trace_id,
+        "jobset_id" => $jobset_id,
+        "jobset" => undef
+    }, $self;
+}
+
+sub interestedIn {
+    my ($self, $plugin) = @_;
+    return int(defined($plugin->can('evalStarted')));
+}
+
+sub load {
+    my ($self, $db) = @_;
+
+    if (!defined($self->{"jobset"})) {
+        $self->{"jobset"} = $db->resultset('Jobsets')->find({ id => $self->{"jobset_id"}})
+            or die "Jobset $self->{'jobset_id'} does not exist\n";
+    }
+}
+
+sub execute {
+    my ($self, $db, $plugin) = @_;
+
+    $self->load($db);
+
+    $plugin->evalStarted($self->{"trace_id"}, $self->{"jobset"});
+
+    return 1;
+}
+
+1;

--- a/src/lib/Hydra/Plugin.pm
+++ b/src/lib/Hydra/Plugin.pm
@@ -42,6 +42,11 @@ sub instantiate {
 #     my ($self, $traceID, $jobset, $evaluation) = @_;
 # }
 
+# # Called when an evaluation of $jobset failed.
+# sub evalFailed {
+#     my ($self, $traceID, $jobset) = @_;
+# }
+
 # # Called when build $build has been queued.
 # sub buildQueued {
 #     my ($self, $build) = @_;

--- a/src/lib/Hydra/Plugin.pm
+++ b/src/lib/Hydra/Plugin.pm
@@ -37,6 +37,11 @@ sub instantiate {
 #     my ($self, $traceID, $jobset) = @_;
 # }
 
+# # Called when an evaluation of $jobset determined the inputs had not changed.
+# sub evalCached {
+#     my ($self, $traceID, $jobset, $evaluation) = @_;
+# }
+
 # # Called when build $build has been queued.
 # sub buildQueued {
 #     my ($self, $build) = @_;

--- a/src/lib/Hydra/Plugin.pm
+++ b/src/lib/Hydra/Plugin.pm
@@ -31,6 +31,12 @@ sub instantiate {
 # See the tests in t/Event/*.t for arguments, and the documentation for
 # notify events for semantics.
 #
+
+# # Called when an evaluation of $jobset has begun.
+# sub evalStarted {
+#     my ($self, $traceID, $jobset) = @_;
+# }
+
 # # Called when build $build has been queued.
 # sub buildQueued {
 #     my ($self, $build) = @_;

--- a/src/lib/Hydra/Plugin.pm
+++ b/src/lib/Hydra/Plugin.pm
@@ -47,6 +47,11 @@ sub instantiate {
 #     my ($self, $traceID, $jobset) = @_;
 # }
 
+# # Called when $evaluation of $jobset has completed successfully.
+# sub evalAdded {
+#     my ($self, $traceID, $jobset, $evaluation) = @_;
+# }
+
 # # Called when build $build has been queued.
 # sub buildQueued {
 #     my ($self, $build) = @_;

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -654,7 +654,7 @@ sub checkJobsetWrapped {
         print STDERR $fetchError;
         $db->txn_do(sub {
             $jobset->update({ lastcheckedtime => time, fetcherrormsg => $fetchError }) if !$dryRun;
-            $db->storage->dbh->do("notify eval_failed, ?", undef, join('\t', $tmpId));
+            $db->storage->dbh->do("notify eval_failed, ?", undef, join("\t", $tmpId, $jobset->get_column('id')));
         });
         return;
     }
@@ -882,7 +882,7 @@ sub checkJobset {
         $db->txn_do(sub {
             $jobset->update({lastcheckedtime => $eventTime});
             setJobsetError($jobset, $checkError, $eventTime);
-            $db->storage->dbh->do("notify eval_failed, ?", undef, join('\t', $tmpId));
+            $db->storage->dbh->do("notify eval_failed, ?", undef, join("\t", $tmpId, $jobset->get_column('id')));
         }) if !$dryRun;
         $failed = 1;
     }

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -771,7 +771,7 @@ sub checkJobsetWrapped {
         });
 
         $db->storage->dbh->do("notify eval_added, ?", undef,
-                              join('\t', $tmpId, $ev->id));
+                              join("\t", $tmpId, $jobset->get_column('id'), $ev->id));
 
         if ($jobsetChanged) {
             # Create JobsetEvalMembers mappings.

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -670,7 +670,11 @@ sub checkJobsetWrapped {
         Net::Statsd::increment("hydra.evaluator.unchanged_checkouts");
         $db->txn_do(sub {
             $jobset->update({ lastcheckedtime => time, fetcherrormsg => undef });
-            $db->storage->dbh->do("notify eval_cached, ?", undef, join('\t', $tmpId));
+            $db->storage->dbh->do("notify eval_cached, ?", undef, join("\t",
+                $tmpId,
+                $jobset->get_column('id'),
+                $prevEval->get_column('id'))
+            );
         });
         return;
     }

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -861,7 +861,7 @@ sub checkJobset {
     my $tmpId = "${startTime}.$$";
 
     $db->storage->dbh->do("notify eval_started, ?", undef,
-                          join('\t', $tmpId, $jobset->get_column('project'), $jobset->name));
+                          join("\t", $tmpId, $jobset->get_column('id')));
 
     eval {
         checkJobsetWrapped($jobset, $tmpId);

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -98,6 +98,7 @@ $listener->subscribe("build_queued");
 $listener->subscribe("build_started");
 $listener->subscribe("cached_build_finished");
 $listener->subscribe("cached_build_queued");
+$listener->subscribe("eval_added");
 $listener->subscribe("eval_cached");
 $listener->subscribe("eval_failed");
 $listener->subscribe("eval_started");

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -99,6 +99,7 @@ $listener->subscribe("build_started");
 $listener->subscribe("cached_build_finished");
 $listener->subscribe("cached_build_queued");
 $listener->subscribe("eval_cached");
+$listener->subscribe("eval_failed");
 $listener->subscribe("eval_started");
 $listener->subscribe("hydra_notify_dump_metrics");
 $listener->subscribe("step_finished");

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -98,6 +98,7 @@ $listener->subscribe("build_queued");
 $listener->subscribe("build_started");
 $listener->subscribe("cached_build_finished");
 $listener->subscribe("cached_build_queued");
+$listener->subscribe("eval_started");
 $listener->subscribe("hydra_notify_dump_metrics");
 $listener->subscribe("step_finished");
 

--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -98,9 +98,11 @@ $listener->subscribe("build_queued");
 $listener->subscribe("build_started");
 $listener->subscribe("cached_build_finished");
 $listener->subscribe("cached_build_queued");
+$listener->subscribe("eval_cached");
 $listener->subscribe("eval_started");
 $listener->subscribe("hydra_notify_dump_metrics");
 $listener->subscribe("step_finished");
+
 
 # Process builds that finished while hydra-notify wasn't running.
 for my $build ($db->resultset('Builds')->search(

--- a/t/Hydra/Event/EvalAdded.t
+++ b/t/Hydra/Event/EvalAdded.t
@@ -1,0 +1,112 @@
+use strict;
+use warnings;
+use Setup;
+use Hydra::Event;
+use Hydra::Event::EvalAdded;
+use Test2::V0;
+use Test2::Tools::Exception;
+use Test2::Tools::Mock qw(mock_obj);
+
+
+my $ctx = test_context();
+my $builds = $ctx->makeAndEvaluateJobset(
+    expression => "basic.nix",
+    build => 1
+);
+
+
+subtest "Parsing eval_added" => sub {
+    like(
+        dies { Hydra::Event::parse_payload("eval_added", "") },
+        qr/three arguments/,
+        "empty payload"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_added", "abc123") },
+        qr/three arguments/,
+        "one argument"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_added", "abc123\tabc123") },
+        qr/three arguments/,
+        "two arguments"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_added", "abc123\tabc123\tabc123\tabc123") },
+        qr/three arguments/,
+        "four arguments"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_added", "abc123\tabc123\t123") },
+        qr/should be an integer/,
+        "not an integer: second position"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_added", "abc123\t123\tabc123") },
+        qr/should be an integer/,
+        "not an integer: third position"
+    );
+    is(
+        Hydra::Event::parse_payload("eval_added", "abc123\t123\t456"),
+        Hydra::Event::EvalAdded->new("abc123", 123, 456)
+    );
+};
+
+subtest "interested" => sub {
+    my $event = Hydra::Event::EvalAdded->new("abc123", 123, 456);
+
+    subtest "A plugin which does not implement the API" => sub {
+        my $plugin = {};
+        my $mock = mock_obj $plugin => ();
+
+        is($event->interestedIn($plugin), 0, "The plugin is not interesting.");
+    };
+
+    subtest "A plugin which does implement the API" => sub {
+        my $plugin = {};
+        my $mock = mock_obj $plugin => (
+            add => [
+                "evalAdded" => sub {}
+            ]
+        );
+
+        is($event->interestedIn($plugin), 1, "The plugin is interesting.");
+    };
+};
+
+subtest "load" => sub {
+    my $jobset = $builds->{"empty_dir"}->jobset;
+    my $evaluation = $builds->{"empty_dir"}->jobsetevals->first();
+
+    my $event = Hydra::Event::EvalAdded->new("traceID", $jobset->id, $evaluation->id);
+
+    $event->load($ctx->db());
+    is($event->{"trace_id"}, "traceID", "The Trace ID matches");
+    is($event->{"jobset_id"}, $jobset->id, "The Jobset ID matches");
+    is($event->{"evaluation_id"}, $evaluation->id, "The Evaluation ID matches");
+
+
+    # Create a fake "plugin" with a evalAdded sub, the sub sets these
+    # "globals"
+    my $passedTraceID;
+    my $passedJobset;
+    my $passedEvaluation;
+    my $plugin = {};
+    my $mock = mock_obj $plugin => (
+        add => [
+            "evalAdded" => sub {
+                my ($self, $traceID, $jobset, $evaluation) = @_;
+                $passedTraceID = $traceID;
+                $passedJobset = $jobset;
+                $passedEvaluation = $evaluation;
+            }
+        ]
+    );
+
+    $event->execute($ctx->db(), $plugin);
+    is($passedTraceID, "traceID", "We get the expected trace ID");
+    is($passedJobset->id, $jobset->id, "The correct jobset is passed");
+    is($passedEvaluation->id, $evaluation->id, "The correct evaluation is passed");
+};
+
+done_testing;

--- a/t/Hydra/Event/EvalCached.t
+++ b/t/Hydra/Event/EvalCached.t
@@ -1,0 +1,112 @@
+use strict;
+use warnings;
+use Setup;
+use Hydra::Event;
+use Hydra::Event::EvalCached;
+use Test2::V0;
+use Test2::Tools::Exception;
+use Test2::Tools::Mock qw(mock_obj);
+
+
+my $ctx = test_context();
+my $builds = $ctx->makeAndEvaluateJobset(
+    expression => "basic.nix",
+    build => 1
+);
+
+
+subtest "Parsing eval_cached" => sub {
+    like(
+        dies { Hydra::Event::parse_payload("eval_cached", "") },
+        qr/three arguments/,
+        "empty payload"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_cached", "abc123") },
+        qr/three arguments/,
+        "one argument"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_cached", "abc123\tabc123") },
+        qr/three arguments/,
+        "two arguments"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_cached", "abc123\tabc123\tabc123\tabc123") },
+        qr/three arguments/,
+        "four arguments"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_cached", "abc123\tabc123\t123") },
+        qr/should be an integer/,
+        "not an integer: second position"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_cached", "abc123\t123\tabc123") },
+        qr/should be an integer/,
+        "not an integer: third position"
+    );
+    is(
+        Hydra::Event::parse_payload("eval_cached", "abc123\t123\t456"),
+        Hydra::Event::EvalCached->new("abc123", 123, 456)
+    );
+};
+
+subtest "interested" => sub {
+    my $event = Hydra::Event::EvalCached->new("abc123", 123, 456);
+
+    subtest "A plugin which does not implement the API" => sub {
+        my $plugin = {};
+        my $mock = mock_obj $plugin => ();
+
+        is($event->interestedIn($plugin), 0, "The plugin is not interesting.");
+    };
+
+    subtest "A plugin which does implement the API" => sub {
+        my $plugin = {};
+        my $mock = mock_obj $plugin => (
+            add => [
+                "evalCached" => sub {}
+            ]
+        );
+
+        is($event->interestedIn($plugin), 1, "The plugin is interesting.");
+    };
+};
+
+subtest "load" => sub {
+    my $jobset = $builds->{"empty_dir"}->jobset;
+    my $evaluation = $builds->{"empty_dir"}->jobsetevals->first();
+
+    my $event = Hydra::Event::EvalCached->new("traceID", $jobset->id, $evaluation->id);
+
+    $event->load($ctx->db());
+    is($event->{"trace_id"}, "traceID", "The Trace ID matches");
+    is($event->{"jobset_id"}, $jobset->id, "The Jobset ID matches");
+    is($event->{"evaluation_id"}, $evaluation->id, "The Evaluation ID matches");
+
+
+    # Create a fake "plugin" with a evalCached sub, the sub sets these
+    # "globals"
+    my $passedTraceID;
+    my $passedJobset;
+    my $passedEvaluation;
+    my $plugin = {};
+    my $mock = mock_obj $plugin => (
+        add => [
+            "evalCached" => sub {
+                my ($self, $traceID, $jobset, $evaluation) = @_;
+                $passedTraceID = $traceID;
+                $passedJobset = $jobset;
+                $passedEvaluation = $evaluation;
+            }
+        ]
+    );
+
+    $event->execute($ctx->db(), $plugin);
+    is($passedTraceID, "traceID", "We get the expected trace ID");
+    is($passedJobset->id, $jobset->id, "The correct jobset is passed");
+    is($passedEvaluation->id, $evaluation->id, "The correct evaluation is passed");
+};
+
+done_testing;

--- a/t/Hydra/Event/EvalFailed.t
+++ b/t/Hydra/Event/EvalFailed.t
@@ -1,0 +1,94 @@
+use strict;
+use warnings;
+use Setup;
+use Hydra::Event;
+use Hydra::Event::EvalFailed;
+use Test2::V0;
+use Test2::Tools::Exception;
+use Test2::Tools::Mock qw(mock_obj);
+
+my $ctx = test_context();
+
+my $builds = $ctx->makeAndEvaluateJobset(
+    expression => "basic.nix",
+    build => 1
+);
+
+subtest "Parsing eval_failed" => sub {
+    like(
+        dies { Hydra::Event::parse_payload("eval_failed", "") },
+        qr/two arguments/,
+        "empty payload"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_failed", "abc123") },
+        qr/two arguments/,
+        "one argument"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_failed", "abc123\tabc123\tabc123") },
+        qr/two arguments/,
+        "three arguments"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_failed", "abc123\tabc123") },
+        qr/should be an integer/,
+        "not an integer: second argument"
+    );
+    is(
+        Hydra::Event::parse_payload("eval_failed", "abc123\t456"),
+        Hydra::Event::EvalFailed->new("abc123", 456)
+    );
+};
+
+subtest "interested" => sub {
+    my $event = Hydra::Event::EvalFailed->new(123, []);
+
+    subtest "A plugin which does not implement the API" => sub {
+        my $plugin = {};
+        my $mock = mock_obj $plugin => ();
+
+        is($event->interestedIn($plugin), 0, "The plugin is not interesting.");
+    };
+
+    subtest "A plugin which does implement the API" => sub {
+        my $plugin = {};
+        my $mock = mock_obj $plugin => (
+            add => [
+                "evalFailed" => sub {}
+            ]
+        );
+
+        is($event->interestedIn($plugin), 1, "The plugin is interesting.");
+    };
+};
+
+subtest "load" => sub {
+    my $jobset = $builds->{"empty_dir"}->jobset;
+
+    my $event = Hydra::Event::EvalFailed->new("traceID", $jobset->id);
+
+    $event->load($ctx->db());
+    is($event->{"jobset"}->get_column("id"), $jobset->id, "The jobset record matches.");
+
+    # Create a fake "plugin" with a evalFailed sub, the sub sets this
+    # "global" passedTraceID, passedJobset
+    my $passedTraceID;
+    my $passedJobset;
+    my $plugin = {};
+    my $mock = mock_obj $plugin => (
+        add => [
+            "evalFailed" => sub {
+                my ($self, $traceID, $jobset) = @_;
+                $passedTraceID = $traceID;
+                $passedJobset = $jobset;
+            }
+        ]
+    );
+
+    $event->execute($ctx->db(), $plugin);
+    is($passedTraceID, "traceID", "The plugin is told what the trace ID was");
+    is($passedJobset->get_column("id"), $jobset->id, "The plugin's evalFailed hook is called with the right jobset");
+};
+
+done_testing;

--- a/t/Hydra/Event/EvalStarted.t
+++ b/t/Hydra/Event/EvalStarted.t
@@ -1,0 +1,94 @@
+use strict;
+use warnings;
+use Setup;
+use Hydra::Event;
+use Hydra::Event::EvalStarted;
+use Test2::V0;
+use Test2::Tools::Exception;
+use Test2::Tools::Mock qw(mock_obj);
+
+my $ctx = test_context();
+
+my $builds = $ctx->makeAndEvaluateJobset(
+    expression => "basic.nix",
+    build => 1
+);
+
+subtest "Parsing eval_started" => sub {
+    like(
+        dies { Hydra::Event::parse_payload("eval_started", "") },
+        qr/two arguments/,
+        "empty payload"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_started", "abc123") },
+        qr/two arguments/,
+        "one argument"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_started", "abc123\tabc123\tabc123") },
+        qr/two arguments/,
+        "three arguments"
+    );
+    like(
+        dies { Hydra::Event::parse_payload("eval_started", "abc123\tabc123") },
+        qr/should be an integer/,
+        "not an integer: second argument"
+    );
+    is(
+        Hydra::Event::parse_payload("eval_started", "abc123\t456"),
+        Hydra::Event::EvalStarted->new("abc123", 456)
+    );
+};
+
+subtest "interested" => sub {
+    my $event = Hydra::Event::EvalStarted->new(123, []);
+
+    subtest "A plugin which does not implement the API" => sub {
+        my $plugin = {};
+        my $mock = mock_obj $plugin => ();
+
+        is($event->interestedIn($plugin), 0, "The plugin is not interesting.");
+    };
+
+    subtest "A plugin which does implement the API" => sub {
+        my $plugin = {};
+        my $mock = mock_obj $plugin => (
+            add => [
+                "evalStarted" => sub {}
+            ]
+        );
+
+        is($event->interestedIn($plugin), 1, "The plugin is interesting.");
+    };
+};
+
+subtest "load" => sub {
+    my $jobset = $builds->{"empty_dir"}->jobset;
+
+    my $event = Hydra::Event::EvalStarted->new("traceID", $jobset->id);
+
+    $event->load($ctx->db());
+    is($event->{"jobset"}->get_column("id"), $jobset->id, "The jobset record matches.");
+
+    # Create a fake "plugin" with a evalStarted sub, the sub sets this
+    # "global" passedTraceID, passedJobset
+    my $passedTraceID;
+    my $passedJobset;
+    my $plugin = {};
+    my $mock = mock_obj $plugin => (
+        add => [
+            "evalStarted" => sub {
+                my ($self, $traceID, $jobset) = @_;
+                $passedTraceID = $traceID;
+                $passedJobset = $jobset;
+            }
+        ]
+    );
+
+    $event->execute($ctx->db(), $plugin);
+    is($passedTraceID, "traceID", "The plugin is told what the trace ID was");
+    is($passedJobset->get_column("id"), $jobset->id, "The plugin's evalStarted hook is called with the right jobset");
+};
+
+done_testing;


### PR DESCRIPTION
Needs:

- [ ] changelog

The old format for these events used the two-character string `\t` as a separator between the fields. I wasn't going to break these event's message format until I saw this and assumed nobody used it. I assume if nobody reported the bug nobody used it. It is obviously a bug that it isn't a tab character. If somebody did depend on such an obvious bug without reporting it, well, oops.

This PR lets plugins attach to evalStarted, evalCached, evalFinished, evalFailed, evalAdded events. This is useful for sending status events to, eg, GitHub (PR soon.)

Note this PR includes #1144 which is fixups originally part of this branch.