### PR TITLE
Fix webhook-secrets.conf permissions

### DIFF
--- a/doc/manual/src/webhook-migration-guide.md
+++ b/doc/manual/src/webhook-migration-guide.md
@@ -28,7 +28,7 @@ EOF
 
 # Set secure permissions
 chmod 0600 /var/lib/hydra/secrets/webhook-secrets.conf
-chown hydra:hydra /var/lib/hydra/secrets/webhook-secrets.conf
+chown hydra-www:hydra /var/lib/hydra/secrets/webhook-secrets.conf
 ```
 
 **Important**: Save the generated secrets to configure them in GitHub/Gitea later. You can view them with:


### PR DESCRIPTION
The secret is read by hydra-server which is run under hydra-www so that needs to be able to read the file.