### PR TITLE
hydra-notify: enable IPv6 support

### DIFF
--- a/src/script/hydra-notify
+++ b/src/script/hydra-notify
@@ -63,6 +63,7 @@ if (defined($promCfg)) {
             host => $promCfg->{"listen_address"},
             port => $promCfg->{"port"},
             timeout => 1,
+            ipv6 => 1,
         );
 
         $server->run($prom->psgi);


### PR DESCRIPTION
HTTP::Server::PSGI uses the `ipv6` flag to decide between
  `IO::Socket::INET` and `IO::Socket::IP`
  (https://metacpan.org/dist/Plack/source/lib/HTTP/Server/PSGI.pm#L80-84)
and (from IO/Socket/IP.pm):
> C`IO::Socket::IP` - Family-neutral IP socket supporting both IPv4 and IPv6

so setting the `ipv6` flag makes it support both IPv4 and IPv6.

Fixes #1394