### PR TITLE
fix: Allow Github status to work on flakes with `?narHash...` in URL

### DIFF
--- a/src/lib/Hydra/Plugin/GithubStatus.pm
+++ b/src/lib/Hydra/Plugin/GithubStatus.pm
@@ -97,7 +97,7 @@ sub common {
                 if (defined $eval->flake) {
                     my $fl = $eval->flake;
                     print STDERR "Flake is $fl\n";
-                    if ($eval->flake =~ m!github:([^/]+)/([^/]+)/([[:xdigit:]]{40})$! or $eval->flake =~ m!git\+ssh://git\@github.com/([^/]+)/([^/]+)\?.*rev=([[:xdigit:]]{40})$!) {
+                    if ($eval->flake =~ m!github:([^/]+)/([^/]+)/([[:xdigit:]]{40})(\?narHash[^ ]*)?$! or $eval->flake =~ m!git\+ssh://git\@github.com/([^/]+)/([^/]+)\?.*rev=([[:xdigit:]]{40})(\?narHash[^ ]*)?$!) {
                         $sendStatus->("src", $1, $2, $3);
                     } else {
                         print STDERR "Can't parse flake, skipping GitHub status update\n";


### PR DESCRIPTION
GithubStatus plugin now works with Flake URLs such as `github:Lyndeno/hydra/1a276aff2aa1db7a8e11862bcb781002bfeb8564?narHash=sha256-ZwzZeI3XUhVoTCOpIohxCqcqWU4t4Yv84s1XGJ5%2BFPM%3D` whereas before the regex used would not recognize this as a valid flake.

Related to, but does not complete, #1563.