### PR TITLE
Fix rendering of metrics with special characters

### DIFF
--- a/src/lib/Hydra/View/TT.pm
+++ b/src/lib/Hydra/View/TT.pm
@@ -6,6 +6,7 @@ use base 'Catalyst::View::TT';
 use Template::Plugin::HTML;
 use Hydra::Helper::Nix;
 use Time::Seconds;
+use Digest::SHA qw(sha1_hex);
 
 __PACKAGE__->config(
     TEMPLATE_EXTENSION => '.tt',
@@ -25,7 +26,13 @@ __PACKAGE__->config(
     makeNameTextForJobset
     relativeDuration
     stripSSHUser
+    metricDivId
     /]);
+
+sub metricDivId {
+    my ($self, $c, $text) = @_;
+    return "metric-" . sha1_hex($text);
+}
 
 sub buildLogExists {
     my ($self, $c, $build) = @_;

--- a/src/root/job-metrics-tab.tt
+++ b/src/root/job-metrics-tab.tt
@@ -18,8 +18,7 @@
 
     <h3>Metric: <a [% HTML.attributes(href => c.uri_for('/job' project.name jobset.name job 'metric' metric.name)) %]><tt>[%HTML.escape(metric.name)%]</tt></a></h3>
 
-    [% id = "metric-" _ metric.name;
-       id = id.replace('\.', '_');
+    [% id = metricDivId(metric.name);
        INCLUDE createChart dataUrl=c.uri_for('/job' project.name jobset.name job 'metric' metric.name); %]
 
   [% END %]


### PR DESCRIPTION
My main motivation here is to get metrics with brackets to work in order
to support "pytest" test names:

- `test_foo.py::test_bar[1]`
- `test_foo.py::test_bar[2]`

I couldn't find an "HTML escape"-style function that would generate
valid html `id` attribute names from arbitrary strings, so I went with a
hash digest instead.

(See also the previous fix for [metrics with dots](https://github.com/NixOS/hydra/commit/dc2010eafcc395308016cb5525db525585997e40#diff-b63339813e72c4a1f3700bd16f677fccc99e798d7bea3f1d43a3c6175d0747b3))