### PR TITLE
Fix race condition in hydra-compress-logs

### DIFF
--- a/nixos-modules/hydra.nix
+++ b/nixos-modules/hydra.nix
@@ -468,7 +468,7 @@ in
             elif [[ $compression == zstd ]]; then
               compression="zstd --rm"
             fi
-            find ${baseDir}/build-logs -type f -name "*.drv" -mtime +3 -size +0c | xargs -r "$compression" --force --quiet
+            find ${baseDir}/build-logs -ignore_readdir_race -type f -name "*.drv" -mtime +3 -size +0c | xargs -r "$compression" --force --quiet
           '';
         startAt = "Sun 01:45";
       };


### PR DESCRIPTION
On hydra.nixos.org the following happened and this is the most plausible fix I could come up with.

```
Mar 02 01:45:00 mimas systemd[1]: Started hydra-compress-logs.service.
Mar 02 01:46:20 mimas hydra-compress-logs-start[2162537]: find: ‘/var/lib/hydra/build-logs/fv/qzi69s810vppw3ld5l04q9w7grlady-system-path.drv’: No such file or directory
Mar 02 01:46:33 mimas systemd[1]: hydra-compress-logs.service: Main process exited, code=exited, status=1/FAILURE
Mar 02 01:46:33 mimas systemd[1]: hydra-compress-logs.service: Failed with result 'exit-code'.
```