### PR TITLE
Drop unused IndexBuildOutputsOnPath index

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:

--- a/src/sql/upgrade-83.sql
+++ b/src/sql/upgrade-83.sql
@@ -1,0 +1,3 @@
+-- This index was introduced in a migration but was never recorded in
+-- hydra.sql (the source of truth), which is why `if exists` is required.
+drop index if exists IndexBuildOutputsOnPath;


### PR DESCRIPTION
Also it's larger than the actual table it's indexing lol.

    -[ RECORD 30 ]----------+-----------------------------------------
    table_name              | buildoutputs
    index_name              | indexbuildoutputsonpath
    index_scans_count       | 0
    index_size              | 31 GB
    table_reads_index_count | 2128699937
    table_reads_seq_count   | 0
    table_reads_count       | 2128699937
    table_writes_count      | 22442976
    table_size              | 28 GB