### PR TITLE
nix-prefetch-git: set branch name to suppress hint from git

### DIFF
--- a/src/script/nix-prefetch-git
+++ b/src/script/nix-prefetch-git
@@ -78,7 +78,7 @@ fi
 
 init_remote(){
     local url=$1;
-    git init;
+    git init --initial-branch=trunk;
     git remote add origin $url;
 }
 


### PR DESCRIPTION
In my system logs I see this every time a new eval starts:

```
hydra-evaluator[PID]: hint: Using 'master' as the name for the initial branch. This default branch name
hydra-evaluator[PID]: hint: is subject to change. To configure the initial branch name to use in all
hydra-evaluator[PID]: hint: of your new repositories, which will suppress this warning, call:
hydra-evaluator[PID]: hint:
hydra-evaluator[PID]: hint:         git config --global init.defaultBranch <name>
hydra-evaluator[PID]: hint:
hydra-evaluator[PID]: hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hydra-evaluator[PID]: hint: 'development'. The just-created branch can be renamed via this command:
hydra-evaluator[PID]: hint:
hydra-evaluator[PID]: hint:         git branch -m <name>
```

This ensures this hint is not logged anymore and unclutters the syslog. I presume it does not really matter what name is chosen for the branch.