### PR TITLE
Fetch Git LFS objects

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -17,9 +17,11 @@
 , pkg-config
 , mdbook
 
+, runtimeShellPackage
 , unzip
 , libpqxx
 , top-git
+, git-lfs
 , mercurial
 , darcs
 , subversion
@@ -185,6 +187,7 @@ stdenv.mkDerivation (finalAttrs: {
     darcs
     foreman
     top-git
+    git-lfs
     mercurial
     subversion
     breezy
@@ -215,6 +218,8 @@ stdenv.mkDerivation (finalAttrs: {
       unzip
       git
       top-git
+      git-lfs
+      runtimeShellPackage # For Git LFS: https://github.com/git-lfs/git-lfs/discussions/5196#discussioncomment-4221187
       mercurial
       darcs
       gnused

--- a/src/lib/Hydra/Plugin/GitInput.pm
+++ b/src/lib/Hydra/Plugin/GitInput.pm
@@ -148,7 +148,9 @@ sub fetchInput {
     my $localBranch = _isHash($branch) ? "_hydra_tmp" : $branch;
     $res = run(cmd => ["git", "fetch", "-fu", "origin", "+$branch:$localBranch"], dir => $clonePath,
                timeout => $cfg->{timeout});
+    $res = run(cmd => ["git", "lfs", "fetch", "origin", $branch], dir => $clonePath, timeout => $cfg->{timeout}) unless $res->{status};
     $res = run(cmd => ["git", "fetch", "-fu", "origin"], dir => $clonePath, timeout => $cfg->{timeout}) if $res->{status};
+    $res = run(cmd => ["git", "lfs", "fetch", "origin", "--all"], dir => $clonePath, timeout => $cfg->{timeout}) unless $res->{status};
     die "error fetching latest change from git repo at `$uri':\n$res->{stderr}" if $res->{status};
 
     # If deepClone is defined, then we look at the content of the repository


### PR DESCRIPTION
This PR changes the Git input plugin to fetch LFS objects alongside the regular `git fetch` when creating SCM caches. This allows the objects to be used in subsequent clones from the cache (done automatically when `programs.git-lfs.enable` is `true`).

This is harmless for repositories that do not use LFS.