### PR TITLE
align `system` retrieval with `nix-build`

### DIFF
--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -177,15 +177,14 @@ static void worker(
 
                 DrvInfo::Outputs outputs = drv->queryOutputs();
 
-                if (drv->querySystem() == "unknown")
-                    throw EvalError("derivation must have a 'system' attribute");
+                auto drvContent = state.store->readDerivation(drv->requireDrvPath());
 
                 auto drvPath = state.store->printStorePath(drv->requireDrvPath());
 
                 nlohmann::json job;
 
                 job["nixName"] = drv->queryName();
-                job["system"] =drv->querySystem();
+                job["system"] = drvContent.platform;
                 job["drvPath"] = drvPath;
                 job["description"] = drv->queryMetaString("description");
                 job["license"] = queryMetaStrings(state, *drv, "license", "shortName");


### PR DESCRIPTION
Read the system from the instantiated derivation instead of getting it from the eval time drv attrs.

This is better in terms of correctness as it derives the system through a derivations string context, instead of relying on builder implementations to set the `system` attribute correctly.

This derivation for example did not build with hydra before while it builds fine with the nix repl:

```
:b { name="hello"; type="derivation"; drvPath = hello.drvPath; }
```