### PR TITLE
flake.nix: update to nixos-25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759652726,
-        "narHash": "sha256-2VjnimOYDRb3DZHyQ2WH2KCouFqYm9h0Rr007Al/WSA=",
+        "lastModified": 1764020296,
+        "narHash": "sha256-6zddwDs2n+n01l+1TG6PlyokDdXzu/oBmEejcH5L5+A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "06b2985f0cc9eb4318bf607168f4b15af1e5e81d",
+        "rev": "a320ce8e6e2cc6b4397eef214d202a50a4583829",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05-small",
+        "ref": "nixos-25.11-small",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A Nix-based continuous build system";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05-small";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11-small";
 
   inputs.nix = {
     url = "github:NixOS/nix/2.32-maintenance";
@@ -59,7 +59,7 @@
 
         manual = forEachSystem (system: let
           pkgs = nixpkgs.legacyPackages.${system};
-          hydra = self.packages.${pkgs.hostPlatform.system}.hydra;
+          hydra = self.packages.${pkgs.stdenv.hostPlatform.system}.hydra;
         in
           pkgs.runCommand "hydra-manual-${hydra.version}" { }
             ''

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -4,7 +4,7 @@
   hydra = { pkgs, lib,... }: {
     _file = ./default.nix;
     imports = [ ./hydra.nix ];
-    services.hydra-dev.package = lib.mkDefault self.packages.${pkgs.hostPlatform.system}.hydra;
+    services.hydra-dev.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.hydra;
   };
 
   hydraTest = { pkgs, ... }: {


### PR DESCRIPTION
And squashes eval warnings from accessing pkgs.hostPlatform.