### PR TITLE
hydra-queue-runner: fix compilation warning

### DIFF
--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -164,7 +164,7 @@ void State::parseMachines(const std::string & contents)
                 ? string2Int<MaxJobs>(tokens[3]).value()
                 : 1,
             // `speedFactor`
-            atof(tokens[4].c_str()),
+            std::stof(tokens[4].c_str()),
             // `supportedFeatures`
             std::move(supportedFeatures),
             // `mandatoryFeatures`


### PR DESCRIPTION
instead of converting to double, we can convert to float right away.