### PR TITLE
module: only activate pg_trgm extensions on first db setup

### DIFF
--- a/hydra-module.nix
+++ b/hydra-module.nix
@@ -287,9 +287,9 @@ in
             if ! [ -e ${baseDir}/.db-created ]; then
               runuser -u ${config.services.postgresql.superUser} -- ${config.services.postgresql.package}/bin/createuser hydra
               runuser -u ${config.services.postgresql.superUser} -- ${config.services.postgresql.package}/bin/createdb -O hydra hydra
+              echo "create extension if not exists pg_trgm" | runuser -u ${config.services.postgresql.superUser} -- ${config.services.postgresql.package}/bin/psql hydra
               touch ${baseDir}/.db-created
             fi
-            echo "create extension if not exists pg_trgm" | runuser -u ${config.services.postgresql.superUser} -- ${config.services.postgresql.package}/bin/psql hydra
           ''}
 
           if [ ! -e ${cfg.gcRootsDir} ]; then


### PR DESCRIPTION
This was a migration step introduced in https://github.com/NixOS/nixpkgs/commit/ce37a040c262aed26e9c6fd63ba527ba1bc028cc almost 3 years ago.
This avoids executing sudo on every start and makes hydra easier to use with sudo's requiretty setting activated.