### PR TITLE
doc/configuration: fix ldap role mapping example

### DIFF
--- a/doc/manual/src/configuration.md
+++ b/doc/manual/src/configuration.md
@@ -185,7 +185,7 @@ Example configuration:
     hydra_admin = admin
     # Allow all users in the dev group to restart jobs and cancel builds
     dev = restart-jobs
-    dev = cancel-builds
+    dev = cancel-build
   </role_mapping>
 </ldap>
 ```


### PR DESCRIPTION
To group is called `cancel-build`, not `cancel-builds` (note the
trailing `s`).

cc @grahamc @dasJ 