### PR TITLE
Broken constituents: emit useful log messages on evaluation errors on constituents

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -801,7 +801,7 @@ sub checkJobsetWrapped {
                 next unless $job->{constituents};
 
                 if (defined $job->{error}) {
-                    die "aggregate job ‘$job->{jobName}’ failed with the error: $job->{error}";
+                    die "aggregate job ‘$job->{jobName}’ failed with the error: $job->{error}\n";
                 }
 
                 my $x = $drvPathToId{$job->{drvPath}} or

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -799,7 +799,13 @@ sub checkJobsetWrapped {
 
             foreach my $job (values %{$jobs}) {
                 next unless $job->{constituents};
-                my $x = $drvPathToId{$job->{drvPath}} or die;
+
+                if (defined $job->{error}) {
+                    die "aggregate job ‘$job->{jobName}’ failed with the error: $job->{error}";
+                }
+
+                my $x = $drvPathToId{$job->{drvPath}} or
+                    die "aggregate job ‘$job->{jobName}’ has no corresponding build record.\n";
                 foreach my $drvPath (@{$job->{constituents}}) {
                     my $constituent = $drvPathToId{$drvPath};
                     if (defined $constituent) {

--- a/t/evaluator/evaluate-constituents-broken.t
+++ b/t/evaluator/evaluate-constituents-broken.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Setup;
+use Test2::V0;
+use Hydra::Helper::Exec;
+
+my $ctx = test_context();
+
+my $jobsetCtx = $ctx->makeJobset(
+    expression => 'constituents-broken.nix',
+);
+my $jobset = $jobsetCtx->{"jobset"};
+
+my ($res, $stdout, $stderr) = captureStdoutStderr(60,
+    ("hydra-eval-jobset", $jobsetCtx->{"project"}->name, $jobset->name)
+);
+isnt($res, 0, "hydra-eval-jobset exits non-zero");
+ok(utf8::decode($stderr), "Stderr output is UTF8-clean");
+like(
+    $stderr,
+    qr/aggregate job ‘mixed_aggregate’ failed with the error: constituentA: does not exist/,
+    "The stderr record includes a relevant error message"
+);
+
+$jobset->discard_changes;  # refresh from DB
+like(
+    $jobset->errormsg,
+    qr/aggregate job ‘mixed_aggregate’ failed with the error: constituentA: does not exist/,
+    "The jobset records a relevant error message"
+);
+
+done_testing;

--- a/t/jobs/constituents-broken.nix
+++ b/t/jobs/constituents-broken.nix
@@ -1,0 +1,19 @@
+with import ./config.nix;
+rec {
+  constituentA = null;
+
+  constituentB = mkDerivation {
+    name = "empty-dir-B";
+    builder = ./empty-dir-builder.sh;
+  };
+
+  mixed_aggregate = mkDerivation {
+    name = "mixed_aggregate";
+    _hydraAggregate = true;
+    constituents = [
+      "constituentA"
+      constituentB
+    ];
+    builder = ./empty-dir-builder.sh;
+  };
+}

--- a/t/lib/HydraTestContext.pm
+++ b/t/lib/HydraTestContext.pm
@@ -145,7 +145,7 @@ sub nix_state_dir {
 sub makeAndEvaluateJobset {
     my ($self, %opts) = @_;
 
-    my $expression = $opts{'expression'} || die "Mandatory 'expression' option not passed to makeAndEvaluateJobset.";
+    my $expression = $opts{'expression'} || die "Mandatory 'expression' option not passed to makeAndEvaluateJobset.\n";
     my $jobsdir = $opts{'jobsdir'} // $self->jobsdir;
     my $should_build = $opts{'build'} // 0;
 
@@ -155,13 +155,13 @@ sub makeAndEvaluateJobset {
     );
     my $jobset = $jobsetCtx->{"jobset"};
 
-    evalSucceeds($jobset) or die "Evaluating jobs/$expression should exit with return code 0";
+    evalSucceeds($jobset) or die "Evaluating jobs/$expression should exit with return code 0.\n";
 
     my $builds = {};
 
     for my $build ($jobset->builds) {
         if ($should_build) {
-            runBuild($build) or die "Build '".$build->job."' from jobs/$expression should exit with return code 0";
+            runBuild($build) or die "Build '".$build->job."' from jobs/$expression should exit with return code 0.\n";
             $build->discard_changes();
         }
 
@@ -184,7 +184,7 @@ sub makeAndEvaluateJobset {
 sub makeJobset {
     my ($self, %opts) = @_;
 
-    my $expression = $opts{'expression'} || die "Mandatory 'expression' option not passed to makeJobset.";
+    my $expression = $opts{'expression'} || die "Mandatory 'expression' option not passed to makeJobset.\n";
     my $jobsdir = $opts{'jobsdir'} // $self->jobsdir;
 
     # Create a new user for this test
@@ -227,7 +227,7 @@ sub DESTROY
 
 sub write_file {
     my ($path, $text) = @_;
-    open(my $fh, '>', $path) or die "Could not open file '$path' $!";
+    open(my $fh, '>', $path) or die "Could not open file '$path' $!\n.";
     print $fh $text || "";
     close $fh;
 }


### PR DESCRIPTION
Closes #1090.

Changes:

> 1{UNKNOWN}: Died at /nix/store/bj4ihx5hnmb51isf59j869wc1mhxqs28-hydra-0.1.20211223.76962bf/bin/.hydra-eval-jobset-wrapped line 779. at /nix/store/w6an5b9802y52k4x2d1cj3ngyx35mfsn-hydra-perl-deps/lib/perl5/site_perl/5.34.0/Catalyst/Model/DBIC/Schema.pm line 526

to:

> {UNKNOWN}: aggregate job ‘mixed_aggregate’ failed with the error: constituentA: does not exist at xxx