### PR TITLE
jobset-eval: reduce compare options to active jobsets

### DIFF
--- a/src/root/jobset-eval.tt
+++ b/src/root/jobset-eval.tt
@@ -13,7 +13,7 @@
     <a class="dropdown-item" href="?compare=-[% 31 * 24 * 60 * 60 %]&full=[% full ? 1 : 0 %]">This jobset <strong>one month</strong> earlier</a>
     [% IF project.jobsets_rs.count > 1 %]
       <div class="dropdown-divider"></div>
-      [% FOREACH j IN project.jobsets.sort('name'); IF j.name != jobset.name %]
+      [% FOREACH j IN project.jobsets.sort('name'); IF j.name != jobset.name && j.enabled == 1 %]
         <a class="dropdown-item" href="?compare=[% j.name | uri %]&full=[% full ? 1 : 0 %]">Jobset <tt>[% project.name | html %]:[% j.name | html %]</tt></a>
       [% END; END %]
     [% END %]


### PR DESCRIPTION
The list of jobsets is very high on hydra.nixos.org and the compare to dropdown listing goes over multiple full pages in the busy projects.

If we ignore jobsets that we disable this interface becomes more usable again.

This is untested.

<img width="369" height="1990" alt="image" src="https://github.com/user-attachments/assets/ed14b8ce-789e-41b0-bf47-c3940c290981" />
