### PR TITLE
docs: refine instructions for proxy setting

### DIFF
--- a/doc/manual/src/configuration.md
+++ b/doc/manual/src/configuration.md
@@ -51,10 +51,12 @@ base_uri example.com
 `base_uri` should be your hydra servers proxied URL. If you are using
 Hydra nixos module then setting `hydraURL` option should be enough.
 
-If you want to serve Hydra with a prefix path, for example
-[http://example.com/hydra]() then you need to configure your reverse
-proxy to pass `X-Request-Base` to hydra, with prefix path as value. For
-example if you are using nginx, then use configuration similar to
+You also need to configure your reverse proxy to pass `X-Request-Base`
+to hydra, with the same value as `base_uri`.
+This also covers the case of serving Hydra with a prefix path,
+as in [http://example.com/hydra]().
+
+For example if you are using nginx, then use configuration similar to
 following:
 
     server {


### PR DESCRIPTION
This is formally a PR but it's more of an issue.

I was having trouble deploying Hydra behind a reverse proxy, I wanted the url to look like [hydra.example.com]().
I didn't need a prefix path, so I didn't set up `X-Request-Base` -- a fatal mistake. Hydra didn't set up its links correctly, and I was systematically redirected to [127.0.0.1:_]().

I corrected the docs so that someone who wants to do something like me won't make the same mistake :
```
Serving behind reverse proxy
----------------------------

[...]

You also need to configure your reverse proxy to pass `X-Request-Base`
to hydra, with the same value as `base_uri`.
```

I hope this is the correct and idiomatic fix, but I'm not fluent in perl/Catalyst, feel free to dismiss this PR :rocket: