### PR TITLE
Set output length of C::P::Argon2 hashes to 16

### DIFF
--- a/src/lib/Hydra/Schema/Result/Users.pm
+++ b/src/lib/Hydra/Schema/Result/Users.pm
@@ -216,7 +216,7 @@ sub json_hint {
 
 sub _authenticator() {
     my $authenticator = Crypt::Passphrase->new(
-        encoder    => 'Argon2',
+        encoder    => { module => 'Argon2', output_size => 16 },
         validators => [
             (sub {
                 my ($password, $hash) = @_;


### PR DESCRIPTION
Since the default lengths in Crypt::Passphrase::Argon2 changed from 16 to 32 in in 0.009, some tests that expected the passphrase to be unchanged started failing.