### PR TITLE
Workaround for fetching git submodules for flakes

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -645,10 +645,16 @@ sub checkJobsetWrapped {
     if (defined $flakeRef) {
         (my $res, my $json, my $stderr) = captureStdoutStderr(
             600, "nix", "flake", "metadata", "--refresh", "--json", "--", $flakeRef);
+
         die "'nix flake metadata' returned " . ($res & 127 ? "signal $res" : "exit code " . ($res >> 8))
             . ":\n" . ($stderr ? decode("utf-8", $stderr) : "(no output)\n")
             if $res;
-        $flakeRef = decode_json($json)->{'url'};
+        my $decoded = decode_json($json);
+        my $url = $decoded->{'url'};   # Doesn't have the &submodules=1, so add it back if needed
+        if ($decoded->{'resolved'}->{'submodules'}) {
+            $url = $url . "&submodules=1";
+        }
+        $flakeRef = $url;
     }
 
     Net::Statsd::increment("hydra.evaluator.checkouts");


### PR DESCRIPTION
Workaround/fix for [1353](https://github.com/NixOS/hydra/issues/1353)

If a flake URI contains 'submodules=1' in the query part then any submodules should be fetched/initialized.

At present, hydra-eval-jobset uses the 'url' field of the flake metadata as the flake URI.  This URI is missing the 'submodules=1' query, which is present elsewhere in the metadata.

This PR appends "&submodules=1" if the flake metadata indicates submodules are used (specifically, if the resolved.submodules field is true).