### PR TITLE
Correctly apply the setting `allow_import_from_derivation = true`

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -382,7 +382,7 @@ sub evalJobs {
     push @cmd, "--meta";
     push @cmd, "--constituents";
     push @cmd, "--force-recurse";
-    push @cmd, ("--option", "allow-import-from-derivation", "false") if $config->{allow_import_from_derivation} // "true" ne "true";
+    push @cmd, ("--option", "allow-import-from-derivation", "false") if ($config->{allow_import_from_derivation} // "true") ne "true";
     push @cmd, ("--workers", $config->{evaluator_workers} // 1);
     push @cmd, ("--max-memory-size", $config->{evaluator_max_memory_size} // 4096);
 

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -382,7 +382,7 @@ sub evalJobs {
     push @cmd, "--meta";
     push @cmd, "--constituents";
     push @cmd, "--force-recurse";
-    push @cmd, ("--option", "allow-import-from-derivation", "false") if ($config->{allow_import_from_derivation} // "true") ne "true";
+    push @cmd, ("--option", "allow-import-from-derivation", "false") if ($config->{allow_import_from_derivation} // "false") ne "true";
     push @cmd, ("--workers", $config->{evaluator_workers} // 1);
     push @cmd, ("--max-memory-size", $config->{evaluator_max_memory_size} // 4096);
 


### PR DESCRIPTION
`ne` evaluates before `//` in Perl; which caused the setting
```
allow_import_from_derivation = true
```
to actually evaluate into not allowing import-from-derivation; while `0` became a value that did allow IFD.

This PR adds parentheses to fix the evaluation order, so `true` allows IFD while `0` does not anymore.