### PR TITLE
captureStdoutStderr*: move to Hydra::Helper::Exec which helps avoid some environment variable fixation problems

### DIFF
--- a/src/lib/Hydra/Helper/Exec.pm
+++ b/src/lib/Hydra/Helper/Exec.pm
@@ -1,0 +1,35 @@
+use warnings;
+use strict;
+use IPC::Run;
+
+package Hydra::Helper::Exec;
+our @ISA = qw(Exporter);
+our @EXPORT = qw(
+    captureStdoutStderr
+    captureStdoutStderrWithStdin
+);
+
+sub captureStdoutStderr {
+    my ($timeout, @cmd) = @_;
+
+    return captureStdoutStderrWithStdin($timeout, \@cmd, "");
+}
+
+sub captureStdoutStderrWithStdin {
+    my ($timeout, $cmd, $stdin) = @_;
+    my $stdout;
+    my $stderr;
+
+    eval {
+        local $SIG{ALRM} = sub { die "timeout\n" }; # NB: \n required
+        alarm $timeout;
+        IPC::Run::run($cmd, \$stdin, \$stdout, \$stderr);
+        alarm 0;
+        1;
+    } or do {
+        die unless $@ eq "timeout\n"; # propagate unexpected errors
+        return (-1, $stdout, ($stderr // "") . "timeout\n");
+    };
+
+    return ($?, $stdout, $stderr);
+}

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -18,8 +18,6 @@ use UUID4::Tiny qw(is_uuid4_string);
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
     cancelBuilds
-    captureStdoutStderr
-    captureStdoutStderrWithStdin
     constructRunCommandLogPath
     findLog
     gcRootFor
@@ -429,30 +427,7 @@ sub pathIsInsidePrefix {
 }
 
 
-sub captureStdoutStderr {
-    my ($timeout, @cmd) = @_;
 
-    return captureStdoutStderrWithStdin($timeout, \@cmd, "");
-}
-
-sub captureStdoutStderrWithStdin {
-    my ($timeout, $cmd, $stdin) = @_;
-    my $stdout;
-    my $stderr;
-
-    eval {
-        local $SIG{ALRM} = sub { die "timeout\n" }; # NB: \n required
-        alarm $timeout;
-        IPC::Run::run($cmd, \$stdin, \$stdout, \$stderr);
-        alarm 0;
-        1;
-    } or do {
-        die unless $@ eq "timeout\n"; # propagate unexpected errors
-        return (-1, $stdout, ($stderr // "") . "timeout\n");
-    };
-
-    return ($?, $stdout, $stderr);
-}
 
 
 sub run {

--- a/src/lib/Hydra/Plugin/BazaarInput.pm
+++ b/src/lib/Hydra/Plugin/BazaarInput.pm
@@ -5,6 +5,7 @@ use warnings;
 use parent 'Hydra::Plugin';
 use Digest::SHA qw(sha256_hex);
 use File::Path;
+use Hydra::Helper::Exec;
 use Hydra::Helper::Nix;
 use Nix::Store;
 

--- a/src/lib/Hydra/Plugin/DarcsInput.pm
+++ b/src/lib/Hydra/Plugin/DarcsInput.pm
@@ -5,6 +5,7 @@ use warnings;
 use parent 'Hydra::Plugin';
 use Digest::SHA qw(sha256_hex);
 use File::Path;
+use Hydra::Helper::Exec;
 use Hydra::Helper::Nix;
 use Nix::Store;
 

--- a/src/lib/Hydra/Plugin/MercurialInput.pm
+++ b/src/lib/Hydra/Plugin/MercurialInput.pm
@@ -6,6 +6,7 @@ use parent 'Hydra::Plugin';
 use Digest::SHA qw(sha256_hex);
 use File::Path;
 use Hydra::Helper::Nix;
+use Hydra::Helper::Exec;
 use Nix::Store;
 use Fcntl qw(:flock);
 

--- a/src/lib/Hydra/Plugin/SubversionInput.pm
+++ b/src/lib/Hydra/Plugin/SubversionInput.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use parent 'Hydra::Plugin';
 use Digest::SHA qw(sha256_hex);
+use Hydra::Helper::Exec;
 use Hydra::Helper::Nix;
 use IPC::Run;
 use Nix::Store;

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -11,6 +11,7 @@ use File::Slurper qw(read_text);
 use Hydra::Helper::AddBuilds;
 use Hydra::Helper::CatalystUtils;
 use Hydra::Helper::Email;
+use Hydra::Helper::Exec;
 use Hydra::Helper::Nix;
 use Hydra::Model::DB;
 use Hydra::Plugin;

--- a/t/Hydra/Controller/Jobset/channel.t
+++ b/t/Hydra/Controller/Jobset/channel.t
@@ -6,13 +6,13 @@ use IO::Uncompress::Bunzip2 qw(bunzip2);
 use Archive::Tar;
 use JSON::MaybeXS qw(decode_json);
 use Data::Dumper;
+use Hydra::Helper::Exec;
 my %ctx = test_init(
   use_external_destination_store => 0
 );
 
 require Hydra::Schema;
 require Hydra::Model::DB;
-require Hydra::Helper::Nix;
 
 use Test2::V0;
 require Catalyst::Test;
@@ -47,7 +47,7 @@ $tar->extract_file("channel/default.nix", $defaultnix);
 
 print STDERR $tar->get_content("channel/default.nix");
 
-(my $status, my $stdout, my $stderr) = Hydra::Helper::Nix::captureStdoutStderr(5, "nix-env", "--json", "--query", "--available", "--attr-path", "--file", $defaultnix);
+(my $status, my $stdout, my $stderr) = captureStdoutStderr(5, "nix-env", "--json", "--query", "--available", "--attr-path", "--file", $defaultnix);
 is($stderr, "", "Stderr should be empty");
 is($status, 0, "Querying the packages should succeed");
 

--- a/t/Hydra/Plugin/RunCommand/basic.t
+++ b/t/Hydra/Plugin/RunCommand/basic.t
@@ -13,6 +13,8 @@ my %ctx = test_init(
 
 require Hydra::Schema;
 require Hydra::Model::DB;
+require Hydra::Helper::Nix;
+
 
 use Test2::V0;
 

--- a/t/lib/CliRunners.pm
+++ b/t/lib/CliRunners.pm
@@ -2,34 +2,14 @@ use warnings;
 use strict;
 
 package CliRunners;
+use Hydra::Helper::Exec;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
-    captureStdoutStderr
-    captureStdoutStderrWithStdin
     evalFails
     evalSucceeds
     runBuild
     sendNotifications
 );
-
-
-sub captureStdoutStderr {
-    # "Lazy"-load Hydra::Helper::Nix to avoid the compile-time
-    # import of Hydra::Model::DB. Early loading of the DB class
-    # causes fixation of the DSN, and we need to fixate it after
-    # the temporary DB is setup.
-    require Hydra::Helper::Nix;
-    return Hydra::Helper::Nix::captureStdoutStderr(@_)
-}
-
-sub captureStdoutStderrWithStdin {
-    # "Lazy"-load Hydra::Helper::Nix to avoid the compile-time
-    # import of Hydra::Model::DB. Early loading of the DB class
-    # causes fixation of the DSN, and we need to fixate it after
-    # the temporary DB is setup.
-    require Hydra::Helper::Nix;
-    return Hydra::Helper::Nix::captureStdoutStderrWithStdin(@_)
-}
 
 sub evalSucceeds {
     my ($jobset) = @_;

--- a/t/lib/Setup.pm
+++ b/t/lib/Setup.pm
@@ -8,12 +8,11 @@ use File::Temp;
 use File::Path qw(make_path);
 use File::Basename;
 use Cwd qw(abs_path getcwd);
+use Hydra::Helper::Exec;
 use CliRunners;
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
-    captureStdoutStderr
-    captureStdoutStderrWithStdin
     createBaseJobset
     createJobsetWithOneInput
     evalFails

--- a/t/queue-runner/build-locally-with-substitutable-path.t
+++ b/t/queue-runner/build-locally-with-substitutable-path.t
@@ -3,9 +3,13 @@ use warnings;
 use Setup;
 use Data::Dumper;
 use Test2::V0;
+use Hydra::Helper::Exec;
+
 my $ctx = test_context(
     use_external_destination_store => 1
 );
+
+require Hydra::Helper::Nix;
 
 # This test is regarding https://github.com/NixOS/hydra/pull/1126
 #

--- a/t/scripts/hydra-create-user.t
+++ b/t/scripts/hydra-create-user.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Setup;
 use Test2::V0;
+use Hydra::Helper::Exec;
 
 my $ctx = test_context();
 my $db = $ctx->db();

--- a/t/scripts/hydra-init.t
+++ b/t/scripts/hydra-init.t
@@ -2,6 +2,7 @@ use feature 'unicode_strings';
 use strict;
 use warnings;
 use Setup;
+use Hydra::Helper::Exec;
 
 my %ctx = test_init();
 

--- a/t/scripts/hydra-send-stats.t
+++ b/t/scripts/hydra-send-stats.t
@@ -2,6 +2,7 @@ use feature 'unicode_strings';
 use strict;
 use warnings;
 use Setup;
+use Hydra::Helper::Exec;
 
 my %ctx = test_init();
 

--- a/t/scripts/hydra-update-gc-roots/update-gc-roots.t
+++ b/t/scripts/hydra-update-gc-roots/update-gc-roots.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Setup;
 use Test2::V0;
+use Hydra::Helper::Exec;
 
 my $ctx = test_context();
 my $builds = $ctx->makeAndEvaluateJobset(


### PR DESCRIPTION
Using Hydra::Helper::Nix in tests causes environment variables like HYDRA_DBI to be fixated too early, making us `require` it. A common reason to do this in a test is to access captureStdoutStderrWithStdin. This PR moves those functions to a new helper.