### PR TITLE
Cleanup deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ nix-build
 You can use the provided shell.nix to get a working development environment:
 ```
 $ nix-shell
-$ ./bootstrap
+$ autoreconfPhase
 $ configurePhase # NOTE: not ./configure
 $ make
 ```

--- a/bootstrap
+++ b/bootstrap
@@ -1,2 +1,0 @@
-#! /bin/sh -e
-exec autoreconf -vfi

--- a/flake.nix
+++ b/flake.nix
@@ -61,10 +61,11 @@
 
         };
 
-        hydra = with final; let
-          perlDeps = buildEnv {
+        hydra = let
+          inherit (final) lib stdenv;
+          perlDeps = final.buildEnv {
             name = "hydra-perl-deps";
-            paths = with perlPackages; lib.closePropagation
+            paths = with final.perlPackages; lib.closePropagation
               [
                 AuthenSASL
                 CatalystActionREST
@@ -98,7 +99,7 @@
                 FileSlurper
                 FileWhich
                 final.nix.perl-bindings
-                git
+                final.git
                 IOCompress
                 IPCRun
                 IPCRun3
@@ -141,15 +142,20 @@
 
           src = self;
 
-          buildInputs =
-            [
+          nativeBuildInputs =
+            with final.buildPackages; [
               makeWrapper
-              autoconf
+              autoreconfHook
               automake
               libtool
-              unzip
               nukeReferences
               pkg-config
+              mdbook
+            ];
+
+          buildInputs =
+            with final; [
+              unzip
               libpqxx
               top-git
               mercurial
@@ -162,7 +168,6 @@
               final.nix
               perlDeps
               perl
-              mdbook
               pixz
               boost
               postgresql_13
@@ -172,7 +177,7 @@
               prometheus-cpp
             ];
 
-          checkInputs = [
+          checkInputs = with final; [
             cacert
             foreman
             glibcLocales
@@ -181,7 +186,7 @@
             python3
           ];
 
-          hydraPath = lib.makeBinPath (
+          hydraPath = with final; lib.makeBinPath (
             [
               subversion
               openssh
@@ -203,7 +208,7 @@
             ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ]
           );
 
-          OPENLDAP_ROOT = openldap;
+          OPENLDAP_ROOT = final.openldap;
 
           shellHook = ''
             pushd $(git rev-parse --show-toplevel) >/dev/null
@@ -217,8 +222,6 @@
 
             popd >/dev/null
           '';
-
-          preConfigure = "autoreconf -vfi";
 
           NIX_LDFLAGS = [ "-lpthread" ];
 


### PR DESCRIPTION
- `nativeBuildInputs` vs `buildInputs`

- narrow down `with`s for clarity

- use `autoreconfHook` not `bootstrap` script

These sorts of changes have also been done in the Nix repo.