### PR TITLE
hydra-queue-runner: make drv available to remote pre-build-hook

### DIFF
--- a/src/hydra-queue-runner/build-remote.cc
+++ b/src/hydra-queue-runner/build-remote.cc
@@ -209,7 +209,9 @@ static BasicDerivation sendInputs(
             destStore.computeFSClosure(basicDrv.inputSrcs, closure);
             copyPaths(destStore, localStore, closure, NoRepair, NoCheckSigs, NoSubstitute);
         } else {
-            copyClosureTo(conn, destStore, basicDrv.inputSrcs, Substitute);
+            StorePathSet pathsToCopy = basicDrv.inputSrcs;
+            pathsToCopy.insert(step.drvPath);
+            copyClosureTo(conn, destStore, pathsToCopy, Substitute);
         }
 
         auto now2 = std::chrono::steady_clock::now();


### PR DESCRIPTION
For our use-case, [we](https://nixos-cuda.org/) need the pre-build-hook to have access to the `.drv` file of the derivation being built.
See https://github.com/NixOS/nix/issues/9272 for additional context.

Attached is a naive solution that we have tested on our infrastructure.
Please, instruct us on how to implement this properly.

cc @SomeoneSerge @YorikSar
