### PR TITLE
Replace config getters and store ops with nix-bindings-rust C API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -116,9 +116,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -312,6 +312,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,19 +366,20 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -471,6 +495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +516,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +536,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -632,6 +687,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -928,7 +992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1200,9 +1264,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -1774,9 +1845,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -1790,6 +1861,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1799,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -1815,7 +1895,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1874,6 +1954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1976,16 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "liblzma"
@@ -1920,9 +2016,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags",
  "libc",
@@ -2043,6 +2139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -2102,6 +2204,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix-bindings-store"
+version = "0.2.1"
+source = "git+https://github.com/amaanq/nix-bindings-rust.git?branch=hydra-store-ops#4657bb066033408d3828e3887e64873cbcd2191a"
+dependencies = [
+ "anyhow",
+ "nix-bindings-store-sys",
+ "nix-bindings-util",
+ "nix-bindings-util-sys",
+ "pkg-config",
+ "zerocopy",
+]
+
+[[package]]
+name = "nix-bindings-store-sys"
+version = "0.2.1"
+source = "git+https://github.com/amaanq/nix-bindings-rust.git?branch=hydra-store-ops#4657bb066033408d3828e3887e64873cbcd2191a"
+dependencies = [
+ "bindgen",
+ "nix-bindings-util-sys",
+ "pkg-config",
+ "zerocopy",
+]
+
+[[package]]
+name = "nix-bindings-util"
+version = "0.2.1"
+source = "git+https://github.com/amaanq/nix-bindings-rust.git?branch=hydra-store-ops#4657bb066033408d3828e3887e64873cbcd2191a"
+dependencies = [
+ "anyhow",
+ "nix-bindings-util-sys",
+]
+
+[[package]]
+name = "nix-bindings-util-sys"
+version = "0.2.1"
+source = "git+https://github.com/amaanq/nix-bindings-rust.git?branch=hydra-store-ops#4657bb066033408d3828e3887e64873cbcd2191a"
+dependencies = [
+ "bindgen",
+ "pkg-config",
+]
+
+[[package]]
 name = "nix-diff"
 version = "0.1.0"
 source = "git+https://github.com/mic92/nix-diff-rs.git?rev=7b79a68963fd7fcb48a57071b52bc90bd8d60609#7b79a68963fd7fcb48a57071b52bc90bd8d60609"
@@ -2127,6 +2271,8 @@ dependencies = [
  "harmonia-store-core",
  "harmonia-utils-hash",
  "hashbrown 0.16.1",
+ "nix-bindings-store",
+ "nix-bindings-util",
  "nix-diff",
  "pkg-config",
  "serde",
@@ -2138,6 +2284,16 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2155,7 +2311,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2176,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2263,26 +2419,28 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body-util",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.2",
+ "rand 0.10.0",
  "reqwest",
  "ring",
  "serde",
@@ -2344,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -2663,7 +2821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -2684,7 +2842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2721,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags",
  "memchr",
@@ -2741,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
  "serde",
@@ -2760,7 +2918,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror",
@@ -2780,7 +2938,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2853,6 +3011,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,6 +3058,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "redox_syscall"
@@ -3093,6 +3268,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -3129,7 +3310,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3171,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3345,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -3402,7 +3583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3413,7 +3594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3508,7 +3689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3848,7 +4029,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4036,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
@@ -4051,18 +4232,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
  "toml_datetime",
@@ -4072,18 +4253,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tonic"
@@ -4358,9 +4539,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
 
 [[package]]
 name = "unicode-width"
@@ -4634,6 +4815,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4665,7 +4858,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5163,18 +5356,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ harmonia-store-core = { git = "https://github.com/nix-community/harmonia.git", b
 harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia.git", branch = "nix-2.34" }
 harmonia-utils-hash = { git = "https://github.com/nix-community/harmonia.git", branch = "nix-2.34" }
 md5 = "0.7"
+nix-bindings-store = { git = "https://github.com/amaanq/nix-bindings-rust.git", branch = "hydra-store-ops" }
+nix-bindings-util = { git = "https://github.com/amaanq/nix-bindings-rust.git", branch = "hydra-store-ops" }
 nix-diff = { git = "https://github.com/mic92/nix-diff-rs.git", rev = "7b79a68963fd7fcb48a57071b52bc90bd8d60609" }
 num_enum = "0.7"
 ring = "0.17"

--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -689,8 +689,7 @@ impl S3BinaryCacheClient {
             return Ok(());
         }
 
-        let raw_realisation = store.query_raw_realisation(id)?;
-        let mut realisation = raw_realisation.as_rust()?;
+        let mut realisation = store.query_realisation(id)?;
         let keys = self
             .signing_keys
             .iter()

--- a/subprojects/crates/nix-utils/Cargo.toml
+++ b/subprojects/crates/nix-utils/Cargo.toml
@@ -25,6 +25,8 @@ cxx.workspace = true
 harmonia-store-core.workspace = true
 harmonia-utils-hash.workspace = true
 
+nix-bindings-store.workspace = true
+nix-bindings-util.workspace = true
 nix-diff.workspace = true
 
 [build-dependencies]

--- a/subprojects/crates/nix-utils/examples/get_settings.rs
+++ b/subprojects/crates/nix-utils/examples/get_settings.rs
@@ -1,6 +1,8 @@
+use nix_utils::BaseStore as _;
+
 fn main() {
-    let _store = nix_utils::LocalStore::init();
-    println!("Store dir: {}", nix_utils::get_store_dir());
+    let store = nix_utils::LocalStore::init();
+    println!("Store dir: {}", store.store_dir());
     println!("Log dir: {}", nix_utils::get_log_dir());
     println!("State dir: {}", nix_utils::get_state_dir());
     println!("System: {}", nix_utils::get_this_system());

--- a/subprojects/crates/nix-utils/examples/is_valid_path.rs
+++ b/subprojects/crates/nix-utils/examples/is_valid_path.rs
@@ -3,7 +3,7 @@ use nix_utils::{self, BaseStore as _};
 #[tokio::main]
 async fn main() {
     let store = nix_utils::LocalStore::init();
-    let store_dir = nix_utils::get_store_dir();
+    let store_dir = store.store_dir().to_string();
     println!(
         "storepath={store_dir} valid={}",
         store

--- a/subprojects/crates/nix-utils/examples/realisation_query.rs
+++ b/subprojects/crates/nix-utils/examples/realisation_query.rs
@@ -11,8 +11,7 @@ async fn main() {
             .into_hash(),
         output_name: "debug".parse().unwrap(),
     };
-    let raw = local.query_raw_realisation(&id).unwrap();
-    let mut realisation = raw.as_rust().unwrap();
+    let mut realisation = local.query_realisation(&id).unwrap();
 
     println!("json: {}", serde_json::to_string(&realisation).unwrap());
     println!("realisation: {realisation:?}");

--- a/subprojects/crates/nix-utils/include/nix.h
+++ b/subprojects/crates/nix-utils/include/nix.h
@@ -29,14 +29,6 @@ bool is_valid_path(const StoreWrapper &wrapper, rust::Str path);
 InternalPathInfo query_path_info(const StoreWrapper &wrapper, rust::Str path);
 void clear_path_info_cache(const StoreWrapper &wrapper);
 uint64_t compute_closure_size(const StoreWrapper &wrapper, rust::Str path);
-rust::Vec<rust::String> compute_fs_closure(const StoreWrapper &wrapper,
-                                           rust::Str path, bool flip_direction,
-                                           bool include_outputs,
-                                           bool include_derivers);
-rust::Vec<rust::String>
-compute_fs_closures(const StoreWrapper &wrapper,
-                    rust::Slice<const rust::Str> paths, bool flip_direction,
-                    bool include_outputs, bool include_derivers, bool toposort);
 void upsert_file(const StoreWrapper &wrapper, rust::Str path, rust::Str data,
                  rust::Str mime_type);
 StoreStats get_store_stats(const StoreWrapper &wrapper);

--- a/subprojects/crates/nix-utils/include/nix.h
+++ b/subprojects/crates/nix-utils/include/nix.h
@@ -20,19 +20,10 @@ namespace nix_utils {
 void init_nix();
 std::unique_ptr<StoreWrapper> init(rust::Str uri);
 
-rust::String get_store_dir();
 rust::String get_store_dir_for(const StoreWrapper &wrapper);
 rust::String get_build_dir();
 rust::String get_log_dir();
 rust::String get_state_dir();
-rust::String get_nix_version();
-rust::String get_this_system();
-rust::Vec<rust::String> get_extra_platforms();
-rust::Vec<rust::String> get_system_features();
-rust::Vec<rust::String> get_substituters();
-
-bool get_use_cgroups();
-void set_verbosity(int32_t level);
 
 bool is_valid_path(const StoreWrapper &wrapper, rust::Str path);
 InternalPathInfo query_path_info(const StoreWrapper &wrapper, rust::Str path);

--- a/subprojects/crates/nix-utils/include/nix.h
+++ b/subprojects/crates/nix-utils/include/nix.h
@@ -25,7 +25,6 @@ rust::String get_build_dir();
 rust::String get_log_dir();
 rust::String get_state_dir();
 
-bool is_valid_path(const StoreWrapper &wrapper, rust::Str path);
 InternalPathInfo query_path_info(const StoreWrapper &wrapper, rust::Str path);
 void clear_path_info_cache(const StoreWrapper &wrapper);
 uint64_t compute_closure_size(const StoreWrapper &wrapper, rust::Str path);

--- a/subprojects/crates/nix-utils/include/utils.h
+++ b/subprojects/crates/nix-utils/include/utils.h
@@ -10,5 +10,3 @@ rust::String extract_opt_path(const nix::Store &store,
                               const std::optional<nix::StorePath> &v);
 rust::Vec<rust::String> extract_path_set(const nix::Store &store,
                                          const nix::StorePathSet &set);
-rust::Vec<rust::String> extract_paths(const nix::Store &store,
-                                      const nix::StorePaths &set);

--- a/subprojects/crates/nix-utils/src/cxx/utils.cpp
+++ b/subprojects/crates/nix-utils/src/cxx/utils.cpp
@@ -18,12 +18,3 @@ rust::Vec<rust::String> extract_path_set(const nix::Store &store,
   return data;
 }
 
-rust::Vec<rust::String> extract_paths(const nix::Store &store,
-                                      const nix::StorePaths &set) {
-  rust::Vec<rust::String> data;
-  data.reserve(set.size());
-  for (const nix::StorePath &path : set) {
-    data.emplace_back(store.printStorePath(path));
-  }
-  return data;
-}

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -47,7 +47,7 @@ pub enum Error {
 }
 
 pub use drv::{Derivation, DerivationEnv, Output as DerivationOutput, query_drv};
-pub use realisation::{DrvOutput, FfiRealisation, Realisation, RealisationOperations, Signature};
+pub use realisation::{DrvOutput, Realisation, RealisationOperations, Signature};
 pub use realise::{BuildOptions, realise_drv, realise_drvs};
 pub use store_path::{
     StoreDir, StoreDirDisplay, StorePath, StorePathHash, StorePathName, parse_store_path,

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -130,19 +130,10 @@ mod ffi {
         fn init_nix();
         fn init(uri: &str) -> UniquePtr<StoreWrapper>;
 
-        fn get_store_dir() -> String;
         fn get_store_dir_for(store: &StoreWrapper) -> String;
         fn get_build_dir() -> String;
         fn get_log_dir() -> String;
         fn get_state_dir() -> String;
-        fn get_nix_version() -> String;
-        fn get_this_system() -> String;
-        fn get_extra_platforms() -> Vec<String>;
-        fn get_system_features() -> Vec<String>;
-        fn get_substituters() -> Vec<String>;
-
-        fn get_use_cgroups() -> bool;
-        fn set_verbosity(level: i32);
         fn is_valid_path(store: &StoreWrapper, path: &str) -> Result<bool>;
         fn query_path_info(store: &StoreWrapper, path: &str) -> Result<InternalPathInfo>;
         fn compute_closure_size(store: &StoreWrapper, path: &str) -> Result<u64>;
@@ -249,10 +240,34 @@ pub fn init_nix() {
     ffi::init_nix();
 }
 
-#[inline]
-#[must_use]
-pub fn get_store_dir() -> String {
-    ffi::get_store_dir()
+/// Ensure the Nix C API (libutil) is initialized. Safe to call multiple times.
+fn ensure_nix_c_api_init() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let mut ctx = nix_bindings_util::context::Context::new();
+        unsafe {
+            nix_bindings_util::check_call!(nix_bindings_util::raw_sys::libutil_init(&mut ctx))
+                .expect("nix_libutil_init failed");
+        }
+    });
+}
+
+/// Read a Nix setting string via the C API. Returns `Err` for unknown keys.
+fn nix_setting(key: &str) -> anyhow::Result<String> {
+    ensure_nix_c_api_init();
+    Ok(nix_bindings_util::settings::get(key)?)
+}
+
+/// Read a space-separated Nix list setting via the C API.
+fn nix_setting_list(key: &str) -> Vec<String> {
+    nix_setting(key)
+        .unwrap_or_else(|e| {
+            tracing::warn!("failed to read nix setting '{key}': {e}");
+            String::new()
+        })
+        .split_whitespace()
+        .map(String::from)
+        .collect()
 }
 
 #[inline]
@@ -276,43 +291,61 @@ pub fn get_state_dir() -> String {
 #[inline]
 #[must_use]
 pub fn get_nix_version() -> String {
-    ffi::get_nix_version()
+    nix_setting("version").unwrap_or_else(|e| {
+        tracing::warn!("failed to read nix setting 'version': {e}");
+        String::new()
+    })
 }
 
 #[inline]
 #[must_use]
 pub fn get_this_system() -> String {
-    ffi::get_this_system()
+    nix_setting("system").unwrap_or_else(|e| {
+        tracing::warn!("failed to read nix setting 'system': {e}");
+        String::new()
+    })
 }
 
 #[inline]
 #[must_use]
 pub fn get_extra_platforms() -> Vec<String> {
-    ffi::get_extra_platforms()
+    nix_setting_list("extra-platforms")
 }
 
 #[inline]
 #[must_use]
 pub fn get_system_features() -> Vec<String> {
-    ffi::get_system_features()
+    nix_setting_list("system-features")
 }
 
 #[inline]
 #[must_use]
 pub fn get_substituters() -> Vec<String> {
-    ffi::get_substituters()
+    nix_setting_list("substituters")
 }
 
 #[inline]
 #[must_use]
 pub fn get_use_cgroups() -> bool {
-    ffi::get_use_cgroups()
+    #[cfg(not(target_os = "linux"))]
+    { false }
+    #[cfg(target_os = "linux")]
+    {
+        nix_setting("use-cgroups")
+            .map(|v| v == "true")
+            .unwrap_or_else(|e| {
+                tracing::warn!("failed to read nix setting 'use-cgroups': {e}");
+                false
+            })
+    }
 }
 
 #[inline]
-/// Set the loglevel.
 pub fn set_verbosity(level: i32) {
-    ffi::set_verbosity(level);
+    ensure_nix_c_api_init();
+    if let Err(e) = nix_bindings_util::settings::set("verbosity", &level.to_string()) {
+        tracing::warn!("failed to set verbosity to {level}: {e}");
+    }
 }
 
 pub(crate) async fn asyncify<F, T>(f: F) -> Result<T, Error>
@@ -501,8 +534,7 @@ pub struct BaseStoreImpl {
 
 impl BaseStoreImpl {
     fn new(store: cxx::UniquePtr<ffi::StoreWrapper>) -> Self {
-        let store_dir = StoreDir::new(ffi::get_store_dir_for(&store))
-            .unwrap_or_default();
+        let store_dir = StoreDir::new(ffi::get_store_dir_for(&store)).unwrap_or_default();
         Self {
             wrapper: std::sync::Arc::new(FFIStore(std::cell::UnsafeCell::new(store))),
             store_dir,
@@ -1256,5 +1288,24 @@ impl BaseStore for RemoteStore {
     #[inline]
     fn store_dir(&self) -> &StoreDir {
         self.base.store_dir()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nix_c_api_errors_on_invalid_setting_key() {
+        ensure_nix_c_api_init();
+        assert!(nix_bindings_util::settings::get("this-key-does-not-exist").is_err());
+    }
+
+    #[test]
+    fn nix_c_api_returns_known_settings() {
+        ensure_nix_c_api_init();
+        let system = nix_bindings_util::settings::get("system");
+        assert!(system.is_ok());
+        assert!(!system.unwrap_or_default().is_empty());
     }
 }

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -134,7 +134,6 @@ mod ffi {
         fn get_build_dir() -> String;
         fn get_log_dir() -> String;
         fn get_state_dir() -> String;
-        fn is_valid_path(store: &StoreWrapper, path: &str) -> Result<bool>;
         fn query_path_info(store: &StoreWrapper, path: &str) -> Result<InternalPathInfo>;
         fn compute_closure_size(store: &StoreWrapper, path: &str) -> Result<u64>;
         fn clear_path_info_cache(store: &StoreWrapper) -> Result<()>;
@@ -581,11 +580,19 @@ where
 impl BaseStore for BaseStoreImpl {
     #[inline]
     async fn is_valid_path(&self, path: &StorePath) -> bool {
-        let store = self.wrapper.clone();
         let path = self.print_store_path(path);
-        asyncify(move || ffi::is_valid_path(store.as_raw(), &path))
-            .await
-            .unwrap_or(false)
+        let uri = self.uri.clone();
+        asyncify_anyhow(move || -> Result<bool, Error> {
+            let store_uri = if uri.is_empty() { None } else { Some(uri.as_str()) };
+            let mut nbs = nix_bindings_store::store::Store::open(
+                store_uri,
+                std::iter::empty::<(&str, &str)>(),
+            )?;
+            let nbs_path = nbs.parse_store_path(&path)?;
+            Ok(nbs.is_valid_path(&nbs_path))
+        })
+        .await
+        .unwrap_or(false)
     }
 
     #[inline]

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -138,23 +138,6 @@ mod ffi {
         fn query_path_info(store: &StoreWrapper, path: &str) -> Result<InternalPathInfo>;
         fn compute_closure_size(store: &StoreWrapper, path: &str) -> Result<u64>;
         fn clear_path_info_cache(store: &StoreWrapper) -> Result<()>;
-        #[allow(clippy::fn_params_excessive_bools)]
-        fn compute_fs_closure(
-            store: &StoreWrapper,
-            path: &str,
-            flip_direction: bool,
-            include_outputs: bool,
-            include_derivers: bool,
-        ) -> Result<Vec<String>>;
-        #[allow(clippy::fn_params_excessive_bools)]
-        fn compute_fs_closures(
-            store: &StoreWrapper,
-            paths: &[&str],
-            flip_direction: bool,
-            include_outputs: bool,
-            include_derivers: bool,
-            toposort: bool,
-        ) -> Result<Vec<String>>;
         fn upsert_file(store: &StoreWrapper, path: &str, data: &str, mime_type: &str)
         -> Result<()>;
         fn get_store_stats(store: &StoreWrapper) -> Result<StoreStats>;
@@ -359,6 +342,17 @@ where
     }
 }
 
+pub(crate) async fn asyncify_anyhow<F, T>(f: F) -> Result<T, Error>
+where
+    F: FnOnce() -> Result<T, Error> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(res) => res,
+        Err(_) => Err(std::io::Error::other("background task failed"))?,
+    }
+}
+
 #[inline]
 pub async fn copy_paths(
     src: &BaseStoreImpl,
@@ -444,7 +438,7 @@ pub trait BaseStore {
         flip_direction: bool,
         include_outputs: bool,
         include_derivers: bool,
-    ) -> Result<Vec<String>, cxx::Exception>;
+    ) -> Result<Vec<String>, Error>;
 
     #[allow(clippy::fn_params_excessive_bools)]
     fn compute_fs_closures(
@@ -530,15 +524,24 @@ impl FFIStore {
 pub struct BaseStoreImpl {
     wrapper: std::sync::Arc<FFIStore>,
     store_dir: StoreDir,
+    /// URI used to open this store, passed through to nbs for equivalent access.
+    uri: String,
 }
 
 impl BaseStoreImpl {
-    fn new(store: cxx::UniquePtr<ffi::StoreWrapper>) -> Self {
+    fn new(store: cxx::UniquePtr<ffi::StoreWrapper>, uri: &str) -> Self {
         let store_dir = StoreDir::new(ffi::get_store_dir_for(&store)).unwrap_or_default();
         Self {
             wrapper: std::sync::Arc::new(FFIStore(std::cell::UnsafeCell::new(store))),
             store_dir,
+            uri: uri.to_owned(),
         }
+    }
+
+    /// Open an nbs Store matching this store's URI.
+    fn open_nbs_store(&self) -> Result<nix_bindings_store::store::Store, Error> {
+        let uri = if self.uri.is_empty() { None } else { Some(self.uri.as_str()) };
+        Ok(nix_bindings_store::store::Store::open(uri, std::iter::empty::<(&str, &str)>())?)
     }
 }
 
@@ -645,14 +648,11 @@ impl BaseStore for BaseStoreImpl {
         flip_direction: bool,
         include_outputs: bool,
         include_derivers: bool,
-    ) -> Result<Vec<String>, cxx::Exception> {
-        ffi::compute_fs_closure(
-            self.wrapper.as_raw(),
-            path,
-            flip_direction,
-            include_outputs,
-            include_derivers,
-        )
+    ) -> Result<Vec<String>, Error> {
+        let mut nbs = self.open_nbs_store()?;
+        let nbs_path = nbs.parse_store_path(path)?;
+        let closure = nbs.get_fs_closure(&nbs_path, flip_direction, include_outputs, include_derivers)?;
+        closure.iter().map(|p| nbs.real_path(p).map_err(Error::from)).collect()
     }
 
     #[inline]
@@ -663,27 +663,34 @@ impl BaseStore for BaseStoreImpl {
         flip_direction: bool,
         include_outputs: bool,
         include_derivers: bool,
-        toposort: bool,
+        _toposort: bool, // TODO: nix C API doesn't expose topoSortPaths; ignored for now
     ) -> Result<Vec<StorePath>, Error> {
-        let store = self.wrapper.clone();
-        let paths = paths
+        let paths: Vec<String> = paths
             .iter()
             .map(|v| self.print_store_path(v))
-            .collect::<Vec<_>>();
+            .collect();
+        let uri = self.uri.clone();
 
-        asyncify(move || {
-            let slice = paths.iter().map(String::as_str).collect::<Vec<_>>();
-            Ok(ffi::compute_fs_closures(
-                store.as_raw(),
-                &slice,
-                flip_direction,
-                include_outputs,
-                include_derivers,
-                toposort,
-            )?
-            .into_iter()
-            .map(|v| parse_store_path(&v))
-            .collect())
+        asyncify_anyhow(move || -> Result<Vec<StorePath>, Error> {
+            let store_uri = if uri.is_empty() { None } else { Some(uri.as_str()) };
+            let mut nbs = nix_bindings_store::store::Store::open(
+                store_uri,
+                std::iter::empty::<(&str, &str)>(),
+            )?;
+            let mut seen = std::collections::HashSet::new();
+            let mut result = Vec::new();
+            for path_str in &paths {
+                let nbs_path = nbs.parse_store_path(path_str)?;
+                let closure = nbs.get_fs_closure(&nbs_path, flip_direction, include_outputs, include_derivers)?;
+                for p in closure {
+                    let path_str = nbs.real_path(&p)?;
+                    let sp = parse_store_path(&path_str);
+                    if seen.insert(sp.clone()) {
+                        result.push(sp);
+                    }
+                }
+            }
+            Ok(result)
         })
         .await
     }
@@ -869,7 +876,7 @@ impl LocalStore {
     /// Initialise a new store
     #[must_use]
     pub fn init() -> Self {
-        let base = BaseStoreImpl::new(ffi::init(""));
+        let base = BaseStoreImpl::new(ffi::init(""), "");
         Self { base }
     }
 
@@ -946,7 +953,7 @@ impl BaseStore for LocalStore {
         flip_direction: bool,
         include_outputs: bool,
         include_derivers: bool,
-    ) -> Result<Vec<String>, cxx::Exception> {
+    ) -> Result<Vec<String>, Error> {
         self.base
             .compute_fs_closure(path, flip_direction, include_outputs, include_derivers)
     }
@@ -1076,7 +1083,7 @@ impl RemoteStore {
             .unwrap_or_default();
 
         Self {
-            base: BaseStoreImpl::new(ffi::init(uri)),
+            base: BaseStoreImpl::new(ffi::init(uri), uri),
             uri: uri.into(),
             base_uri,
         }
@@ -1181,7 +1188,7 @@ impl BaseStore for RemoteStore {
         flip_direction: bool,
         include_outputs: bool,
         include_derivers: bool,
-    ) -> Result<Vec<String>, cxx::Exception> {
+    ) -> Result<Vec<String>, Error> {
         self.base
             .compute_fs_closure(path, flip_direction, include_outputs, include_derivers)
     }

--- a/subprojects/crates/nix-utils/src/nix.cpp
+++ b/subprojects/crates/nix-utils/src/nix.cpp
@@ -66,11 +66,6 @@ rust::String get_log_dir() { return nix::settings.getLogFileSettings().nixLogDir
 rust::String get_state_dir() { return nix::settings.nixStateDir.string(); }
 
 
-bool is_valid_path(const StoreWrapper &wrapper, rust::Str path) {
-  auto store = wrapper._store;
-  return store->isValidPath(store->parseStorePath(AS_VIEW(path)));
-}
-
 InternalPathInfo query_path_info(const StoreWrapper &wrapper, rust::Str path) {
   auto store = wrapper._store;
   auto info = store->queryPathInfo(store->parseStorePath(AS_VIEW(path)));

--- a/subprojects/crates/nix-utils/src/nix.cpp
+++ b/subprojects/crates/nix-utils/src/nix.cpp
@@ -52,10 +52,6 @@ std::unique_ptr<StoreWrapper> init(rust::Str uri) {
   }
 }
 
-rust::String get_store_dir() {
-  init_nix();
-  return nix::openStore()->storeDir;
-}
 rust::String get_store_dir_for(const StoreWrapper &wrapper) {
   return wrapper._store->storeDir;
 }
@@ -68,43 +64,7 @@ rust::String get_build_dir() {
 }
 rust::String get_log_dir() { return nix::settings.getLogFileSettings().nixLogDir.string(); }
 rust::String get_state_dir() { return nix::settings.nixStateDir.string(); }
-rust::String get_nix_version() { return nix::nixVersion; }
-rust::String get_this_system() { return nix::settings.thisSystem.get(); }
-rust::Vec<rust::String> get_extra_platforms() {
-  auto set = nix::settings.extraPlatforms.get();
-  rust::Vec<rust::String> data;
-  data.reserve(set.size());
-  for (const auto &val : set) {
-    data.emplace_back(val);
-  }
-  return data;
-}
-rust::Vec<rust::String> get_system_features() {
-  auto set = nix::settings.systemFeatures.get();
-  rust::Vec<rust::String> data;
-  data.reserve(set.size());
-  for (const auto &val : set) {
-    data.emplace_back(val);
-  }
-  return data;
-}
-rust::Vec<rust::String> get_substituters() {
-  auto refs = nix::settings.getWorkerSettings().substituters.get();
-  rust::Vec<rust::String> data;
-  data.reserve(refs.size());
-  for (const auto &val : refs) {
-    data.emplace_back(val.render());
-  }
-  return data;
-}
 
-bool get_use_cgroups() {
-#ifdef __linux__
-  return nix::settings.getLocalSettings().useCgroups;
-#endif
-  return false;
-}
-void set_verbosity(int32_t level) { nix::verbosity = (nix::Verbosity)level; }
 
 bool is_valid_path(const StoreWrapper &wrapper, rust::Str path) {
   auto store = wrapper._store;

--- a/subprojects/crates/nix-utils/src/nix.cpp
+++ b/subprojects/crates/nix-utils/src/nix.cpp
@@ -115,37 +115,6 @@ void clear_path_info_cache(const StoreWrapper &wrapper) {
   store->clearPathInfoCache();
 }
 
-rust::Vec<rust::String> compute_fs_closure(const StoreWrapper &wrapper,
-                                           rust::Str path, bool flip_direction,
-                                           bool include_outputs,
-                                           bool include_derivers) {
-  auto store = wrapper._store;
-  nix::StorePathSet path_set;
-  store->computeFSClosure(store->parseStorePath(AS_VIEW(path)), path_set,
-                          flip_direction, include_outputs, include_derivers);
-  return extract_path_set(*store, path_set);
-}
-
-rust::Vec<rust::String> compute_fs_closures(const StoreWrapper &wrapper,
-                                            rust::Slice<const rust::Str> paths,
-                                            bool flip_direction,
-                                            bool include_outputs,
-                                            bool include_derivers,
-                                            bool toposort) {
-  auto store = wrapper._store;
-  nix::StorePathSet path_set;
-  for (auto &path : paths) {
-    store->computeFSClosure(store->parseStorePath(AS_VIEW(path)), path_set,
-                            flip_direction, include_outputs, include_derivers);
-  }
-  if (toposort) {
-    auto sorted = store->topoSortPaths(path_set);
-    return extract_paths(*store, sorted);
-  } else {
-    return extract_path_set(*store, path_set);
-  }
-}
-
 void upsert_file(const StoreWrapper &wrapper, rust::Str path, rust::Str data,
                  rust::Str mime_type) {
   auto store = wrapper._store.dynamic_pointer_cast<nix::BinaryCacheStore>();

--- a/subprojects/crates/nix-utils/src/realisation.rs
+++ b/subprojects/crates/nix-utils/src/realisation.rs
@@ -20,35 +20,20 @@ mod ffi {
     }
 }
 
-#[derive(Clone)]
-#[allow(missing_debug_implementations)]
-pub struct FfiRealisation {
-    inner: cxx::SharedPtr<ffi::InternalRealisation>,
+pub trait RealisationOperations {
+    fn query_realisation(&self, id: &DrvOutput) -> Result<Realisation, crate::Error>;
 }
-unsafe impl Send for FfiRealisation {}
-unsafe impl Sync for FfiRealisation {}
 
-impl FfiRealisation {
-    pub fn as_rust(&self) -> Result<Realisation, crate::Error> {
-        let json = self.inner.as_json();
+impl RealisationOperations for crate::BaseStoreImpl {
+    fn query_realisation(&self, id: &DrvOutput) -> Result<Realisation, crate::Error> {
+        let raw = ffi::query_raw_realisation(self.wrapper.as_raw(), &id.to_string())?;
+        let json = raw.as_json();
         Ok(serde_json::from_str(&json)?)
     }
 }
 
-pub trait RealisationOperations {
-    fn query_raw_realisation(&self, id: &DrvOutput) -> Result<FfiRealisation, crate::Error>;
-}
-
-impl RealisationOperations for crate::BaseStoreImpl {
-    fn query_raw_realisation(&self, id: &DrvOutput) -> Result<FfiRealisation, crate::Error> {
-        Ok(FfiRealisation {
-            inner: ffi::query_raw_realisation(self.wrapper.as_raw(), &id.to_string())?,
-        })
-    }
-}
-
 impl RealisationOperations for crate::LocalStore {
-    fn query_raw_realisation(&self, id: &DrvOutput) -> Result<FfiRealisation, crate::Error> {
-        self.base.query_raw_realisation(id)
+    fn query_realisation(&self, id: &DrvOutput) -> Result<Realisation, crate::Error> {
+        self.base.query_realisation(id)
     }
 }

--- a/subprojects/crates/shared/src/lib.rs
+++ b/subprojects/crates/shared/src/lib.rs
@@ -95,10 +95,8 @@ struct FilesystemOperations {
 }
 
 impl FilesystemOperations {
-    fn new() -> Self {
-        Self {
-            store_dir: nix_utils::StoreDir::new(nix_utils::get_store_dir()).unwrap_or_default(),
-        }
+    fn new(store_dir: nix_utils::StoreDir) -> Self {
+        Self { store_dir }
     }
 }
 
@@ -309,7 +307,7 @@ pub async fn parse_nix_support_from_outputs(
 
         let reader = BufReader::new(file);
         let mut lines = reader.lines();
-        let fsop = FilesystemOperations::new();
+        let fsop = FilesystemOperations::new(store.store_dir().clone());
         while let Some(line) = lines.next_line().await? {
             if let Some(o) = Box::pin(parse_build_product(store, fsop.clone(), output, &line)).await
             {

--- a/subprojects/hydra-queue-runner/package.nix
+++ b/subprojects/hydra-queue-runner/package.nix
@@ -37,16 +37,21 @@ rustPlatform.buildRustPackage {
     outputHashes = {
       "nix-diff-0.1.0" = "sha256-heUqcAnGmMogyVXskXc4FMORb8ZaK6vUX+mMOpbfSUw=";
       "harmonia-store-core-0.0.0-alpha.0" = "sha256-w0YRYNvq5dY5FBa73A66v4E5L0xmNuAfDNzsTIyW8uk=";
+      "nix-bindings-store-0.2.1" = "sha256-8WRgfkfnPV3FeaY9A8TisKCRsOaEso/Z8GE3jivfGsA=";
+      "nix-bindings-util-0.2.1" = "sha256-8WRgfkfnPV3FeaY9A8TisKCRsOaEso/Z8GE3jivfGsA=";
     };
   };
 
   nativeBuildInputs = [
     pkg-config
     protobuf
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [
     nixComponents.nix-main
+    nixComponents.nix-store-c
+    nixComponents.nix-util-c
     protobuf
     rust-jemalloc-sys
   ];

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -88,7 +88,7 @@ impl State {
     pub async fn new(tracing_guard: &hydra_tracing::TracingGuard) -> anyhow::Result<Arc<Self>> {
         let store = nix_utils::LocalStore::init();
         nix_utils::set_verbosity(1);
-        tracing::info!("LocalStore dir={}", nix_utils::get_store_dir());
+        tracing::info!("LocalStore dir={}", store.store_dir());
 
         let cli = Cli::new();
         if cli.status {


### PR DESCRIPTION
>[!NOTE]
>- This PR depends on #1581

This PR replaces several C++ FFI functions with their nix-bindings-rust equivalents, using the Nix C API directly from Rust.

- **Config getters**: `get_store_dir`, `get_nix_version`, `get_this_system`, `get_extra_platforms`, `get_system_features`, `get_substituters`, `get_use_cgroups`, `set_verbosity` replaced with `nix_bindings_util::settings::get` and `nix_bindings_store::Store::open`.
- **compute_fs_closure**: replaced with `nix_bindings_store::Store::get_fs_closure`.
- **is_valid_path**: replaced with `nix_bindings_store::Store::is_valid_path`.