### PR TITLE
reproduce.tt: Use realpath for tmpDir to fix macOS compatibility

### DIFF
--- a/src/root/reproduce.tt
+++ b/src/root/reproduce.tt
@@ -7,7 +7,7 @@ main() {
 
 set -e
 
-tmpDir=${TMPDIR:-/tmp}/build-[% build.id +%]
+tmpDir=$(realpath "${TMPDIR:-/tmp}")/build-[% build.id +%]
 declare -a args extraArgs
 
 


### PR DESCRIPTION
On macOS, `$TMPDIR` comes with a trailing slash:
```
bash-3.2$ echo $TMPDIR
/var/folders/_q/t4wwsxvs33j409tc1tp3t5mc0000gn/T/
```

This causes `tmpDir` to be `/var/folders/_q/t4wwsxvs33j409tc1tp3t5mc0000gn/T//build-277917310` and breaks the reproduction script.

```
❯ curl https://hydra.nixos.org/build/277917310/reproduce | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  4293  100  4293    0     0   4420      0 --:--:-- --:--:-- --:--:--  4416
storing inputs and results in /var/folders/_q/t4wwsxvs33j409tc1tp3t5mc0000gn/T//build-277917310...
running nix-build...
using the following invocation:
+ nix-build --arg nixpkgs '{ outPath = /var/folders/_q/t4wwsxvs33j409tc1tp3t5mc0000gn/T//build-277917310/nixpkgs/source; rev = "b2a0e3125e8b373ee2d6480ebd3b8f5c20080796"; shortRev = "b2a0e31"; revCount = 705472; }' -I nixpkgs=/var/folders/_q/t4wwsxvs33j409tc1tp3t5mc0000gn/T//build-277917310/nixpkgs/source --arg officialRelease false --arg supportedSystems '[ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]' --option extra-binary-caches https://hydra.nixos.org/ --option system x86_64-linux /var/folders/_q/t4wwsxvs33j409tc1tp3t5mc0000gn/T//build-277917310/nixpkgs/source/pkgs/top-level/release.nix -A ''
error: syntax error, unexpected PATH_END, expecting DOLLAR_CURLY
       at «string»:1:62:
            1| { outPath = /var/folders/_q/t4wwsxvs33j409tc1tp3t5mc0000gn/T//build-277917310/nixpkgs/source; rev = "b2a0e3125e8b373ee2d6480ebd3b8f5c20080796"; shortRev = "b2a0e31"; revCount = 705472; }
             |
```