### PR TITLE
Show queue runner v2 status

### DIFF
--- a/foreman/start-hydra.sh
+++ b/foreman/start-hydra.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export PATH=$(pwd)/src/script:$PATH
+
 # wait for postgresql to listen
 while ! pg_isready -h $(pwd)/.hydra-data/postgres -p 64444; do sleep 1; done
 

--- a/foreman/start-notify.sh
+++ b/foreman/start-notify.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export PATH=$(pwd)/src/script:$PATH
+
 # wait for hydra-server to listen
 while ! nc -z localhost 63333; do sleep 1; done
 

--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -188,8 +188,10 @@ sub machines :Local Args(0) {
     my ($self, $c) = @_;
     my $machines = getMachines;
 
-    # Add entry for localhost.
-    $machines->{''} //= {};
+    # Add entry for localhost. The implicit addition is not needed with queue runner v2
+    if (not $c->config->{'queue_runner_endpoint'}) {
+        $machines->{''} //= {};
+    }
     delete $machines->{'localhost'};
 
     my $status = $c->model('DB::SystemStatus')->find("queue-runner");

--- a/t/Hydra/Helper/Nix.t
+++ b/t/Hydra/Helper/Nix.t
@@ -33,7 +33,6 @@ close $fh;
 is(Hydra::Helper::Nix::getMachines(), {
     'root@ip' => {
         'systemTypes' => ["x86_64-darwin"],
-        'sshKeys' => '/sshkey',
         'maxJobs' => 15,
         'speedFactor' => 15,
         'supportedFeatures' => ["big-parallel", "kvm", "nixos-test" ],
@@ -41,7 +40,6 @@ is(Hydra::Helper::Nix::getMachines(), {
     },
     'root@baz' => {
         'systemTypes' => [ "aarch64-darwin" ],
-        'sshKeys' => '/sshkey',
         'maxJobs' => 4,
         'speedFactor' => 1,
         'supportedFeatures' => ["big-parallel"],
@@ -49,7 +47,6 @@ is(Hydra::Helper::Nix::getMachines(), {
     },
     'root@bux' => {
         'systemTypes' => [ "i686-linux", "x86_64-linux" ],
-        'sshKeys' => '/var/sshkey',
         'maxJobs' => 1,
         'speedFactor' => 1,
         'supportedFeatures' => [ "kvm", "nixos-test", "benchmark" ],
@@ -57,7 +54,6 @@ is(Hydra::Helper::Nix::getMachines(), {
     },
     'root@lotsofspace' => {
         'systemTypes' => [ "i686-linux", "x86_64-linux" ],
-        'sshKeys' => '/var/sshkey',
         'maxJobs' => 1,
         'speedFactor' => 1,
         'supportedFeatures' => [ "kvm", "nixos-test", "benchmark" ],


### PR DESCRIPTION
This is guarded behind a setting and will overwrite everything that was learned from the machines file. Also drops `sshKeys` since that wasn't used anyway.