### PR TITLE
Use libmagic for better output MIME detection

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -503,6 +503,7 @@
                 DigestSHA1
                 EmailMIME
                 EmailSender
+                FileLibMagic
                 FileSlurper
                 FileWhich
                 final.nix.perl-bindings


### PR DESCRIPTION
MIME::Types isn't flexible enough to detect the correct MIME type since it only goes off of the file name, which breaks for file names without extensions. This changes MIME detection to use libmagic which also takes the file contents into account. I took out the path that calls serve_static_file since that function also uses MIME::Types internally.

Closes #1184.