### PR TITLE
Remove gapi.auth2 usage

### DIFF
--- a/src/root/auth.tt
+++ b/src/root/auth.tt
@@ -1,30 +1,12 @@
 [% IF c.user_exists  %]
 
-  [% IF c.user.type == 'google' %]
-    <script src="https://apis.google.com/js/platform.js" async="1" defer="1"></script>
-  [% END %]
-
   <script>
-    function finishSignOut() {
+    function signOut() {
       $.post("[% c.uri_for('/logout') %]")
         .done(function(data) {
           window.location.reload();
         })
         .fail(function() { bootbox.alert("Server request failed!"); });
-    }
-
-    function signOut() {
-      [% IF c.user.type == 'google' %]
-        gapi.load('auth2', function() {
-          gapi.auth2.init();
-          var auth2 = gapi.auth2.getAuthInstance();
-          auth2.then(function () {
-            auth2.signOut().then(finishSignOut, finishSignOut);
-          });
-        });
-      [% ELSE %]
-        finishSignOut();
-      [% END %]
     }
   </script>
 


### PR DESCRIPTION
This API has been deprecated and doesn't work for newly created client IDs.

The login part is already migrated previously in https://github.com/NixOS/hydra/pull/1281 and the only usage left is the logout part with `auth2.signOut()` call. Accordingly to Google's [migration guide](https://developers.google.com/identity/gsi/web/guides/migration#user_consent_and_revoking_permission), the signOut is no longer needed and can simply be removed.

> Previously, auth2.signOut() could be used to help manage user sign-out from your app. Any usage of auth2.signOut() should be removed, and your app should directly manage per user session state and sign-in status.