### PR TITLE
Move postgres host and port to a single location.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -624,7 +624,10 @@
             export HYDRA_HOME="$(pwd)/src/"
             mkdir -p .hydra-data
             export HYDRA_DATA="$(pwd)/.hydra-data"
-            export HYDRA_DBI='dbi:Pg:dbname=hydra;host=localhost;port=64444'
+            export LOGNAME="hydra-dev"
+            export PGPORT=64444
+            export PGHOST="localhost"
+            export HYDRA_DBI="dbi:Pg:dbname=hydra;host=$PGHOST;port=$PGPORT"
 
             popd >/dev/null
           '';

--- a/foreman/start-hydra.sh
+++ b/foreman/start-hydra.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 
 # wait for postgresql to listen
-while ! pg_isready -h $(pwd)/.hydra-data/postgres -p 64444; do sleep 1; done
+while ! pg_isready ; do sleep 1; done
 
-createdb -h $(pwd)/.hydra-data/postgres -p 64444 hydra
+createdb hydra
 
 # create a db for the default user. Not sure why, but
 # the terminal is otherwise spammed with:
 #
 #     FATAL:  database "USERNAME" does not exist
-createdb -h $(pwd)/.hydra-data/postgres -p 64444 "$(whoami)" || true
+createdb "$(whoami)" || true
 
 hydra-init
 hydra-create-user alice --password foobar --role admin

--- a/foreman/start-postgres.sh
+++ b/foreman/start-postgres.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 initdb ./.hydra-data/postgres
-exec postgres -D ./.hydra-data/postgres -k $(pwd)/.hydra-data/postgres -p 64444
+exec postgres -D ./.hydra-data/postgres -k $(pwd)/.hydra-data/postgres -p ${PGPORT}


### PR DESCRIPTION
These are some minor changes I did when I started development work on https://github.com/NixOS/hydra/pull/1204. I'm not on NixOS and did most development in a NixOS docker container. Following the steps to bring up the development environment in a Docker container didn't work at first, Postgres doesn't allow running as root, and the NixOS docker image user is root. So in the end I ended up using a second container to run the Postgres server and then pointed the hydra instance running in the NixOS docker container at the external database. This did allow me to easily load a copy of the production database, so in the end it was actually quite convenient for development.

The postgres command line utilities respect the `PGPORT` and `PGHOST` [environment variables](https://www.postgresql.org/docs/current/libpq-envars.html), so we don't need to specify them manually in various files. Putting them in the environment allows overriding them manually when using a different postgres server.

The `LOGNAME` variable is new, but it appeared to be necessary for the queue runner to come up.

This also switches communication to the database during initialisation of the development environment to use tcp instead of a unix domain socket.

I have not tested these changes on a 'real' instance NixOS, only in a NixOS docker container (where Postgres doesn't start), the environment variables looked good inside the nix shell.

fyi @mikepurvis.
