### PR TITLE
Looser timeouts, disable broken test, less verbose output

### DIFF
--- a/t/evaluator/evaluate-oom-job.t
+++ b/t/evaluator/evaluate-oom-job.t
@@ -31,6 +31,10 @@ if ($sd_res != 0) {
   skip_all("`systemd-run` returned non-zero when executing `true` (expected 0)");
 }
 
+# XXX(Mindavi): We should think about how to fix this.
+#               Note that it was always skipped on ofborg/h.n.o (nixos hydra) since systemd-run is not present in the ambient environment there.
+skip_all("Always fails, an error about 'oom' being a string is logged and the process never OOMs. Needs a way to use more memory.");
+
 my $ctx = test_context();
 
 # Contain the memory usage to 25 MegaBytes using `systemd-run`

--- a/t/lib/HydraTestContext.pm
+++ b/t/lib/HydraTestContext.pm
@@ -92,7 +92,7 @@ sub new {
         $opts{'before_init'}->($self);
     }
 
-    expectOkay(5, ("hydra-init"));
+    expectOkay(30, ("hydra-init"));
 
     return $self;
 }

--- a/t/lib/LDAPContext.pm
+++ b/t/lib/LDAPContext.pm
@@ -70,7 +70,7 @@ sub add_user {
     my $email = $opts{'email'} // "$name\@example";
     my $password = $opts{'password'} // rand_chars();
 
-    my ($res, $stdout, $stderr) = captureStdoutStderr(1, ("slappasswd", "-s", $password));
+    my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("slappasswd", "-s", $password));
     if ($res) {
         die "Failed to execute slappasswd ($res): $stderr, $stdout";
     }
@@ -178,7 +178,7 @@ sub start {
 sub validateConfig {
     my ($self) = @_;
 
-    expectOkay(1, ("slaptest", "-u", "-F", $self->{"_slapd_dir"}));
+    expectOkay(5, ("slaptest", "-u", "-F", $self->{"_slapd_dir"}));
 }
 
 sub _spawn {
@@ -218,7 +218,7 @@ sub load_ldif {
 
     my $path = "${\$self->{'_tmpdir'}}/load.ldif";
     write_file($path, $content);
-    expectOkay(1, ("slapadd", "-F", $self->{"_slapd_dir"}, "-b", $suffix, "-l", $path));
+    expectOkay(5, ("slapadd", "-F", $self->{"_slapd_dir"}, "-b", $suffix, "-l", $path));
     $self->validateConfig();
 }
 

--- a/t/queue-runner/build-locally-with-substitutable-path.t
+++ b/t/queue-runner/build-locally-with-substitutable-path.t
@@ -39,7 +39,7 @@ subtest "Building, caching, and then garbage collecting the underlying job" => s
 
     ok(unlink(Hydra::Helper::Nix::gcRootFor($path)), "Unlinking the GC root for underlying Dependency succeeds");
 
-    (my $ret, my $stdout, my $stderr) = captureStdoutStderr(5, "nix-store", "--delete", $path);
+    (my $ret, my $stdout, my $stderr) = captureStdoutStderr(15, "nix-store", "--delete", $path);
     is($ret, 0, "Deleting the underlying dependency should succeed");
 };
 

--- a/t/scripts/hydra-create-user.t
+++ b/t/scripts/hydra-create-user.t
@@ -9,7 +9,7 @@ my $db = $ctx->db();
 
 subtest "Handling password and password hash creation" => sub {
     subtest "Creating a user with a plain text password (insecure) stores the password securely" => sub {
-        my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-create-user", "plain-text-user", "--password", "foobar"));
+        my ($res, $stdout, $stderr) = captureStdoutStderr(15, ("hydra-create-user", "plain-text-user", "--password", "foobar"));
         is($res, 0, "hydra-create-user should exit zero");
         like($stderr, qr/Submitting plaintext passwords as arguments is deprecated and will be removed/, "Submitting a plain text password is deprecated.");
 
@@ -23,7 +23,7 @@ subtest "Handling password and password hash creation" => sub {
     };
 
     subtest "Creating a user with a sha1 password (still insecure) stores the password as a hashed sha1" => sub {
-        my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-create-user", "old-password-hash-user", "--password-hash", "8843d7f92416211de9ebb963ff4ce28125932878"));
+        my ($res, $stdout, $stderr) = captureStdoutStderr(15, ("hydra-create-user", "old-password-hash-user", "--password-hash", "8843d7f92416211de9ebb963ff4ce28125932878"));
         is($res, 0, "hydra-create-user should exit zero");
 
         my $user = $db->resultset('Users')->find({ username => "old-password-hash-user" });
@@ -36,7 +36,7 @@ subtest "Handling password and password hash creation" => sub {
     };
 
     subtest "Creating a user with an argon2 password stores the password as given" => sub {
-        my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-create-user", "argon2-hash-user", "--password-hash", '$argon2id$v=19$m=262144,t=3,p=1$tMnV5paYjmIrUIb6hylaNA$M8/e0i3NGrjhOliVLa5LqQ'));
+        my ($res, $stdout, $stderr) = captureStdoutStderr(15, ("hydra-create-user", "argon2-hash-user", "--password-hash", '$argon2id$v=19$m=262144,t=3,p=1$tMnV5paYjmIrUIb6hylaNA$M8/e0i3NGrjhOliVLa5LqQ'));
         is($res, 0, "hydra-create-user should exit zero");
 
         my $user = $db->resultset('Users')->find({ username => "argon2-hash-user" });
@@ -50,7 +50,7 @@ subtest "Handling password and password hash creation" => sub {
 
     subtest "Creating a user by prompting for the password" => sub {
         subtest "with the same password twice" => sub {
-            my ($res, $stdout, $stderr) = captureStdoutStderrWithStdin(5, ["hydra-create-user", "prompted-pass-user", "--password-prompt"], "my-password\nmy-password\n");
+            my ($res, $stdout, $stderr) = captureStdoutStderrWithStdin(15, ["hydra-create-user", "prompted-pass-user", "--password-prompt"], "my-password\nmy-password\n");
             is($res, 0, "hydra-create-user should exit zero");
 
             my $user = $db->resultset('Users')->find({ username => "prompted-pass-user" });
@@ -62,7 +62,7 @@ subtest "Handling password and password hash creation" => sub {
         };
 
         subtest "With mismatched password confirmation" => sub {
-            my ($res, $stdout, $stderr) = captureStdoutStderrWithStdin(5, ["hydra-create-user", "prompted-pass-user", "--password-prompt"], "my-password\nnot-my-password\n");
+            my ($res, $stdout, $stderr) = captureStdoutStderrWithStdin(15, ["hydra-create-user", "prompted-pass-user", "--password-prompt"], "my-password\nnot-my-password\n");
             isnt($res, 0, "hydra-create-user should exit non-zero");
         };
     };
@@ -76,7 +76,7 @@ subtest "Handling password and password hash creation" => sub {
         );
 
         for my $case (@cases) {
-            my ($res, $stdout, $stderr) = captureStdoutStderr(5, (
+            my ($res, $stdout, $stderr) = captureStdoutStderr(15, (
                 "hydra-create-user", "bogus-password-options", @{$case}));
             like($stderr, qr/please specify only one of --password-prompt or --password-hash/, "We get an error about specifying the password");
             isnt($res, 0, "hydra-create-user should exit non-zero with conflicting " . join(" ", @{$case}));
@@ -84,7 +84,7 @@ subtest "Handling password and password hash creation" => sub {
     };
 
     subtest "A password is not required for creating a Google-based account" => sub {
-        my ($res, $stdout, $stderr) = captureStdoutStderr(5, (
+        my ($res, $stdout, $stderr) = captureStdoutStderr(15, (
             "hydra-create-user", "google-account", "--type", "google"));
         is($res, 0, "hydra-create-user should exit zero");
     };

--- a/t/scripts/hydra-init.t
+++ b/t/scripts/hydra-init.t
@@ -28,7 +28,7 @@ subtest "hydra-init upgrades user's password hashes from sha1 to sha1 inside Arg
     $janet->setPassword("foobar");
 
     is($alice->password, "8843d7f92416211de9ebb963ff4ce28125932878", "Alices's sha1 is stored in the database");
-    my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-init"));
+    my ($res, $stdout, $stderr) = captureStdoutStderr(30, ("hydra-init"));
     if ($res != 0) {
         is($stdout, "");
         is($stderr, "");
@@ -55,7 +55,7 @@ subtest "hydra-init upgrades user's password hashes from sha1 to sha1 inside Arg
     };
 
     subtest "Running hydra-init don't break Alice or Janet's passwords" => sub {
-        my ($res, $stdout, $stderr) = captureStdoutStderr(5, ("hydra-init"));
+        my ($res, $stdout, $stderr) = captureStdoutStderr(30, ("hydra-init"));
         is($res, 0, "hydra-init should exit zero");
 
         my $updatedAlice = $db->resultset('Users')->find({ username => "alice" });

--- a/t/test.pl
+++ b/t/test.pl
@@ -21,7 +21,7 @@ if (defined($ENV{"NIX_BUILD_CORES"})
     print STDERR "test.pl: Defaulting \$YATH_JOB_COUNT to \$NIX_BUILD_CORES (${\$ENV{'NIX_BUILD_CORES'}})\n";
 }
 
-system($^X, find_yath(), '-D', 'test', '--default-search' => './', @ARGV);
+system($^X, find_yath(), '-D', 'test', '--qvf', '--event-timeout', 240, '--default-search' => './', @ARGV);
 my $exit = $?;
 
 # This makes sure it works with prove.


### PR DESCRIPTION
I did some testing (see how in the commit messages) to hash out any unstable tests. On pull requests and possibly also on hydra we keep running into troubles with running the tests, since they keep giving seemingly random errors (timeouts, I figured out now).

This patchset increases timeouts for some commands that kept timing out under higher load, likely resolving almost all issues we have with instability on ofborg and with local builds.

We've already disabled a test (https://github.com/NixOS/nixpkgs/pull/173887) and increased the timeout in nixpkgs itself (https://github.com/NixOS/nixpkgs/blob/24e36589b79da526f339245641ade6261dcafaf8/pkgs/development/tools/misc/hydra/unstable.nix#L210-L212). Let's now resolve this upstream for good.

Also found out that t/evaluator/evaluate-oom-job.t always fails, so I put a comment that for later reference. I'd like to keep fixing it out of scope for this PR, but I though putting a note would be good, and unconditionally skipping it for now.