### PR TITLE
fix: Github diffs URL

### DIFF
--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -347,9 +347,10 @@ BLOCK renderDiffUri;
     url = res.0;
     branch = res.1;
     IF bi1.type == "hg" || bi1.type == "git" %]
-      [% IF url.substr(0, 19) == "https://github.com/" %]
+      [% IF url.substr(0, 19) == "https://github.com/";
+         github_url = url.replace('\.git$', '') %]
         <a target="_blank" [% HTML.attributes(href =>
-          url
+          github_url
           _ "/compare/"
           _ bi1.revision
           _ "..."


### PR DESCRIPTION
In https://github.com/NixOS/hydra/pull/1549 diffs were offloaded to github for performance reasons.

While in some endpoints github accepts `.git` suffixed in the repository name, in the comparison endpoint this does not seem to be the case.

Specifically, on the main nixos org hydra this isn't working:

Example job: https://hydra.nixos.org/build/320178054

Generates a comparison link like so:
https://github.com/NixOS/nixpkgs.git/compare/078d69f03934859a181e81ba987c2bb033eebfc5...1cd347bf3355fce6c64ab37d3967b4a2cb4b878c

This just stips away the suffix and seems to work fine in local testing.

cc @dasJ 