### PR TITLE
feat: Offload git diffs to GitHub

### DIFF
--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -347,13 +347,23 @@ BLOCK renderDiffUri;
     url = res.0;
     branch = res.1;
     IF bi1.type == "hg" || bi1.type == "git" %]
-      <a target="_blank" [% HTML.attributes(href => c.uri_for('/api/scmdiff', {
-        uri = url,
-        rev1 = bi1.revision,
-        rev2 = bi2.revision,
-        type = bi1.type,
-        branch = branch
-      })) %]>[% HTML.escape(contents) %]</a>
+      [% IF url.substr(0, 19) == "https://github.com/" %]
+        <a target="_blank" [% HTML.attributes(href =>
+          url
+          _ "/compare/"
+          _ bi1.revision
+          _ "..."
+          _ bi2.revision,
+        ) %]>[% HTML.escape(contents) %]</a>
+      [% ELSE %]
+        <a target="_blank" [% HTML.attributes(href => c.uri_for('/api/scmdiff', {
+          uri = url,
+          rev1 = bi1.revision,
+          rev2 = bi2.revision,
+          type = bi1.type,
+          branch = branch
+        })) %]>[% HTML.escape(contents) %]</a>
+      [% END %]
     [% ELSE;
       contents;
     END;


### PR DESCRIPTION
If we are on GitHub, use their scm diff by default which is more feature-rich and offloads the diff work to stronger infrastructure