### PR TITLE
Document the default Hydra user and port in hacking.md

### DIFF
--- a/doc/manual/src/hacking.md
+++ b/doc/manual/src/hacking.md
@@ -30,6 +30,8 @@ foreman:
 $ foreman start
 ```
 
+The Hydra interface will be available on port 63333, with an admin user named "alice" with password "foobar"
+
 You can run just the Hydra web server in your source tree as follows:
 
 ```console


### PR DESCRIPTION
I found that this was lacking in the documentation. This avoid having to look at foreman script.