### PR TITLE
Make hydra-queue-runner want network-online.target

### DIFF
--- a/nixos-modules/hydra.nix
+++ b/nixos-modules/hydra.nix
@@ -338,6 +338,7 @@ in
     systemd.services.hydra-queue-runner =
       { wantedBy = [ "multi-user.target" ];
         requires = [ "hydra-init.service" ];
+        wants = [ "network-online.target" ];
         after = [ "hydra-init.service" "network.target" "network-online.target" ];
         path = [ cfg.package pkgs.nettools pkgs.openssh pkgs.bzip2 config.nix.package ];
         restartTriggers = [ hydraConf ];


### PR DESCRIPTION
Just ordering yourself after network-online.target will not guarantee that it will be loaded. You'll have to either want or require it. Hence the following trace on recent nixpkgs versions:

```
evaluation warning: hydra-queue-runner.service is ordered after 'network-online.target' but doesn't depend on it