### PR TITLE
Add a link to the raw log.

### DIFF
--- a/src/root/log.tt
+++ b/src/root/log.tt
@@ -11,7 +11,8 @@
   [% ELSE %]
   is
   [% END %]
-  the build log of derivation <tt>[% IF step; step.drvpath; ELSE; build.drvpath; END %]</tt>.
+  the build log (<a href="[% step ? c.uri_for('/build' build.id 'nixlog' step.stepnr, 'raw')
+  : c.uri_for('/build' build.id 'log', 'raw') %]">raw</a>) of derivation <tt>[% IF step; step.drvpath; ELSE; build.drvpath; END %]</tt>.
   [% IF step && step.machine %]
     It was built on <tt>[% step.machine %]</tt>.
   [% END %]


### PR DESCRIPTION
I could not find a link to download the raw log in the log view, so for example on this (randomly picked) page, I would expect a download link; https://hydra.nixos.org/build/175606766/nixlog/2125

The raw log is accessible and served by Hydra, by adding `/raw` to the URL, we obtain: https://hydra.nixos.org/build/175606766/nixlog/2125/raw which in turn redirects to; https://hydra.nixos.org/log/bs93xva3z3pkig6f5gaxj6pgmmpmx59y-squashfs.img.drv

I think there's a lot of value in providing a link to the raw log, such that it is convenient for users to download this, for example if they want to grep in it locally.

This PR adds a link to the log overview page that links to the raw log, it looks like this:
![Screenshot at 2022-05-04 13-29-17](https://user-images.githubusercontent.com/1732289/166746764-d662d104-53a9-4a1c-adbc-afcb492cd963.png)

The logic with the ternary is copy pasted from the [tail section](https://github.com/iwanders/NixOS-hydra/blob/cba85a6a196d26eb1090af95e12a81434947cef8/src/root/log.tt#L20-L21) in the same file.

fyi @mikepurvis
