### PR TITLE
hydra-eval-jobs: Report forked worker process status information on exception

### DIFF
--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -31,7 +31,7 @@ void check_pid_status_nonblocking(pid_t check_pid) {
 
     int wstatus = 0;
     pid_t pid = waitpid(check_pid, &wstatus, WNOHANG);
-    // -1 = failiure, WNOHANG: 0 = no change
+    // -1 = failure, WNOHANG: 0 = no change
     if (pid <= 0) { return; }
 
     std::cerr << "child process (" << pid << ") ";

--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -25,6 +25,28 @@
 
 #include <nlohmann/json.hpp>
 
+void check_pid_status_quick(pid_t check_pid) {
+    // Only check 'initialized' and known PID's
+    if (check_pid <= 0) { return; }
+
+    int wstatus = 0;
+    pid_t pid = waitpid(check_pid, &wstatus, WNOHANG);
+    // -1 = failiure, WNOHANG: 0 = no change
+    if (pid <= 0) { return; }
+
+    std::cerr << "child process (" << pid << ") ";
+
+    if (WIFEXITED(wstatus)) {
+        std::cerr << "exited with status=" << WEXITSTATUS(wstatus) << std::endl;
+    } else if (WIFSIGNALED(wstatus)) {
+        std::cerr << "killed by signal=" << WTERMSIG(wstatus) << std::endl;
+    } else if (WIFSTOPPED(wstatus)) {
+        std::cerr << "stopped by signal=" << WSTOPSIG(wstatus) << std::endl;
+    } else if (WIFCONTINUED(wstatus)) {
+        std::cerr << "continued" << std::endl;
+    }
+}
+
 using namespace nix;
 
 static Path gcRootsDir;

--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -25,7 +25,7 @@
 
 #include <nlohmann/json.hpp>
 
-void check_pid_status_quick(pid_t check_pid) {
+void check_pid_status_nonblocking(pid_t check_pid) {
     // Only check 'initialized' and known PID's
     if (check_pid <= 0) { return; }
 
@@ -333,8 +333,8 @@ int main(int argc, char * * argv)
         /* Start a handler thread per worker process. */
         auto handler = [&]()
         {
+            pid_t pid = -1;
             try {
-                pid_t pid = -1;
                 AutoCloseFD from, to;
 
                 while (true) {
@@ -436,6 +436,7 @@ int main(int argc, char * * argv)
                     }
                 }
             } catch (...) {
+                check_pid_status_nonblocking(pid);
                 auto state(state_.lock());
                 state->exc = std::current_exception();
                 wakeup.notify_all();

--- a/t/evaluator/evaluate-oom-job.t
+++ b/t/evaluator/evaluate-oom-job.t
@@ -4,6 +4,10 @@ use Setup;
 use Test2::V0;
 use Hydra::Helper::Exec;
 
+# Ensure that `systemd-run` is
+# - Available in the PATH/envionment
+# - Accessable to the user executing it
+# - Capable of using the command switches we use in our test
 my $sd_res;
 eval {
   ($sd_res) = captureStdoutStderr(3, (
@@ -17,12 +21,21 @@ eval {
     "true"
   ));
 } or do {
+  # The command failed to execute, likely because `systemd-run` is not present
+  # in `PATH`
   skip_all("`systemd-run` failed when invoked in this environment");
 };
-if ($sd_res != 0) { skip_all("`systemd-run` returned non-zero when executing `true` (expected 0)"); }
+if ($sd_res != 0) {
+  # `systemd-run` executed but `sytemd-run` failed to call `true` and return
+  # successfully
+  skip_all("`systemd-run` returned non-zero when executing `true` (expected 0)");
+}
 
 my $ctx = test_context();
 
+# Contain the memory usage to 25 MegaBytes using `systemd-run`
+# Run `hydra-eval-jobs` on test job that will purposefully consume all memory
+# available
 my ($res, $stdout, $stderr) = captureStdoutStderr(60, (
   "systemd-run",
     "--user",
@@ -41,6 +54,8 @@ isnt($res, 0, "`hydra-eval-jobs` exits non-zero");
 ok(utf8::decode($stderr), "Stderr output is UTF8-clean");
 like(
   $stderr,
+  # Assert error log contains messages added in PR
+  # https://github.com/NixOS/hydra/pull/1203
   qr/^child process \(\d+?\) killed by signal=9$/m,
   "The stderr record includes a relevant error message"
 );

--- a/t/evaluator/evaluate-oom-job.t
+++ b/t/evaluator/evaluate-oom-job.t
@@ -21,6 +21,8 @@ eval {
 };
 if ($sd_res != 0) { skip_all("`systemd-run` returned non-zero when executing `true` (expected 0)"); }
 
+my $ctx = test_context();
+
 my ($res, $stdout, $stderr) = captureStdoutStderr(60, (
   "systemd-run",
     "--user",
@@ -31,11 +33,11 @@ my ($res, $stdout, $stderr) = captureStdoutStderr(60, (
   "--",
   "hydra-eval-jobs",
     "-I", "/dev/zero",
-    "-I", "./t/jobs",
-    "./t/jobs/oom.nix"
+    "-I", $ctx->jobsdir,
+    ($ctx->jobsdir . "/oom.nix")
 ));
 
-isnt($res, 0, "hydra-eval-jobs exits non-zero");
+isnt($res, 0, "`hydra-eval-jobs` exits non-zero");
 ok(utf8::decode($stderr), "Stderr output is UTF8-clean");
 like(
   $stderr,

--- a/t/evaluator/evaluate-oom-job.t
+++ b/t/evaluator/evaluate-oom-job.t
@@ -4,30 +4,41 @@ use Setup;
 use Test2::V0;
 use Hydra::Helper::Exec;
 
-my ($systemdrRes) = captureStdoutStderr(3, (
-   "systemd-run", "--user", "--collect", "--scope", "--property", "MemoryMax=25M", "--",
-   "true"
+eval {
+  captureStdoutStderr(3, (
+    "systemd-run",
+      "--user",
+      "--collect",
+      "--scope",
+      "--property",
+        "MemoryMax=25M",
+    "--",
+    "true"
+  ));
+} or do {
+  skip_all("systemd-run does not work in this environment");
+};
+
+my ($res, $stdout, $stderr) = captureStdoutStderr(60, (
+  "systemd-run",
+    "--user",
+    "--collect",
+    "--scope",
+    "--property",
+      "MemoryMax=25M",
+  "--",
+  "hydra-eval-jobs",
+    "-I", "/dev/zero",
+    "-I", "./t/jobs",
+    "./t/jobs/oom.nix"
 ));
-
-skip_all("systemd-run does not work in this environment") if($systemdrRes != 0);
-
-
-my ($res, $stdout, $stderr) = captureStdoutStderr(60,
-    (
-       "systemd-run", "--user", "--collect", "--scope", "--property", "MemoryMax=25M", "--",
-       "hydra-eval-jobs",
-         "-I", "/dev/zero",
-         "-I", "./t/jobs",
-         "./t/jobs/oom.nix"
-   )
-);
 
 isnt($res, 0, "hydra-eval-jobs exits non-zero");
 ok(utf8::decode($stderr), "Stderr output is UTF8-clean");
 like(
-    $stderr,
-    qr/^child process \(\d+?\) killed by signal=9$/m,
-    "The stderr record includes a relevant error message"
+  $stderr,
+  qr/^child process \(\d+?\) killed by signal=9$/m,
+  "The stderr record includes a relevant error message"
 );
 
 done_testing;

--- a/t/evaluator/evaluate-oom-job.t
+++ b/t/evaluator/evaluate-oom-job.t
@@ -4,8 +4,9 @@ use Setup;
 use Test2::V0;
 use Hydra::Helper::Exec;
 
+my $sd_res;
 eval {
-  captureStdoutStderr(3, (
+  ($sd_res) = captureStdoutStderr(3, (
     "systemd-run",
       "--user",
       "--collect",
@@ -16,8 +17,9 @@ eval {
     "true"
   ));
 } or do {
-  skip_all("systemd-run does not work in this environment");
+  skip_all("`systemd-run` failed when invoked in this environment");
 };
+if ($sd_res != 0) { skip_all("`systemd-run` returned non-zero when executing `true` (expected 0)"); }
 
 my ($res, $stdout, $stderr) = captureStdoutStderr(60, (
   "systemd-run",

--- a/t/evaluator/evaluate-oom-job.t
+++ b/t/evaluator/evaluate-oom-job.t
@@ -4,6 +4,14 @@ use Setup;
 use Test2::V0;
 use Hydra::Helper::Exec;
 
+my ($systemdrRes) = captureStdoutStderr(3, (
+   "systemd-run", "--user", "--collect", "--scope", "--property", "MemoryMax=25M", "--",
+   "true"
+));
+
+skip_all("systemd-run does not work in this environment") if($systemdrRes != 0);
+
+
 my ($res, $stdout, $stderr) = captureStdoutStderr(60,
     (
        "systemd-run", "--user", "--collect", "--scope", "--property", "MemoryMax=25M", "--",

--- a/t/evaluator/evaluate-oom-job.t
+++ b/t/evaluator/evaluate-oom-job.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Setup;
+use Test2::V0;
+use Hydra::Helper::Exec;
+
+my ($res, $stdout, $stderr) = captureStdoutStderr(60,
+    (
+       "systemd-run", "--user", "--collect", "--scope", "--property", "MemoryMax=25M", "--",
+       "hydra-eval-jobs",
+         "-I", "/dev/zero",
+         "-I", "./t/jobs",
+         "./t/jobs/oom.nix"
+   )
+);
+
+isnt($res, 0, "hydra-eval-jobs exits non-zero");
+ok(utf8::decode($stderr), "Stderr output is UTF8-clean");
+like(
+    $stderr,
+    qr/^child process \(\d+?\) killed by signal=9$/m,
+    "The stderr record includes a relevant error message"
+);
+
+done_testing;

--- a/t/jobs/oom.nix
+++ b/t/jobs/oom.nix
@@ -1,0 +1,3 @@
+{
+  oom = builtins.readFile "/dev/zero";
+}


### PR DESCRIPTION
When evaluating jobs using `hydra-eval-jobs` it's possible for the evaluation to fail in various unexpected ways, such as consuming more than the available memory, which in turn can trigger `OOMKiller` on child worker processes of `hydra-eval-jobs`. When `hydra-eval-jobs` attempts to interact with a dead child process by reading or writing to the file descriptors `to`/`stdin` and `from`/`stdout` pipes attached to the child process, [`readLine`](https://github.com/NixOS/nix/blob/ee57f91413c9d01f1027eccbe01f7706c94919ac/src/libutil/util.cc#L387-L405) reaches and throws [`EndOfFile`](https://github.com/NixOS/nix/blob/ee57f91413c9d01f1027eccbe01f7706c94919ac/src/libutil/util.cc#L399) and [the thread which is responsible for that process cleans up and exits, while also notifying any other workers](https://github.com/NixOS/hydra/blob/5c90edd19f1787141ae3d9751f567b4df11fc0fa/src/hydra-eval-jobs/hydra-eval-jobs.cc#L416-L420) to [wakeup and continue execution](https://github.com/NixOS/hydra/blob/5c90edd19f1787141ae3d9751f567b4df11fc0fa/src/hydra-eval-jobs/hydra-eval-jobs.cc#L378), in which they should [exit because the shared state shows that an exception has been raised](https://github.com/NixOS/hydra/blob/5c90edd19f1787141ae3d9751f567b4df11fc0fa/src/hydra-eval-jobs/hydra-eval-jobs.cc#L368-L371).

This snippet is the error information reported in the hydra UI currently, when a worker process dies for any reason.
```
hydra-eval-jobs returned exit code 1:
error: unexpected EOF reading a line
```

This PR attempts to make errors in the worker visible in the hydra UI by running `waitpid` on the child process when there's an error. 
I've attached examples of what the output should look like with this PR.
```
hydra-eval-jobs returned exit code 1:
child process (1354273) exited with status=247
error: unexpected EOF reading a line
```
```
hydra-eval-jobs returned exit code 1:
child process (1353091) killed by signal=9
error: unexpected EOF reading a line
```
