### PR TITLE
Try again to ensure hydra module is usable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
         modules =
           [
             self.nixosModules.hydra
-            self.nixosModules.overlayNixpkgsForThisHyydra
+            self.nixosModules.overlayNixpkgsForThisHydra
             self.nixosModules.hydraTest
             self.nixosModules.hydraProxy
             {

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -3,8 +3,9 @@
 {
   hydra = import ./hydra.nix;
 
-  overlayNixpkgsForThisHyydra = {
+  overlayNixpkgsForThisHydra = { pkgs, ... }: {
     nixpkgs = { inherit overlays; };
+    services.hydra.package = pkgs.hydra;
   };
 
   hydraTest = { pkgs, ... }: {

--- a/nixos-modules/hydra.nix
+++ b/nixos-modules/hydra.nix
@@ -68,7 +68,7 @@ in
 
       package = mkOption {
         type = types.path;
-        default = pkgs.hydra;
+        default = pkgs.hydra_unstable;
         defaultText = literalExpression "pkgs.hydra";
         description = "The Hydra package.";
       };
@@ -233,7 +233,7 @@ in
       gc-keep-outputs = true;
       gc-keep-derivations = true;
     };
-    
+
     services.hydra-dev.extraConfig =
       ''
         using_frontend_proxy = 1

--- a/nixos-tests.nix
+++ b/nixos-tests.nix
@@ -7,7 +7,7 @@ let
     {
       imports = [
         nixosModules.hydra
-        nixosModules.overlayNixpkgsForThisHyydra
+        nixosModules.overlayNixpkgsForThisHydra
         nixosModules.hydraTest
       ];
 


### PR DESCRIPTION
Nixpkgs only contains a `hydra_unstable`, not `hydra`, package, so adjust the default accordingly, and then override it to our package in the separate module which does that.