### PR TITLE
Remove useless previous eval message

### DIFF
--- a/src/root/jobset-eval.tt
+++ b/src/root/jobset-eval.tt
@@ -30,8 +30,6 @@ eval.checkouttime %]s and evaluation took [% eval.evaltime %]s.</p>
 project=otherEval.jobset.project.name jobset=otherEval.jobset.name %] evaluation <a href="[%
 c.uri_for(c.controller('JobsetEval').action_for('view'),
 [otherEval.id]) %]">[% otherEval.id %]</a>.</p>
-[% ELSE %]
-<div class="alert alert-danger">Couldn't find an evaluation to compare to.</div>
 [% END %]
 
 <form>


### PR DESCRIPTION
This message serves no purpose and looks like something went wrong. There is nothing wrong, there is just no previous evaluation.