### PR TITLE
Use Nix::Store and Nix::Utils in NARInfo.pm

### DIFF
--- a/src/lib/Hydra/View/NARInfo.pm
+++ b/src/lib/Hydra/View/NARInfo.pm
@@ -6,6 +6,8 @@ use File::Basename;
 use Hydra::Helper::CatalystUtils;
 use MIME::Base64;
 use Nix::Manifest;
+use Nix::Store;
+use Nix::Utils;
 use Hydra::Helper::Nix;
 use base qw/Catalyst::View/;
 


### PR DESCRIPTION
These are required for some subroutines used when signing NARs. They were erroneously removed in #1359.

Without this change, and with `binary_cache_secret_key_file` defined, when requesting a `.narinfo`:

```
Caught exception in Hydra::View::NARInfo->process "Can't locate object method "readFile" via package "/path/to/secret-key" (perhaps you forgot to load "/path/to/secret-key"?) at /nix/store/j1j3fyxwlbgkxczm6kr62nhkxw21xjnp-hydra-2024-07-09/libexec/hydra/lib/Hydra/View/NARInfo.pm line 39."
```

```
Caught exception in Hydra::View::NARInfo->process "Undefined subroutine &Hydra::View::NARInfo::signString called at /nix/store/g5w3py1ik48lgjql0fw45pvs3yi55g1h-hydra-2024-07-09/libexec/hydra/lib/Hydra/View/NARInfo.pm line 42."
```