### PR TITLE
Fix compilation with a nix which was compiled without aws sdk

### DIFF
--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -703,6 +703,7 @@ void State::dumpStatus(Connection & conn)
             : 0.0},
         };
 
+#if NIX_WITH_S3_SUPPORT
         auto s3Store = dynamic_cast<S3BinaryCacheStore *>(&*store);
         if (s3Store) {
             auto & s3Stats = s3Store->getS3Stats();
@@ -728,6 +729,7 @@ void State::dumpStatus(Connection & conn)
                         + s3Stats.getBytes / (1024.0 * 1024.0 * 1024.0) * 0.09},
             };
         }
+#endif
     }
 
     {


### PR DESCRIPTION
```
/nix/store/7mn50swh39iz4jilgligd4r14b4zr1a8-libpqxx-7.10.0-dev/include/pqxx/transaction_base.hxx:749:10: note: declared here
      |                                     ^~~~~~~~~~~~~~~~~~
../src/hydra-queue-runner/hydra-queue-runner.cc:706:56: error: expected '>' before '*' token
  706 |         auto s3Store = dynamic_cast<S3BinaryCacheStore *>(&*store);
      |                                                        ^
../src/hydra-queue-runner/hydra-queue-runner.cc:706:56: error: expected '(' before '*' token
  706 |         auto s3Store = dynamic_cast<S3BinaryCacheStore *>(&*store);
      |                                                        ^
      |                                                        (
../src/hydra-queue-runner/hydra-queue-runner.cc:706:57: error: expected primary-expression before '>' token
  706 |         auto s3Store = dynamic_cast<S3BinaryCacheStore *>(&*store);
      |                                                         ^
../src/hydra-queue-runner/hydra-queue-runner.cc:706:67: error: expected ')' before ';' token
  706 |         auto s3Store = dynamic_cast<S3BinaryCacheStore *>(&*store);
      |                                                                   ^
      |                                                                   )
../src/hydra-queue-runner/hydra-queue-runner.cc:729:13: error: no match for 'operator=' (operand types are 'nlohmann::json_abi_v3_11_3::basic_json<>::value_type' {aka 'nlohmann::json_abi_v3_11_3::basic_json<>'} and '<brace-enclosed initializer list>')
  729 |             };
      |             ^
```