### PR TITLE
Fix MIME types when serving .js and .css to fix rendering of HTML reports

### DIFF
--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -238,9 +238,17 @@ sub serveFile {
                                                       "store", "cat", "--store", getStoreUri(), "$path"]) };
 
         # Detect MIME type.
-        state $magic = File::LibMagic->new(follow_symlinks => 1);
-        my $info = $magic->info_from_filename($path);
-        my $type = $info->{mime_with_encoding};
+        my $type = "text/plain";
+        if ($path =~ /.*\.(\S{1,})$/xms) {
+            my $ext = $1;
+            my $mimeTypes = MIME::Types->new(only_complete => 1);
+            my $t = $mimeTypes->mimeTypeOf($ext);
+            $type = ref $t ? $t->type : $t if $t;
+        } else {
+            state $magic = File::LibMagic->new(follow_symlinks => 1);
+            my $info = $magic->info_from_filename($path);
+            $type = $info->{mime_with_encoding};
+        }
         $c->response->content_type($type);
         $c->forward('Hydra::View::Plain');
     }


### PR DESCRIPTION
To correctly render HTML reports we make sure to return the following MIME types instead of "text/plain"

- *.css: "text/css"
- *.js: "application/javascript"

Fixes: #1267