### PR TITLE
jobsets: Show status of next evaluation as emoji

### DIFF
--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -596,11 +596,18 @@ BLOCK renderJobsetOverview %]
         </td>
         <td><span class="[% IF !j.enabled %]disabled-jobset[% END %] [%+ IF j.hidden %]hidden-jobset[% END %]">[% IF showProject; INCLUDE renderFullJobsetName project=j.get_column('project') jobset=j.name inRow=1; ELSE; INCLUDE renderJobsetName project=j.get_column('project') jobset=j.name inRow=1; END %]</span></td>
         <td>[% HTML.escape(j.description) %]</td>
-        <td>[% IF j.lastcheckedtime;
-                 INCLUDE renderDateTime timestamp = j.lastcheckedtime;
-                 IF j.errormsg || j.fetcherrormsg; %]&nbsp;<span class = 'badge badge-warning'>Error</span>[% END;
-                 ELSE; "-";
-               END %]</td>
+        <td>[% IF j.lastcheckedtime %]
+                [% INCLUDE renderDateTime timestamp = j.lastcheckedtime %]&nbsp;
+                [% IF j.starttime %]<img src="[% c.uri_for("/static/images/emojione-question-2754.svg") %]" height="16" width="16" title="New evaluation running" alt="New evaluation running" />
+                [% ELSIF j.triggertime %]<span title="New evaluation pending">…</span>
+                [% ELSIF j.fetcherrormsg %]<img src="[% c.uri_for("/static/images/emojione-red-x-274c.svg") %]" height="16" width="16" title="Fetching Failed" alt="Fetching failed" />
+                [% ELSIF j.errormsg %]<img src="[% c.uri_for("/static/images/emojione-red-x-274c.svg") %]" height="16" width="16" title="Last Evaluation Failed" alt="Last evaluation failed" />
+                [% ELSE %]<img src="[% c.uri_for("/static/images/emojione-check-2714.svg") %]" height="16" width="16" title="Succeeded" alt="Succeeded" />
+                [% END %]
+            [% ELSE %]
+                -
+            [% END %]
+        </td>
         [% IF j.get_column('nrtotal') > 0 %]
           [% successrate = ( j.get_column('nrsucceeded') / j.get_column('nrtotal') )*100 %]
           [% IF j.get_column('nrscheduled') > 0 %]


### PR DESCRIPTION
This also cleans up the tt code because it was quite horrible to look at
imo

![image](https://user-images.githubusercontent.com/4971975/153757767-b1e08e05-1058-4e58-8dba-c4033d515a80.png)
![image](https://user-images.githubusercontent.com/4971975/153757773-03036e5b-1c04-4a16-98df-fdf6042ac76f.png)
