### PR TITLE
GithubPulls: Don't fail on missing `Link`

### DIFF
--- a/src/lib/Hydra/Plugin/GithubPulls.pm
+++ b/src/lib/Hydra/Plugin/GithubPulls.pm
@@ -30,7 +30,7 @@ sub _iterate {
         $pulls->{$pull->{number}} = $pull;
     }
     # TODO Make Link header parsing more robust!!!
-    my @links = split ',', $res->header("Link");
+    my @links = split ',', ($res->header("Link") // "");
     my $next = "";
     foreach my $link (@links) {
         my ($url, $rel) = split ";", $link;


### PR DESCRIPTION
Thank you @dasJ for this fix

(If someone finds this while searching for a working setup with dynamic jobs you can look here: https://github.com/anmonteiro/nix-overlays/pull/299)