### PR TITLE
doc/manual: correct nginx reverse proxy example

### DIFF
--- a/doc/manual/src/configuration.md
+++ b/doc/manual/src/configuration.md
@@ -63,8 +63,7 @@ following:
         .. other configuration ..
         location /hydra/ {
 
-            proxy_pass     http://127.0.0.1:3000;
-            proxy_redirect http://127.0.0.1:3000 https://example.com/hydra;
+            proxy_pass http://127.0.0.1:3000/;
 
             proxy_set_header  Host              $host;
             proxy_set_header  X-Real-IP         $remote_addr;
@@ -73,6 +72,9 @@ following:
             proxy_set_header  X-Request-Base    /hydra;
         }
     }
+
+Note the trailing slash on the `proxy_pass` directive, which causes nginx to
+strip off the `/hydra/` part of the URL before passing it to hydra.
 
 Populating a Cache
 ------------------


### PR DESCRIPTION
- hydra does not remove the base URI from the request before processing it, so this must be done in the reverse proxy. in nginx this is done by giving proxy_pass a URI rather than a protocol/host/port; see:

  https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass

- proxy_redirect is not correct/required: hydra uses proxy headers to correctly form redirects in most cases, and where it doesn't it produces local redirects which aren't matched by this directive anyway

I've tried this exact setup on both http and https, and it works fine (apart from the redirects). It might also be worth showing how to configure this in nixos, as the defaults work and that's probably more relevant to most users?

There is an existing PR for this, #1310 , which i didn't see before making this. This one is a bit more thorough, so seems worth keeping. This is orthogonal to #1202 , which is also a good idea IMO.