### PR TITLE
flake: inputs.nix: 2.6.0 -> 2.6.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,16 +23,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1643066034,
-        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "lastModified": 1645099657,
+        "narHash": "sha256-E9iQ7f+9Z6xFcUvvfksTEfn8LsDfzmwrcRBC//5B3V0=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "rev": "e044ccb67ce38d11059de32515306f5f1bd2f04f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "2.6.0",
+        "ref": "2.6.1",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A Nix-based continuous build system";
 
   inputs.nixpkgs.follows = "nix/nixpkgs";
-  inputs.nix.url = github:NixOS/nix/2.6.0;
+  inputs.nix.url = github:NixOS/nix/2.6.1;
 
   outputs = { self, nixpkgs, nix }:
     let


### PR DESCRIPTION
cc @grahamc (was about to push it to the previous PR when you merged it :sweat_smile: )