### PR TITLE
[wip] hydra-eval-jobs: use nix-eval-jobs's --select rather --expr

### DIFF
--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -358,21 +358,14 @@ sub evalJobs {
     my @cmd;
 
     if (defined $flakeRef) {
-        my $nix_expr =
-            "let " .
-            "flake = builtins.getFlake (toString \"$flakeRef\"); " .
-            "in " .
-            "flake.hydraJobs " .
-            "or flake.checks " .
-            "or (throw \"flake '$flakeRef' does not provide any Hydra jobs or checks\")";
-
         @cmd = ("nix-eval-jobs",
                 # Disable the eval cache to prevent SQLite database contention.
                 # Since Hydra typically evaluates each revision only once,
                 # parallel workers would compete for database locks without
                 # providing any benefit from caching.
                 "--option", "eval-cache", "false",
-                "--expr", $nix_expr);
+                "--flake", $flakeRef,
+                "--select", "flake: flake.outputs.hydraJobs or flake.outputs.checks or (throw \"flake '$flakeRef' does not provide any Hydra jobs or checks\")");
     } else {
         my $nixExprInput = $inputInfo->{$nixExprInputName}->[0]
             or die "cannot find the input containing the job expression\n";

--- a/t/jobs/basic.nix
+++ b/t/jobs/basic.nix
@@ -1,4 +1,6 @@
-with import ./config.nix;
+{ system ? builtins.currentSystem }:
+
+with import ./config.nix { inherit system; };
 {
   empty_dir =
     mkDerivation {

--- a/t/jobs/config.nix.in
+++ b/t/jobs/config.nix.in
@@ -1,9 +1,11 @@
+{ system ? builtins.currentSystem }:
+
 rec {
   path = "@testPath@";
 
   mkDerivation = args:
     derivation ({
-      system = builtins.currentSystem;
+      inherit system;
       PATH = path;
     } // args);
   mkContentAddressedDerivation = args: mkDerivation ({

--- a/t/jobs/flake-checks/flake.nix
+++ b/t/jobs/flake-checks/flake.nix
@@ -1,6 +1,11 @@
 {
-  outputs = { ... }: {
-    checks =
-      import ./basic.nix;
-  };
+  outputs = { self, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: builtins.listToAttrs (map (system: { name = system; value = f system; }) systems);
+    in {
+      checks = forAllSystems (system:
+        import ./basic.nix { inherit system; }
+      );
+    };
 }

--- a/t/jobs/flake-hydraJobs/flake.nix
+++ b/t/jobs/flake-hydraJobs/flake.nix
@@ -1,6 +1,11 @@
 {
-  outputs = { ... }: {
-    hydraJobs =
-      import ./basic.nix;
-  };
+  outputs = { self, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: builtins.listToAttrs (map (system: { name = system; value = f system; }) systems);
+    in {
+      hydraJobs = forAllSystems (system:
+        import ./basic.nix { inherit system; }
+      );
+    };
 }


### PR DESCRIPTION
the current use of builtins.getFlake, mean we don't have pure evaluation