### PR TITLE
foreman/start-hydra: enable query log in postgres

### DIFF
--- a/foreman/start-hydra.sh
+++ b/foreman/start-hydra.sh
@@ -11,6 +11,8 @@ createdb -h $(pwd)/.hydra-data/postgres -p 64444 hydra
 #     FATAL:  database "USERNAME" does not exist
 createdb -h $(pwd)/.hydra-data/postgres -p 64444 "$(whoami)" || true
 
+psql -h localhost -p 64444 <<<"alter system set log_statement='all'; select pg_reload_conf();"
+
 hydra-init
 hydra-create-user alice --password foobar --role admin
 


### PR DESCRIPTION
That way it's possible to observe which queries are fired against the DB from DBIx. This is particularly useful to find out if DBIx correctly prefetches everything it needs or if too much / too few things are loaded, see e.g. #1335.