### PR TITLE
Begin factoring out the protocol code

### DIFF
--- a/src/hydra-queue-runner/state.hh
+++ b/src/hydra-queue-runner/state.hh
@@ -22,6 +22,7 @@
 #include "sync.hh"
 #include "nar-extractor.hh"
 #include "serve-protocol.hh"
+#include "serve-protocol-impl.hh"
 
 
 typedef unsigned int BuildID;
@@ -302,29 +303,9 @@ struct Machine
     }
 
     // A connection to a machine
-    struct Connection {
-        nix::FdSource from;
-        nix::FdSink to;
-        nix::ServeProto::Version remoteVersion;
-
+    struct Connection : nix::ServeProto::BasicClientConnection {
         // Backpointer to the machine
         ptr machine;
-
-        operator nix::ServeProto::ReadConn ()
-        {
-            return {
-                .from = from,
-                .version = remoteVersion,
-            };
-        }
-
-        operator nix::ServeProto::WriteConn ()
-        {
-            return {
-                .to = to,
-                .version = remoteVersion,
-            };
-        }
     };
 };
 


### PR DESCRIPTION
After a few preparatory moves, this does `cmdQueryValidPaths`

See each commit for details and easier reviewing.

Progress towards https://github.com/NixOS/hydra/issues/1164

This targets `nix-next` not `master`, so it is fine that this depends on an unreleased version of Nix. Only the Nix PR needs to be merged first.

Depends on https://github.com/NixOS/nix/pull/6134
~~Depends on #1324~~

