### PR TITLE
AddBuilds: fix declarative jobsets with dynamic runcommand enabled

### DIFF
--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -67,7 +67,7 @@ sub validateDeclarativeJobset {
     my $enable_dynamic_run_command = defined $update{enable_dynamic_run_command} ? 1 : 0;
     if ($enable_dynamic_run_command
         && !($config->{dynamicruncommand}->{enable}
-            && $project->{enable_dynamic_run_command}))
+            && $project->enable_dynamic_run_command))
     {
         die "Dynamic RunCommand is not enabled by the server or the parent project.";
     }

--- a/t/Helper/AddBuilds/dynamic-disabled.t
+++ b/t/Helper/AddBuilds/dynamic-disabled.t
@@ -6,10 +6,30 @@ use Test2::V0;
 require Catalyst::Test;
 use HTTP::Request::Common qw(POST PUT GET DELETE);
 use JSON::MaybeXS qw(decode_json encode_json);
-use Hydra::Helper::AddBuilds qw(validateDeclarativeJobset);
-use Hydra::Helper::Nix qw(getHydraConfig);
 
 my $ctx = test_context();
+
+Catalyst::Test->import('Hydra');
+
+my $db = Hydra::Model::DB->new;
+hydra_setup($db);
+
+my $user = $db->resultset('Users')->create({ username => 'alice', emailaddress => 'root@invalid.org', password => '!' });
+$user->setPassword('foobar');
+$user->userroles->update_or_create({ role => 'admin' });
+
+my $project_with_dynamic_run_command = $db->resultset('Projects')->create({
+    name => 'tests_with_dynamic_runcommand',
+    displayname => 'Tests with dynamic runcommand',
+    owner => 'alice',
+    enable_dynamic_run_command => 1,
+});
+my $project_without_dynamic_run_command = $db->resultset('Projects')->create({
+    name => 'tests_without_dynamic_runcommand',
+    displayname => 'Tests without dynamic runcommand',
+    owner => 'alice',
+    enable_dynamic_run_command => 0,
+});
 
 sub makeJobsetSpec {
     my ($dynamic) = @_;
@@ -29,14 +49,16 @@ sub makeJobsetSpec {
 };
 
 subtest "validate declarative jobset with dynamic RunCommand disabled by server" => sub {
-    my $config = getHydraConfig();
+    my $config = Hydra::Helper::Nix->getHydraConfig();
+    require Hydra::Helper::AddBuilds;
+    Hydra::Helper::AddBuilds->import( qw(validateDeclarativeJobset) );
 
     subtest "project enabled dynamic runcommand, declarative jobset enabled dynamic runcommand" => sub {
         like(
             dies {
               validateDeclarativeJobset(
                   $config,
-                  { enable_dynamic_run_command => 1 },
+                  $project_with_dynamic_run_command,
                   "test-jobset",
                   makeJobsetSpec(JSON::MaybeXS::true),
               ),
@@ -49,7 +71,7 @@ subtest "validate declarative jobset with dynamic RunCommand disabled by server"
         ok(
             validateDeclarativeJobset(
                 $config,
-                { enable_dynamic_run_command => 1 },
+                $project_with_dynamic_run_command,
                 "test-jobset",
                 makeJobsetSpec(JSON::MaybeXS::false)
             ),
@@ -61,7 +83,7 @@ subtest "validate declarative jobset with dynamic RunCommand disabled by server"
             dies {
               validateDeclarativeJobset(
                   $config,
-                  { enable_dynamic_run_command => 0 },
+                  $project_without_dynamic_run_command,
                   "test-jobset",
                   makeJobsetSpec(JSON::MaybeXS::true),
               ),
@@ -74,7 +96,7 @@ subtest "validate declarative jobset with dynamic RunCommand disabled by server"
         ok(
             validateDeclarativeJobset(
                 $config,
-                { enable_dynamic_run_command => 0 },
+                $project_without_dynamic_run_command,
                 "test-jobset",
                 makeJobsetSpec(JSON::MaybeXS::false)
             ),

--- a/t/Helper/AddBuilds/dynamic-enabled.t
+++ b/t/Helper/AddBuilds/dynamic-enabled.t
@@ -6,8 +6,6 @@ use Test2::V0;
 require Catalyst::Test;
 use HTTP::Request::Common qw(POST PUT GET DELETE);
 use JSON::MaybeXS qw(decode_json encode_json);
-use Hydra::Helper::AddBuilds qw(validateDeclarativeJobset);
-use Hydra::Helper::Nix qw(getHydraConfig);
 
 my $ctx = test_context(
     hydra_config => q|
@@ -16,6 +14,28 @@ my $ctx = test_context(
     </dynamicruncommand>
     |
 );
+
+Catalyst::Test->import('Hydra');
+
+my $db = Hydra::Model::DB->new;
+hydra_setup($db);
+
+my $user = $db->resultset('Users')->create({ username => 'alice', emailaddress => 'root@invalid.org', password => '!' });
+$user->setPassword('foobar');
+$user->userroles->update_or_create({ role => 'admin' });
+
+my $project_with_dynamic_run_command = $db->resultset('Projects')->create({
+    name => 'tests_with_dynamic_runcommand',
+    displayname => 'Tests with dynamic runcommand',
+    owner => 'alice',
+    enable_dynamic_run_command => 1,
+});
+my $project_without_dynamic_run_command = $db->resultset('Projects')->create({
+    name => 'tests_without_dynamic_runcommand',
+    displayname => 'Tests without dynamic runcommand',
+    owner => 'alice',
+    enable_dynamic_run_command => 0,
+});
 
 sub makeJobsetSpec {
     my ($dynamic) = @_;
@@ -35,13 +55,15 @@ sub makeJobsetSpec {
 };
 
 subtest "validate declarative jobset with dynamic RunCommand enabled by server" => sub {
-    my $config = getHydraConfig();
+    my $config = Hydra::Helper::Nix->getHydraConfig();
+    require Hydra::Helper::AddBuilds;
+    Hydra::Helper::AddBuilds->import( qw(validateDeclarativeJobset) );
 
     subtest "project enabled dynamic runcommand, declarative jobset enabled dynamic runcommand" => sub {
         ok(
             validateDeclarativeJobset(
                 $config,
-                { enable_dynamic_run_command => 1 },
+                $project_with_dynamic_run_command,
                 "test-jobset",
                 makeJobsetSpec(JSON::MaybeXS::true)
             ),
@@ -52,7 +74,7 @@ subtest "validate declarative jobset with dynamic RunCommand enabled by server" 
         ok(
             validateDeclarativeJobset(
                 $config,
-                { enable_dynamic_run_command => 1 },
+                $project_with_dynamic_run_command,
                 "test-jobset",
                 makeJobsetSpec(JSON::MaybeXS::false)
             ),
@@ -64,7 +86,7 @@ subtest "validate declarative jobset with dynamic RunCommand enabled by server" 
             dies {
               validateDeclarativeJobset(
                   $config,
-                  { enable_dynamic_run_command => 0 },
+                  $project_without_dynamic_run_command,
                   "test-jobset",
                   makeJobsetSpec(JSON::MaybeXS::true),
               ),
@@ -77,7 +99,7 @@ subtest "validate declarative jobset with dynamic RunCommand enabled by server" 
         ok(
             validateDeclarativeJobset(
                 $config,
-                { enable_dynamic_run_command => 0 },
+                $project_without_dynamic_run_command,
                 "test-jobset",
                 makeJobsetSpec(JSON::MaybeXS::false)
             ),


### PR DESCRIPTION
$project->{enable_dynamic_run_command} is undefined

Currently fails with `ERROR: failed to process declarative jobset […]:[…], Dynamic RunCommand is not enabled by the server or the parent project. at /nix/store/[…]/libexec/hydra/lib/Hydra/Helper/AddBuilds.pm line 72.`.