### PR TITLE
hydra-queue-runner: Allow '+' in product names

### DIFF
--- a/src/hydra-queue-runner/build-result.cc
+++ b/src/hydra-queue-runner/build-result.cc
@@ -93,7 +93,7 @@ BuildOutput getBuildOutput(
             if (file == narMembers.end()) continue;
 
             product.name = product.path == store->printStorePath(output) ? "" : baseNameOf(product.path.string());
-            if (!std::regex_match(product.name, std::regex("[a-zA-Z0-9.@:_ -]*")))
+            if (!std::regex_match(product.name, std::regex("[a-zA-Z0-9.@:_+ -]*")))
                 product.name = "";
 
             if (file->second.type == SourceAccessor::Type::tRegular) {


### PR DESCRIPTION
To account for filenames that contain "+". Commonly used in version strings (e.g. semantic versioning with build metadata such as `1.0.0+build1`).