### PR TITLE
document `force` parameter for `/api/push`

### DIFF
--- a/hydra-api.yaml
+++ b/hydra-api.yaml
@@ -78,6 +78,11 @@ paths:
           description: project and jobset formatted as "<project>:<jobset>" to evaluate
           schema:
             type: string
+        - in: query
+          name: force
+          description: when set to true the jobset gets evaluated even when it did not change
+          schema:
+            type: boolean
       responses:
         '200':
           description: jobset trigger response


### PR DESCRIPTION
This adds the `force` parameter for `/api/push` to the OpenAPI spec.

I did not know it existed until I found it it [here](https://github.com/NixOS/hydra/blob/0d2a030661fb1a6ba3f5cb83c627a72b562ebe74/src/root/jobset.tt#L206).