### PR TITLE
Fix insecure advice in the manual

### DIFF
--- a/doc/manual/src/projects.md
+++ b/doc/manual/src/projects.md
@@ -378,13 +378,18 @@ This section describes how it can be implemented for `gitea`, but the approach f
 analogous:
 
 * [Obtain an API token for your user](https://docs.gitea.io/en-us/api-usage/#authentication)
-* Add it to your `hydra.conf` like this:
+* Add it to a file which only users in the hydra group can read like this: see [including files](configuration.md#including-files) for more information
+  ```
+  <gitea_authorization>
+    your_username=your_token
+  </gitea_authorization>
+  ```
+
+* Include the file in your `hydra.conf` like this:
   ``` nix
   {
     services.hydra-dev.extraConfig = ''
-      <gitea_authorization>
-      your_username=your_token
-      </gitea_authorization>
+      Include /path/to/secret/file
     '';
   }
   ```


### PR DESCRIPTION
Bring the manual in line with the [configuration documentation](https://github.com/NixOS/hydra/blob/master/doc/manual/src/configuration.md#including-files)