### PR TITLE
hydra-eval-jobset: allow attributes other than checks/hydraJobs

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -358,13 +358,24 @@ sub evalJobs {
     my @cmd;
 
     if (defined $flakeRef) {
-        my $nix_expr =
-            "let " .
-            "flake = builtins.getFlake (toString \"$flakeRef\"); " .
-            "in " .
-            "flake.hydraJobs " .
-            "or flake.checks " .
-            "or (throw \"flake '$flakeRef' does not provide any Hydra jobs or checks\")";
+        my $nix_expr;
+        my ($ref, $attr) = split '#', $flakeRef, 2;
+        if (defined $attr) {
+            $nix_expr =
+                "let " .
+                "flake = builtins.getFlake (toString \"$ref\"); " .
+                "in " .
+                "flake.${attr} " .
+                "or (throw \"flake '$ref' does not provide attribute '$attr'\")";
+        } else {
+            $nix_expr =
+                "let " .
+                "flake = builtins.getFlake (toString \"$flakeRef\"); " .
+                "in " .
+                "flake.hydraJobs " .
+                "or flake.checks " .
+                "or (throw \"flake '$flakeRef' does not provide any Hydra jobs or checks\")";
+        }
 
         @cmd = ("nix-eval-jobs",
                 # Disable the eval cache to prevent SQLite database contention.
@@ -713,12 +724,13 @@ sub checkJobsetWrapped {
 
     my $flakeRef = $jobset->flake;
     if (defined $flakeRef) {
+        my ($ref, $attr) = split '#', $flakeRef, 2;
         (my $res, my $json, my $stderr) = captureStdoutStderr(
-            600, "nix", "flake", "metadata", "--refresh", "--json", "--", $flakeRef);
+            600, "nix", "flake", "metadata", "--refresh", "--json", "--", $ref);
         die "'nix flake metadata' returned " . ($res & 127 ? "signal $res" : "exit code " . ($res >> 8))
             . ":\n" . ($stderr ? decode("utf-8", $stderr) : "(no output)\n")
             if $res;
-        $flakeRef = decode_json($json)->{'url'};
+        $ref = decode_json($json)->{'url'};
     }
 
     Net::Statsd::increment("hydra.evaluator.checkouts");

--- a/t/evaluator/evaluate-flake.t
+++ b/t/evaluator/evaluate-flake.t
@@ -17,7 +17,8 @@ my $ctx = test_context(
 );
 
 sub checkFlake {
-    my ($flake) = @_;
+    my ($input) = @_;
+    my ($flake, $attr) = split '#', $input, 2;
 
     cp($ctx->jobsdir . "/basic.nix", $ctx->jobsdir . "/" . $flake);
     cp($ctx->jobsdir . "/config.nix", $ctx->jobsdir . "/" . $flake);
@@ -30,7 +31,7 @@ sub checkFlake {
     chmod 0755, $ctx->jobsdir . "/" . $flake . "/succeed-with-failed.sh";
 
     my $builds = $ctx->makeAndEvaluateJobset(
-        flake => 'path:' . $ctx->jobsdir . "/" . $flake,
+        flake => 'path:' . $ctx->jobsdir . "/" . $input,
         build => 1
     );
 
@@ -62,6 +63,14 @@ subtest "Flake using `checks`" => sub {
 
 subtest "Flake using `hydraJobs`" => sub {
     checkFlake 'flake-hydraJobs'
+};
+
+subtest "Flake using explict `hydraJobs`" => sub {
+    checkFlake 'flake-hydraJobs#hydraJobs'
+};
+
+subtest "Flake using explict `attr`" => sub {
+    checkFlake 'flake-attr#attr'
 };
 
 done_testing;

--- a/t/jobs/flake-attr/flake.nix
+++ b/t/jobs/flake-attr/flake.nix
@@ -1,0 +1,6 @@
+{
+  outputs = { ... }: {
+    attr =
+      import ./basic.nix;
+  };
+}


### PR DESCRIPTION
I'd like to be able to build different attrs from the same flake.