### PR TITLE
treewide: update split calls to make perlcritic happy

### DIFF
--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -106,11 +106,11 @@ sub doEmailLogin {
     my $allowed_domains = $c->config->{allowed_domains} // ($c->config->{persona_allowed_domains} // "");
     if ($allowed_domains ne "") {
         my $email_ok = 0;
-        my @domains = split ',', $allowed_domains;
+        my @domains = split /,/, $allowed_domains;
         map { $_ =~ s/^\s*(.*?)\s*$/$1/ } @domains;
 
         foreach my $domain (@domains) {
-            $email_ok = $email_ok || ((split '@', $email)[1] eq $domain);
+            $email_ok = $email_ok || ((split /@/, $email)[1] eq $domain);
         }
         error($c, "Your email address does not belong to a domain that is allowed to log in.\n")
             unless $email_ok;

--- a/src/lib/Hydra/Plugin/EmailNotification.pm
+++ b/src/lib/Hydra/Plugin/EmailNotification.pm
@@ -71,7 +71,7 @@ sub buildFinished {
 
         my $to = $build->jobset->emailoverride ne "" ? $build->jobset->emailoverride : $build->maintainers;
 
-        foreach my $address (split ",", ($to // "")) {
+        foreach my $address (split /,/, ($to // "")) {
             $address = trim $address;
 
             $addresses{$address} //= { builds => [] };

--- a/src/lib/Hydra/Plugin/GitInput.pm
+++ b/src/lib/Hydra/Plugin/GitInput.pm
@@ -38,7 +38,7 @@ sub _parseValue {
         $start_options = 2;
     }
     foreach my $option (@parts[$start_options .. $#parts]) {
-        (my $key, my $value) = split('=', $option);
+        (my $key, my $value) = split(/=/, $option);
         $options->{$key} = $value;
     }
     return ($uri, $branch, $deepClone, $options);
@@ -265,7 +265,7 @@ sub getCommits {
 
     my $res = [];
     foreach my $line (split /\n/, $out) {
-        my ($revision, $author, $email, $date) = split "\t", $line;
+        my ($revision, $author, $email, $date) = split /\t/, $line;
         push @$res, { revision => $revision, author => decode("utf-8", $author), email => $email };
     }
 

--- a/src/lib/Hydra/Plugin/GithubPulls.pm
+++ b/src/lib/Hydra/Plugin/GithubPulls.pm
@@ -31,10 +31,10 @@ sub _iterate {
         $pulls->{$pull->{number}} = $pull;
     }
     # TODO Make Link header parsing more robust!!!
-    my @links = split ',', ($res->header("Link") // "");
+    my @links = split /,/, ($res->header("Link") // "");
     my $next = "";
     foreach my $link (@links) {
-        my ($url, $rel) = split ";", $link;
+        my ($url, $rel) = split /;/, $link;
         if (trim($rel) eq 'rel="next"') {
             $next = substr trim($url), 1, -1;
             last;

--- a/src/lib/Hydra/Plugin/GithubRefs.pm
+++ b/src/lib/Hydra/Plugin/GithubRefs.pm
@@ -83,10 +83,10 @@ sub _iterate {
         $refs->{$ref_name} = $ref;
     }
     # TODO Make Link header parsing more robust!!!
-    my @links = split ',', $res->header("Link");
+    my @links = split /,/, $res->header("Link");
     my $next = "";
     foreach my $link (@links) {
-        my ($url, $rel) = split ";", $link;
+        my ($url, $rel) = split /;/, $link;
         if (trim($rel) eq 'rel="next"') {
             $next = substr trim($url), 1, -1;
             last;

--- a/src/lib/Hydra/Plugin/GitlabPulls.pm
+++ b/src/lib/Hydra/Plugin/GitlabPulls.pm
@@ -49,10 +49,10 @@ sub _iterate {
         $pulls->{$pull->{iid}} = $pull;
     }
     # TODO Make Link header parsing more robust!!!
-    my @links = split ',', $res->header("Link");
+    my @links = split /,/, $res->header("Link");
     my $next = "";
     foreach my $link (@links) {
-        my ($url, $rel) = split ";", $link;
+        my ($url, $rel) = split /;/, $link;
         if (trim($rel) eq 'rel="next"') {
             $next = substr trim($url), 1, -1;
             last;

--- a/src/lib/Hydra/Plugin/MercurialInput.pm
+++ b/src/lib/Hydra/Plugin/MercurialInput.pm
@@ -126,7 +126,7 @@ sub getCommits {
     my $res = [];
     foreach my $line (split /\n/, $out) {
         if ($line ne "") {
-            my ($revision, $author, $email) = split "\t", $line;
+            my ($revision, $author, $email) = split /\t/, $line;
             push @$res, { revision => $revision, author => $author, email => $email };
         }
     }

--- a/src/lib/Hydra/Plugin/RunCommand.pm
+++ b/src/lib/Hydra/Plugin/RunCommand.pm
@@ -85,7 +85,7 @@ sub isBuildEligibleForDynamicRunCommand {
 sub configSectionMatches {
     my ($name, $project, $jobset, $job) = @_;
 
-    my @elems = split ':', $name;
+    my @elems = split /:/, $name;
 
     die "invalid section name '$name'\n" if scalar(@elems) > 3;
 

--- a/t/queue-runner/notifications.t
+++ b/t/queue-runner/notifications.t
@@ -109,7 +109,7 @@ subtest "Build: not substitutable, unsubstitutable" => sub {
     subtest "Second notification: step_finished" => sub {
         my ($channelName, $pid, $payload) = @{$dbh->func("pg_notifies")};
         is($channelName, "step_finished", "The event is for the step finishing");
-        my ($buildId, $stepNr, $logFile) = split "\t", $payload;
+        my ($buildId, $stepNr, $logFile) = split /\t/, $payload;
         is($buildId, $build->id, "The payload is the build's ID");
         is($stepNr, 1, "The payload is the build's step number");
         isnt($logFile, undef, "The log file is passed");


### PR DESCRIPTION
In nixpkgs this started to fail the build due to an update of, I'm guessing, perlcritic.

Note that hydra currently doesn't build in nixpkgs due to other issues with libpqxx, but while working on that I ran into this. See ticket https://github.com/NixOS/nixpkgs/issues/476278 for background on that.