### PR TITLE
Use `ServeProto::Serialise<ServeProto::BuildOptions>`

### DIFF
--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -293,14 +293,7 @@ static BuildResult performBuild(
 {
     conn.to << ServeProto::Command::BuildDerivation << localStore.printStorePath(drvPath);
     writeDerivation(conn.to, localStore, drv);
-    conn.to << options.maxSilentTime << options.buildTimeout;
-    if (GET_PROTOCOL_MINOR(conn.remoteVersion) >= 2)
-        conn.to << options.maxLogSize;
-    if (GET_PROTOCOL_MINOR(conn.remoteVersion) >= 3) {
-        conn.to
-            << options.nrRepeats
-            << options.enforceDeterminism;
-    }
+    ServeProto::write(localStore, conn, options);
     conn.to.flush();
 
     BuildResult result;


### PR DESCRIPTION
The interesting part is the preparatory commit:

> Do not attempt to speak a newer version of the protocol
>
> Both sides need to agree on a version (with `std::min`) for anything to work. Somehow... we've never done this.
>
> With this comment, the next commit succeeds. Without this commit, the next commit fails. This is because the next commit exposes serializers which do different things for proto version 2.7, and we're currently requesting 2.6.
>
> Opened https://github.com/NixOS/nix/issues/9584 to track this issue