### PR TITLE
Prepare for nixos-search integration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   outputs = { self, nixpkgs, nix }:
     let
 
-      version = "${builtins.readFile ./version.txt}.${builtins.substring 0 8 self.lastModifiedDate}.${self.shortRev or "DIRTY"}";
+      version = "${builtins.readFile ./version.txt}.${builtins.substring 0 8 (self.lastModifiedDate or "19700101")}.${self.shortRev or "DIRTY"}";
 
       pkgs = import nixpkgs {
         system = "x86_64-linux";

--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -69,6 +69,7 @@ in
       package = mkOption {
         type = types.path;
         default = pkgs.hydra;
+        defaultText = literalExpression "pkgs.hydra";
         description = "The Hydra package.";
       };
 
@@ -171,6 +172,7 @@ in
       buildMachinesFiles = mkOption {
         type = types.listOf types.path;
         default = optional (config.nix.buildMachines != []) "/etc/nix/machines";
+        defaultText = literalExpression ''optional (config.nix.buildMachines != []) "/etc/nix/machines"'';
         example = [ "/etc/nix/machines" "/var/lib/hydra/provisioner/machines" ];
         description = "List of files containing build machines.";
       };


### PR DESCRIPTION
As suggested in https://github.com/NixOS/nixos-search/issues/125#issue-653965820

Makes `nix run github:nixos/nixos-search#flake-info -- flake github:nixos/hydra` succeed.

The `lastModifiedDate` fill is just so that we can run that command as `flake-info flake ./hydra` too.