### PR TITLE
web: disable Sign in with Google popup

### DIFF
--- a/src/root/topbar.tt
+++ b/src/root/topbar.tt
@@ -134,7 +134,7 @@
     [% WRAPPER makeSubMenu title="Sign in" id="sign-in-menu" align="right" %]
       [% IF c.config.enable_google_login %]
         <script src="https://accounts.google.com/gsi/client" async defer></script>
-        <div id="g_id_onload" data-client_id="[% c.config.google_client_id %]" data-callback="onGoogleSignIn">
+        <div id="g_id_onload" data-client_id="[% c.config.google_client_id %]" data-auto_prompt="false" data-callback="onGoogleSignIn">
         </div>
         <div class="g_id_signin" data-type="standard"></div>
         <div class="dropdown-divider"></div>


### PR DESCRIPTION
Self-explanatory, if you've used Hydra without being logged in the last few months.

Documentation: https://developers.google.com/identity/gsi/web/reference/html-reference#data-auto_prompt