### PR TITLE
Enable permissive CORS on static file serving

### DIFF
--- a/src/lib/Hydra/Controller/Build.pm
+++ b/src/lib/Hydra/Controller/Build.pm
@@ -237,6 +237,7 @@ sub serveFile {
         # Have the hosted data considered its own origin to avoid being a giant
         # XSS hole.
         $c->response->header('Content-Security-Policy' => 'sandbox allow-scripts');
+        $c->response->header('Access-Control-Allow-Origin', '*');
 
         $c->stash->{'plain'} = { data => grab(cmd => ["nix", "--experimental-features", "nix-command",
                                                       "store", "cat", "--store", getStoreUri(), "$path"]) };


### PR DESCRIPTION
I had this issue while experimenting with CI for MR preview of static site with Hydra. The same issue also impact the Nix and Hydra manual, where font icons are not displayed (at least with recent Firefox and Chromium).

(https://hydra.nixos.org/build/263397466/download/1/manual/)

I’m not really sure why CORS is needed for some request and not other ones. I suspect this is due to the Content-Security-Policy=sandbox header, as the same program I have work well on another deployment that don’t send that header.

This should stay secure, as only static files are served, but will allow other sites to embed content server by Hydra too.