### PR TITLE
Allow metrics that contain colons and brackets

### DIFF
--- a/subprojects/crates/shared/src/lib.rs
+++ b/subprojects/crates/shared/src/lib.rs
@@ -26,7 +26,7 @@ use nix_utils::{BaseStore as _, StorePath};
 
 #[allow(clippy::expect_used)]
 static VALIDATE_METRICS_NAME: LazyLock<regex::Regex> =
-    LazyLock::new(|| regex::Regex::new("[a-zA-Z0-9._-]+").expect("Failed to compile regex"));
+    LazyLock::new(|| regex::Regex::new("[a-zA-Z0-9._:\\[\\]-]+").expect("Failed to compile regex"));
 #[allow(clippy::expect_used)]
 static VALIDATE_METRICS_UNIT: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new("[a-zA-Z0-9._%-]+").expect("Failed to compile regex"));

--- a/subprojects/hydra-tests/Hydra/Plugin/RunCommand/json.t
+++ b/subprojects/hydra-tests/Hydra/Plugin/RunCommand/json.t
@@ -78,10 +78,11 @@ subtest "Validate the outputs match" => sub {
 };
 
 subtest "Validate the metrics match" => sub {
-    is(scalar(@{$dat->{metrics}}), 2, "There are exactly two metrics");
+    is(scalar(@{$dat->{metrics}}), 3, "There are exactly three metrics");
 
     my ($lineCoverage)  = grep { $_->{name} eq "lineCoverage" } @{$dat->{metrics}};
     my ($maxResident) = grep { $_->{name} eq "maxResident" } @{$dat->{metrics}};
+    my ($testFoo) = grep { $_->{name} eq "test_foo.py::best_bar[1]" } @{$dat->{metrics}};
 
     subtest "verifying the lineCoverage metric" => sub {
         is($lineCoverage->{name}, "lineCoverage", "The name matches.");
@@ -93,6 +94,12 @@ subtest "Validate the metrics match" => sub {
         is($maxResident->{name}, "maxResident", "The name matches.");
         is($maxResident->{value}, 27, "The value matches.");
         is($maxResident->{unit}, "KiB", "The unit matches.");
+    };
+
+    subtest "verifying the test_foo.py::best_bar[1] metric" => sub {
+        is($testFoo->{name}, "test_foo.py::best_bar[1]", "The name matches.");
+        is($testFoo->{value}, 42, "The value matches.");
+        is($testFoo->{unit}, undef, "The unit is undefined.");
     };
 };
 

--- a/subprojects/hydra-tests/jobs/runcommand.nix
+++ b/subprojects/hydra-tests/jobs/runcommand.nix
@@ -21,6 +21,7 @@ with import ./config.nix;
           mkdir -p "$(dirname "$metrics")"
           echo "lineCoverage 18 %" >> "$metrics"
           echo "maxResident 27 KiB" >> "$metrics"
+          echo "test_foo.py::best_bar[1] 42" >> "$metrics"
         '')
       ];
     })


### PR DESCRIPTION
On my personal hydra I've been using benchmarking metric names that are derived from pytest test names like `test_foo.py::test_bar[1]`. Since https://github.com/NixOS/hydra/pull/1449 these metrics are rendered correctly in the metrics tab. However since commit 0d3842aa2fa7f these metric names are no longer supported and (silently) don't get ingested anymore. With this commit I'm relaxing the strictness of the metric name regex in order to support ingesting these metrics again.

Ping @dasJ 