### PR TITLE
Fixup std::string usage

### DIFF
--- a/src/libhydra/db.hh
+++ b/src/libhydra/db.hh
@@ -18,7 +18,7 @@ struct Connection : pqxx::connection
         std::string upper_prefix = "DBI:Pg:";
 
         if (hasPrefix(s, lower_prefix) || hasPrefix(s, upper_prefix)) {
-            return concatStringsSep(" ", tokenizeString<Strings>(string(s, lower_prefix.size()), ";"));
+            return concatStringsSep(" ", tokenizeString<Strings>(std::string(s, lower_prefix.size()), ";"));
         }
 
         throw Error("$HYDRA_DBI does not denote a PostgreSQL database");

--- a/src/libhydra/hydra-config.hh
+++ b/src/libhydra/hydra-config.hh
@@ -17,7 +17,7 @@ struct HydraConfig
         if (hydraConfigFile && pathExists(*hydraConfigFile)) {
 
             for (auto line : tokenizeString<Strings>(readFile(*hydraConfigFile), "\n")) {
-                line = trim(string(line, 0, line.find('#')));
+                line = trim(std::string(line, 0, line.find('#')));
 
                 auto eq = line.find('=');
                 if (eq == std::string::npos) continue;


### PR DESCRIPTION
This fails with nixpkgs' default hardening

```
../libhydra/hydra-config.hh:20:29: error: 'string' was not declared in this scope
   20 |                 line = trim(string(line, 0, line.find('#')));
      |
```