### PR TITLE
Remove `PrometheusTiny` from overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,27 +40,6 @@
 
       # A Nixpkgs overlay that provides a 'hydra' package.
       overlays.default = final: prev: {
-
-        # Add LDAP dependencies that aren't currently found within nixpkgs.
-        perlPackages = prev.perlPackages // {
-
-          PrometheusTiny = final.perlPackages.buildPerlPackage {
-            pname = "Prometheus-Tiny";
-            version = "0.007";
-            src = final.fetchurl {
-              url = "mirror://cpan/authors/id/R/RO/ROBN/Prometheus-Tiny-0.007.tar.gz";
-              sha256 = "0ef8b226a2025cdde4df80129dd319aa29e884e653c17dc96f4823d985c028ec";
-            };
-            buildInputs = with final.perlPackages; [ HTTPMessage Plack TestException ];
-            meta = {
-              homepage = "https://github.com/robn/Prometheus-Tiny";
-              description = "A tiny Prometheus client";
-              license = with final.lib.licenses; [ artistic1 gpl1Plus ];
-            };
-          };
-
-        };
-
         hydra = final.callPackage ./package.nix {
           inherit (nixpkgs.lib) fileset;
           rawSrc = self;


### PR DESCRIPTION
It's in Nixpkgs for a good while now.