### PR TITLE
renderInputDiff: Increase git hash length 8 -> 12

### DIFF
--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -374,7 +374,7 @@ BLOCK renderInputDiff; %]
               [% ELSIF bi1.uri == bi2.uri && bi1.revision != bi2.revision %]
                 [% IF bi1.type == "git" %]
                   <tr><td>
-                    <b>[% bi1.name %]</b></td><td><tt>[% INCLUDE renderDiffUri contents=(bi1.revision.substr(0, 8) _ ' to ' _ bi2.revision.substr(0, 8)) %]</tt>
+                    <b>[% bi1.name %]</b></td><td><tt>[% INCLUDE renderDiffUri contents=(bi1.revision.substr(0, 12) _ ' to ' _ bi2.revision.substr(0, 12)) %]</tt>
                   </td></tr>
                 [% ELSE %]
                   <tr><td>


### PR DESCRIPTION
See investigation on lengths required to be conflict-free in practice:

https://github.com/NixOS/hydra/pull/1258#issuecomment-1321891677

---

Reason: Got annoyed / slowed down today again that the commit `c716603a` shown in https://hydra.nixos.org/build/266559156 shows 404 on Github: https://github.com/NixOS/nixpkgs/commit/c716603a

This immediately made me suspect that somebody rewrote history (security issue), when in fact the commit is just too short.

We should not waste time with such things, so bump the length.