### PR TITLE
Only guess domain when gitea_url is not set

### DIFF
--- a/src/lib/Hydra/Plugin/GiteaStatus.pm
+++ b/src/lib/Hydra/Plugin/GiteaStatus.pm
@@ -63,9 +63,9 @@ sub common {
             my $accessToken = $self->{config}->{gitea_authorization}->{$repoOwner};
 
             my $rev = $i->revision;
-            my $domain = URI->new($i->uri)->host;
             my $host;
             unless (defined $gitea_url) {
+                my $domain = URI->new($i->uri)->host;
                 $host = "https://$domain";
             } else {
                 $host = $gitea_url->value;


### PR DESCRIPTION
allows for gitea integration when not using a uri e.g. gitea@example.com:example/example so long as gitea_http_url is set