### PR TITLE
`copyClosureTo`: Use `SubstituteFlag` instead of `bool`

### DIFF
--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -113,7 +113,7 @@ static void copyClosureTo(
     Machine::Connection & conn,
     Store & destStore,
     const StorePathSet & paths,
-    bool useSubstitutes = false)
+    SubstituteFlag useSubstitutes = NoSubstitute)
 {
     StorePathSet closure;
     destStore.computeFSClosure(paths, closure);
@@ -266,7 +266,7 @@ static BasicDerivation sendInputs(
             destStore.computeFSClosure(basicDrv.inputSrcs, closure);
             copyPaths(destStore, localStore, closure, NoRepair, NoCheckSigs, NoSubstitute);
         } else {
-            copyClosureTo(conn, destStore, basicDrv.inputSrcs, true);
+            copyClosureTo(conn, destStore, basicDrv.inputSrcs, Substitute);
         }
 
         auto now2 = std::chrono::steady_clock::now();


### PR DESCRIPTION
This matches Nix (in the same serialization logic in `src/libstore/legacy-ssh-store.cc`) and adds clarity.