### PR TITLE
Use project name in sysbuild query

### DIFF
--- a/src/lib/Hydra/Schema/Result/Builds.pm
+++ b/src/lib/Hydra/Schema/Result/Builds.pm
@@ -563,7 +563,7 @@ makeQueries('', "");
 makeQueries('ForProject', "and jobset_id in (select id from jobsets j where j.project = ?)");
 makeQueries('ForJobset', "and jobset_id = ?");
 makeQueries('ForJob', "and jobset_id = ? and job = ?");
-makeQueries('ForJobName', "and jobset_id = (select id from jobsets j where j.name = ?) and job = ?");
+makeQueries('ForJobName', "and jobset_id = (select id from jobsets j where j.project = ? and j.name = ?) and job = ?");
 
 sub as_json {
   my ($self) = @_;

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -159,7 +159,7 @@ sub fetchInputSystemBuild {
     $jobsetName ||= $jobset->name;
 
     my @latestBuilds = $db->resultset('LatestSucceededForJobName')
-        ->search({}, {bind => [$jobsetName, $jobName]});
+        ->search({}, {bind => [$projectName, $jobsetName, $jobName]});
 
     my @validBuilds = ();
     foreach my $build (@latestBuilds) {


### PR DESCRIPTION
Simple addition to the `LatestSucceededForJobName` query to also filter by the project name (already provided) to avoid duplicate results for jobsets from different projects. AFAICT sysbuilds are the only thing that use this query.