### PR TITLE
Fix "My Jobs" tab in user dashboard

### DIFF
--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -463,7 +463,7 @@ sub my_jobs_tab :Chained('dashboard_base') :PathPart('my-jobs-tab') :Args(0) {
         , "jobset.enabled" => 1
         },
         { order_by => ["project", "jobset", "job"]
-        , join => ["project", "jobset"]
+        , join => {"jobset" => "project"}
         })];
 }
 

--- a/t/Hydra/Controller/User/dashboard.t
+++ b/t/Hydra/Controller/User/dashboard.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Setup;
+my $ctx = test_context();
+use HTTP::Request::Common;
+use Test2::V0;
+use Catalyst::Test ();
+Catalyst::Test->import('Hydra');
+require Hydra::Schema;
+require Hydra::Model::DB;
+my $db = $ctx->db();
+my $user = $db->resultset('Users')->create({ username => 'alice', emailaddress => 'alice@invalid.org', password => '!' });
+$user->setPassword('foobar');
+my $builds = $ctx->makeAndEvaluateJobset(
+    expression => "basic.nix",
+    build => 1
+);
+my $login = request(POST '/login', Referer => 'http://localhost', Content => {
+        username => 'alice',
+        password => 'foobar',
+    });
+is($login->code, 302);
+my $cookie = $login->header("set-cookie");
+my $my_jobs = request(GET '/dashboard/alice/my-jobs-tab', Accept => 'application/json', Cookie => $cookie);
+ok($my_jobs->is_success);
+my $content = $my_jobs->content();
+ok($content =~ /empty_dir/);
+ok(!($content =~ /fails/));
+ok(!($content =~ /succeed_with_failed/));
+done_testing;

--- a/t/jobs/basic.nix
+++ b/t/jobs/basic.nix
@@ -4,6 +4,8 @@ with import ./config.nix;
     mkDerivation {
       name = "empty-dir";
       builder = ./empty-dir-builder.sh;
+      meta.maintainers = [ "alice@invalid.org" ];
+      meta.outPath = "${placeholder "out"}";
     };
 
   fails =


### PR DESCRIPTION
Nowadays `Builds` doesn't reference `Project` directly anymore. This means that simply resolving both `jobset` and `project` with a single JOIN from `Builds` doesn't work anymore. Instead we need to resolve the relation to `jobset` first and then the relation to `project`.

For similar fixes see e.g. c7c47596009687d1652522c556333cefce28ec51.

cc @dasJ @grahamc 