### PR TITLE
Parallel tests, fix a hydra-queue-runner race condition

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,10 +41,12 @@
         perlPackages = prev.perlPackages // {
           TestPostgreSQL = final.perlPackages.buildPerlModule {
             pname = "Test-PostgreSQL";
-            version = "1.27";
-            src = final.fetchurl {
-              url = "mirror://cpan/authors/id/T/TJ/TJC/Test-PostgreSQL-1.27.tar.gz";
-              sha256 = "b1bd231693100cc40905fb0ba3173173201621de9c8301f21c5b593b0a46f907";
+            version = "1.28-1";
+            src = final.fetchFromGitHub {
+              owner = "grahamc";
+              repo = "Test-postgresql";
+              rev = "release-1.28-1";
+              hash = "sha256-SFC1C3q3dbcBos18CYd/s0TIcfJW4g04ld0+XQXVToQ=";
             };
             buildInputs = with final.perlPackages; [ ModuleBuildTiny TestSharedFork pkgs.postgresql ];
             propagatedBuildInputs = with final.perlPackages; [ DBDPg DBI FileWhich FunctionParameters Moo TieHashMethod TryTiny TypeTiny ];
@@ -52,7 +54,7 @@
             makeMakerFlags = "POSTGRES_HOME=${final.postgresql}";
 
             meta = {
-              homepage = https://github.com/TJC/Test-postgresql;
+              homepage = "https://github.com/grahamc/Test-postgresql/releases/tag/release-1.28-1";
               description = "PostgreSQL runner for tests";
               license = with final.lib.licenses; [ artistic2 ];
             };

--- a/src/hydra-queue-runner/dispatcher.cc
+++ b/src/hydra-queue-runner/dispatcher.cc
@@ -31,8 +31,10 @@ void State::makeRunnable(Step::ptr step)
 
 void State::dispatcher()
 {
-    while (true) {
+    printMsg(lvlDebug, "Waiting for the machines parsing to have completed at least once");
+    machinesReadyLock.lock();
 
+    while (true) {
         try {
             printMsg(lvlDebug, "dispatcher woken up");
             nrDispatcherWakeups++;

--- a/src/hydra-queue-runner/state.hh
+++ b/src/hydra-queue-runner/state.hh
@@ -342,6 +342,7 @@ private:
     nix::Pool<Connection> dbPool;
 
     /* The build machines. */
+    std::mutex machinesReadyLock;
     typedef std::map<std::string, Machine::ptr> Machines;
     nix::Sync<Machines> machines; // FIXME: use atomic_shared_ptr
 

--- a/t/Hydra/Plugin/gitea.t
+++ b/t/Hydra/Plugin/gitea.t
@@ -60,6 +60,13 @@ if (!defined($pid = fork())) {
     kill('INT', $pid);
 }
 
+for my $i (1..10) {
+    if (! -f $filename) {
+       diag("$filename does not yet exist");
+       sleep(1);
+    }
+}
+
 open(my $fh, "<", $filename) or die ("Can't open(): $!\n");
 my $i = 0;
 my $uri = <$fh>;

--- a/t/test.pl
+++ b/t/test.pl
@@ -11,6 +11,15 @@ BEGIN {
     $App::Yath::Script::SCRIPT = which 'yath';
 }
 use App::Yath::Util qw/find_yath/;
+use List::SomeUtils qw(none);
+
+if (defined($ENV{"NIX_BUILD_CORES"})
+    and not defined($ENV{"YATH_JOB_COUNT"})
+    and not defined($ENV{"T2_HARNESS_JOB_COUNT"})
+    and not defined($ENV{"T2_HARNESS_JOB_COUNT"})) {
+    $ENV{"YATH_JOB_COUNT"} = $ENV{"NIX_BUILD_CORES"};
+    print STDERR "test.pl: Defaulting \$YATH_JOB_COUNT to \$NIX_BUILD_CORES (${\$ENV{'NIX_BUILD_CORES'}})\n";
+}
 
 system($^X, find_yath(), '-D', 'test', '--default-search' => './', @ARGV);
 my $exit = $?;


### PR DESCRIPTION
Use a patched Test::Postgresql to support parallel test execution. Defaults to the number of NIX_BUILD_CORES. Takes run time from a few minutes to about 15s locally. GitHubACtions takes about 10 minutes, let's see how long it takes with this.