### PR TITLE
Fix docs for  /eval/{id}  endpoint

### DIFF
--- a/hydra-api.yaml
+++ b/hydra-api.yaml
@@ -533,13 +533,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /eval/{build-id}:
+  /eval/{eval-id}:
     get:
-      summary: Retrieves evaluations identified by build id
+      summary: Retrieves evaluations identified by eval id
       parameters:
-        - name: build-id
+        - name: eval-id
           in: path
-          description: build identifier
+          description: eval identifier
           required: true
           schema:
             type: integer


### PR DESCRIPTION
You  need to pass it an eval-id, not a build-id pretty sure