### PR TITLE
fix: broken anchor tag in job.tt

### DIFF
--- a/src/root/job.tt
+++ b/src/root/job.tt
@@ -9,8 +9,8 @@
 [% INCLUDE includeFlot %]
 
 [% IF !jobExists(jobset, job) %]
-<div class="alert alert-warning">This job is not a member of the <a
-[% HTML.attributes(href => c.uri_for('/jobset' project.name jobset.name
+<div class="alert alert-warning">This job is not a member of the
+<a [% HTML.attributes(href => c.uri_for('/jobset' project.name jobset.name
 'evals')) %]>latest evaluation</a> of its jobset. This means it was
 removed or had an evaluation error.</div>
 [% END %]


### PR DESCRIPTION
Commit https://github.com/NixOS/hydra/commit/615798a51eba182b02a8747f86a4d1e61b5477b8 seems to have broken this link in https://hydra.nixos.org/job/nixpkgs/unstable/postgresql13Packages.pgvecto-rs.x86_64-linux due to a missing space:

<img width="1751" height="51" alt="image" src="https://github.com/user-attachments/assets/331333ca-a045-4fb1-8e02-f9251fa8b29f" />

This commit fixes it (tested locally).