### PR TITLE
Make the in-tree package the default package

### DIFF
--- a/nixos-modules/hydra.nix
+++ b/nixos-modules/hydra.nix
@@ -68,7 +68,7 @@ in
 
       package = mkOption {
         type = types.path;
-        default = pkgs.hydra_unstable;
+        default = pkgs.hydra;
         defaultText = literalExpression "pkgs.hydra";
         description = "The Hydra package.";
       };


### PR DESCRIPTION
There is an overlay for the `hydra` name, but `hydra_unstable` was used, which can refer to the nixpkgs package and lead to and outdated hydra version and requires configuring the correct package attribute downstream.