### PR TITLE
Migrate from "gc-" prefixed nix options

### DIFF
--- a/nixos-modules/hydra.nix
+++ b/nixos-modules/hydra.nix
@@ -228,8 +228,8 @@ in
 
     nix.settings = {
       trusted-users = [ "hydra-queue-runner" ];
-      gc-keep-outputs = true;
-      gc-keep-derivations = true;
+      keep-outputs = true;
+      keep-derivations = true;
     };
 
     services.hydra-dev.extraConfig =


### PR DESCRIPTION
These have been deprecated, e.g. gc-keep-outputs is now just keep-outputs.

https://nix.dev/manual/nix/2.28/command-ref/conf-file.html#conf-keep-derivations
https://nix.dev/manual/nix/2.28/command-ref/conf-file.html#conf-keep-outputs