### PR TITLE
Let tests themselves intentionally leak temp dir

### DIFF
--- a/t/lib/HydraTestContext.pm
+++ b/t/lib/HydraTestContext.pm
@@ -39,7 +39,9 @@ use Hydra::Helper::Exec;
 sub new {
     my ($class, %opts) = @_;
 
-    my $dir = File::Temp->newdir();
+    # Cleanup will be managed by yath. By the default it ill be cleaned
+    # up, but can be kept to aid in debugging test failures.
+    my $dir = File::Temp->newdir(CLEANUP => 0);
 
     $ENV{'HYDRA_DATA'} = "$dir/hydra-data";
     mkdir $ENV{'HYDRA_DATA'};


### PR DESCRIPTION
By default Yath will clean up temporary files, so the result is the same. But `--keep-dirs` can be passed to `yath test` telling Yath to *not* clean them up instead. This is very useful for debugging.