### PR TITLE
Small fixes for the development environment

### DIFF
--- a/doc/manual/src/hacking.md
+++ b/doc/manual/src/hacking.md
@@ -18,7 +18,7 @@ $ nix-shell
 To build Hydra, you should then do:
 
 ```console
-[nix-shell]$ ./bootstrap
+[nix-shell]$ autoreconfPhase
 [nix-shell]$ configurePhase
 [nix-shell]$ make
 ```

--- a/package.nix
+++ b/package.nix
@@ -183,6 +183,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [
     bzip2
     darcs
+    foreman
     top-git
     mercurial
     subversion
@@ -194,7 +195,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkInputs = [
     cacert
-    foreman
     glibcLocales
     libressl.nc
     python3


### PR DESCRIPTION
cc @Ericson2314 

 ###### doc/manual: fix instructions in contribution guidelines

In 5db374c the `bootstrap` script was
removed, however it's still referenced in the contribution guidelines.
Change that to `autoreconfPhase` as intended by the commit.

######  package: move foreman to nativeCheckInputs

In 1bd195a strictDeps was set for the
Hydra package. As a result, `checkInputs` aren't available anymore in
the local dev-shell which is the sole purpose of foreman, to start
services and a database for development.