### PR TITLE
nix-utils: remove `FfiRealisation` wrapper, return `Realisation` directly from query

### DIFF
--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -689,8 +689,7 @@ impl S3BinaryCacheClient {
             return Ok(());
         }
 
-        let raw_realisation = store.query_raw_realisation(id)?;
-        let mut realisation = raw_realisation.as_rust()?;
+        let mut realisation = store.query_realisation(id)?;
         let keys = self
             .signing_keys
             .iter()

--- a/subprojects/crates/nix-utils/examples/realisation_query.rs
+++ b/subprojects/crates/nix-utils/examples/realisation_query.rs
@@ -11,8 +11,7 @@ async fn main() {
             .into_hash(),
         output_name: "debug".parse().unwrap(),
     };
-    let raw = local.query_raw_realisation(&id).unwrap();
-    let mut realisation = raw.as_rust().unwrap();
+    let mut realisation = local.query_realisation(&id).unwrap();
 
     println!("json: {}", serde_json::to_string(&realisation).unwrap());
     println!("realisation: {realisation:?}");

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -47,7 +47,7 @@ pub enum Error {
 }
 
 pub use drv::{Derivation, DerivationEnv, Output as DerivationOutput, query_drv};
-pub use realisation::{DrvOutput, FfiRealisation, Realisation, RealisationOperations, Signature};
+pub use realisation::{DrvOutput, Realisation, RealisationOperations, Signature};
 pub use realise::{BuildOptions, realise_drv, realise_drvs};
 pub use store_path::{
     StoreDir, StoreDirDisplay, StorePath, StorePathHash, StorePathName, parse_store_path,

--- a/subprojects/crates/nix-utils/src/realisation.rs
+++ b/subprojects/crates/nix-utils/src/realisation.rs
@@ -20,35 +20,20 @@ mod ffi {
     }
 }
 
-#[derive(Clone)]
-#[allow(missing_debug_implementations)]
-pub struct FfiRealisation {
-    inner: cxx::SharedPtr<ffi::InternalRealisation>,
+pub trait RealisationOperations {
+    fn query_realisation(&self, id: &DrvOutput) -> Result<Realisation, crate::Error>;
 }
-unsafe impl Send for FfiRealisation {}
-unsafe impl Sync for FfiRealisation {}
 
-impl FfiRealisation {
-    pub fn as_rust(&self) -> Result<Realisation, crate::Error> {
-        let json = self.inner.as_json();
+impl RealisationOperations for crate::BaseStoreImpl {
+    fn query_realisation(&self, id: &DrvOutput) -> Result<Realisation, crate::Error> {
+        let raw = ffi::query_raw_realisation(self.wrapper.as_raw(), &id.to_string())?;
+        let json = raw.as_json();
         Ok(serde_json::from_str(&json)?)
     }
 }
 
-pub trait RealisationOperations {
-    fn query_raw_realisation(&self, id: &DrvOutput) -> Result<FfiRealisation, crate::Error>;
-}
-
-impl RealisationOperations for crate::BaseStoreImpl {
-    fn query_raw_realisation(&self, id: &DrvOutput) -> Result<FfiRealisation, crate::Error> {
-        Ok(FfiRealisation {
-            inner: ffi::query_raw_realisation(self.wrapper.as_raw(), &id.to_string())?,
-        })
-    }
-}
-
 impl RealisationOperations for crate::LocalStore {
-    fn query_raw_realisation(&self, id: &DrvOutput) -> Result<FfiRealisation, crate::Error> {
-        self.base.query_raw_realisation(id)
+    fn query_realisation(&self, id: &DrvOutput) -> Result<Realisation, crate::Error> {
+        self.base.query_realisation(id)
     }
 }


### PR DESCRIPTION
Callers went through `FfiRealisation.as_rust()` to deserialize the JSON
into a `Realisation` every time. Inlining that into the trait method
removes the wrapper struct, the unsafe Send/Sync impls, and the extra
conversion step at each call site.