### PR TITLE
Don't show hidden projects on front page if user not logged in

### DIFF
--- a/src/root/overview.tt
+++ b/src/root/overview.tt
@@ -53,11 +53,13 @@
   </thead>
   <tbody>
     [% FOREACH p IN projects %]
-    <tr class="project [% IF !p.enabled %]disabled-project[% END %]">
-      <td><span class="[% IF !p.enabled %]disabled-project[% END %] [%+ IF p.hidden %]hidden-project[% END %]">[% INCLUDE renderProjectName project=p.name inRow=1 %]</span></td>
-      <td>[% HTML.escape(p.displayname) %]</td>
-      <td>[% WRAPPER maybeLink uri=p.homepage %][% HTML.escape(p.description) %][% END %]</td>
-    </tr>
+      [% IF !p.hidden || c.user_exists %]
+        <tr class="project [% IF !p.enabled %]disabled-project[% END %]">
+          <td><span class="[% IF !p.enabled %]disabled-project[% END %] [%+ IF p.hidden %]hidden-project[% END %]">[% INCLUDE renderProjectName project=p.name inRow=1 %]</span></td>
+          <td>[% HTML.escape(p.displayname) %]</td>
+          <td>[% WRAPPER maybeLink uri=p.homepage %][% HTML.escape(p.description) %][% END %]</td>
+        </tr>
+      [% END %]
     [% END %]
   </tbody>
 </table>


### PR DESCRIPTION
Maybe/partly fixes #486. A blunt instrument and doesn't deal with all the cases, but then I don't get the impression hiding projects was intended as any sort of security feature. This just unclutters the front page a bit, and obscures my embarrassing test projects to a degree :)

If one wanted to enhance this a bit, adding a "show hidden" toggle for logged in users would be the next obvious step.