### PR TITLE
Build: use `nix path-info` to test for build output availability

### DIFF
--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -76,7 +76,8 @@ sub isValidPathNixCLI {
     my $pid = fork();
     if (!$pid) {
         open STDERR, ">", "/dev/null";
-        exec "nix", "path-info", $path, "--store", getStoreUri();
+        open STDOUT, ">", "/dev/null";
+        exec "nix", "path-info", $path, "--store", getStoreUri(), "--option", "experimental-features", "nix-command";
     }
     waitpid $pid, 0;
     return $? == 0;


### PR DESCRIPTION
cc @dasj @Ericson2314 

Hacky workaround for https://github.com/NixOS/nix/issues/9859, but after I managed to fix the issue on my end, I decided I could still submit it against upstream.

------

When using the Perl bindings, this usually takes the wrong store, i.e. `auto` even if `store_uri` is a flat-file binary cache.

See also https://github.com/NixOS/nix/issues/9859

Using fork/exec here on purpose to make sure that the output of `nix path-info` isn't spammed into stderr. This could probably done with `system("foo &>/dev/null")`, but I didn't want to worry about shell injection issues then. And finally, I can't seem to silence STDERR for `system` with a list as argument. Not a Perl dev though, so not sure if there's a better way.