### PR TITLE
fix: Update Nix download url

### DIFF
--- a/doc/manual/src/installation.md
+++ b/doc/manual/src/installation.md
@@ -48,7 +48,7 @@ Getting Nix
 If your server runs NixOS you are all set to continue with installation
 of Hydra. Otherwise you first need to install Nix. The latest stable
 version can be found one [the Nix web
-site](http://nixos.org/nix/download.html), along with a manual, which
+site](https://nixos.org/download/), along with a manual, which
 includes installation instructions.
 
 Installation

--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -563,7 +563,7 @@ END;
 
         [% IF eval.flake %]
 
-          <p>If you have <a href='https://nixos.org/nix/download.html'>Nix
+          <p>If you have <a href='https://nixos.org/download/'>Nix
           installed</a>, you can reproduce this build on your own machine by
           running the following command:</p>
 
@@ -573,7 +573,7 @@ END;
 
         [% ELSE %]
 
-          <p>If you have <a href='https://nixos.org/nix/download.html'>Nix
+          <p>If you have <a href='https://nixos.org/download/'>Nix
           installed</a>, you can reproduce this build on your own machine by
           downloading <a [% HTML.attributes(href => url) %]>a script</a>
           that checks out all inputs of the build and then invokes Nix to


### PR DESCRIPTION
Updates the documentation and `reproduce` modal to point to the correct download page for Nix.