### PR TITLE
Use `StoreConfig::getDefaultSystemFeatures` for default machine config

### DIFF
--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -15,6 +15,7 @@
 #include "state.hh"
 #include "hydra-build-result.hh"
 #include "store-api.hh"
+#include "local-store.hh"
 #include "remote-store.hh"
 
 #include "globals.hh"
@@ -226,7 +227,7 @@ void State::monitorMachinesFile()
         parseMachines("localhost " +
             (settings.thisSystem == "x86_64-linux" ? "x86_64-linux,i686-linux" : settings.thisSystem.get())
             + " - " + std::to_string(settings.maxBuildJobs) + " 1 "
-            + concatStringsSep(",", settings.systemFeatures.get()));
+            + concatStringsSep(",", (LocalStoreConfig { {} }).getDefaultSystemFeatures()));
         machinesReadyLock.unlock();
         return;
     }


### PR DESCRIPTION
We have to oddly make a `StoreConfig` subclass to get it, but https://github.com/NixOS/nix/pull/9848 will fix that.

The purpose of this is to ensure that, absent an explicit config, `localhost` includes `ca-derivations` and `recursive-nix` if those experimental features are enabled.

Very much the complement of #1342, the previous PR.