### PR TITLE
Don't pass resolved_drv to the builder

### DIFF
--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -400,11 +400,6 @@ impl State {
 
         let machine_id = self.id;
         let drv = nix_utils::parse_store_path(&m.drv);
-        let resolved_drv = m
-            .resolved_drv
-            .as_ref()
-            .map(|v| nix_utils::parse_store_path(v));
-        let maybe_resolved_drv = resolved_drv.as_ref().unwrap_or(&drv);
 
         let before_import = Instant::now();
         let gcroot_prefix = uuid::Uuid::new_v4().to_string();
@@ -422,7 +417,7 @@ impl State {
             .await;
         let requisites = client
             .fetch_drv_requisites(FetchRequisitesRequest {
-                path: maybe_resolved_drv.to_string().to_owned(),
+                path: drv.to_string().to_owned(),
                 include_outputs: false,
             })
             .await
@@ -435,7 +430,7 @@ impl State {
             store.clone(),
             self.metrics.clone(),
             &gcroot,
-            maybe_resolved_drv,
+            &drv,
             requisites
                 .into_iter()
                 .map(|s| nix_utils::parse_store_path(&s)),
@@ -456,7 +451,7 @@ impl State {
         let before_build = Instant::now();
         let (mut child, stdout, mut stderr) = nix_utils::realise_drv(
             &store,
-            maybe_resolved_drv,
+            &drv,
             &nix_utils::BuildOptions::complete(m.max_log_size, m.max_silent_time, m.build_timeout),
             true,
         )
@@ -516,7 +511,7 @@ impl State {
             .store_dir()
             .parse(&output_raw[0].drv_path)
             .map_err(|e: nix_utils::ParseStorePathError| JobFailure::PostProcessing(e.into()))?;
-        if &actual_out_drv != maybe_resolved_drv {
+        if actual_out_drv != drv {
             return Err(JobFailure::PostProcessing(anyhow::anyhow!(
                 "Nix returned outputs for {actual_out_drv} when we expected {drv}"
             )));

--- a/subprojects/hydra-queue-runner/src/io/machine.rs
+++ b/subprojects/hydra-queue-runner/src/io/machine.rs
@@ -176,7 +176,7 @@ impl Machine {
         sort_fn: crate::config::MachineSortFn,
         free_fn: crate::config::MachineFreeFn,
     ) -> Self {
-        let jobs = { item.jobs.read().iter().map(|j| j.path.clone()).collect() };
+        let jobs = { item.jobs.read().iter().map(|j| j.drv.clone()).collect() };
         let time = jiff::Timestamp::now();
         Self {
             systems: item.systems.clone(),

--- a/subprojects/hydra-queue-runner/src/state/machine.rs
+++ b/subprojects/hydra-queue-runner/src/state/machine.rs
@@ -490,23 +490,17 @@ impl Machines {
 #[derive(Debug, Clone)]
 pub struct Job {
     pub internal_build_id: uuid::Uuid,
-    pub path: nix_utils::StorePath,
-    pub resolved_drv: Option<nix_utils::StorePath>,
+    pub drv: nix_utils::StorePath,
     pub build_id: BuildID,
     pub step_nr: i32,
     pub result: RemoteBuild,
 }
 
 impl Job {
-    pub fn new(
-        build_id: BuildID,
-        path: nix_utils::StorePath,
-        resolved_drv: Option<nix_utils::StorePath>,
-    ) -> Self {
+    pub fn new(build_id: BuildID, drv: nix_utils::StorePath) -> Self {
         Self {
             internal_build_id: uuid::Uuid::new_v4(),
-            path,
-            resolved_drv,
+            drv,
             build_id,
             step_nr: 0,
             result: RemoteBuild::new(),
@@ -538,7 +532,6 @@ pub enum Message {
     BuildMessage {
         build_id: uuid::Uuid,
         drv: nix_utils::StorePath,
-        resolved_drv: Option<nix_utils::StorePath>,
         max_log_size: u64,
         max_silent_time: i32,
         build_timeout: i32,
@@ -560,7 +553,6 @@ impl Message {
             Self::BuildMessage {
                 build_id,
                 drv,
-                resolved_drv,
                 max_log_size,
                 max_silent_time,
                 build_timeout,
@@ -568,7 +560,6 @@ impl Message {
             } => runner_request::Message::Build(BuildMessage {
                 build_id: build_id.to_string(),
                 drv: drv.to_string(),
-                resolved_drv: resolved_drv.map(|p| p.to_string()),
                 max_log_size,
                 max_silent_time,
                 build_timeout,
@@ -697,12 +688,10 @@ impl Machine {
         opts: &nix_utils::BuildOptions,
         presigned_url_opts: Option<PresignedUrlOpts>,
     ) -> anyhow::Result<()> {
-        let drv = job.path.clone();
         self.msg_queue
             .send(Message::BuildMessage {
                 build_id: job.internal_build_id,
-                drv,
-                resolved_drv: job.resolved_drv.clone(),
+                drv: job.drv.clone(),
                 max_log_size: opts.get_max_log_size(),
                 max_silent_time: opts.get_max_silent_time(),
                 build_timeout: opts.get_build_timeout(),
@@ -842,7 +831,7 @@ impl Machine {
     pub fn get_build_id_and_step_nr(&self, drv: &nix_utils::StorePath) -> Option<(i32, i32)> {
         let jobs = self.jobs.read();
         jobs.iter()
-            .find(|j| &j.path == drv)
+            .find(|j| &j.drv == drv)
             .map(|j| (j.build_id, j.step_nr))
     }
 
@@ -859,14 +848,14 @@ impl Machine {
         let jobs = self.jobs.read();
         jobs.iter()
             .find(|j| j.internal_build_id == build_id)
-            .map(|v| v.path.clone())
+            .map(|v| v.drv.clone())
     }
 
     #[tracing::instrument(skip(self), fields(%drv))]
     pub fn get_internal_build_id_for_drv(&self, drv: &nix_utils::StorePath) -> Option<uuid::Uuid> {
         let jobs = self.jobs.read();
         jobs.iter()
-            .find(|j| &j.path == drv)
+            .find(|j| &j.drv == drv)
             .map(|v| v.internal_build_id)
     }
 
@@ -881,8 +870,8 @@ impl Machine {
     pub fn remove_job(&self, drv: &nix_utils::StorePath) -> Option<Job> {
         let job = {
             let mut jobs = self.jobs.write();
-            let job = jobs.iter().find(|j| &j.path == drv).cloned();
-            jobs.retain(|j| &j.path != drv);
+            let job = jobs.iter().find(|j| &j.drv == drv).cloned();
+            jobs.retain(|j| &j.drv != drv);
             self.stats.incr_nr_steps_done();
             self.stats.store_current_jobs(jobs.len() as u64);
             job

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -237,7 +237,7 @@ impl State {
                 if let Err(e) = self
                     .fail_step(
                         machine_id,
-                        &job.path,
+                        &job.drv,
                         // we fail this with preparing because we kinda want to restart all jobs if
                         // a machine is removed
                         BuildResultState::PreparingFailure,
@@ -247,7 +247,7 @@ impl State {
                 {
                     tracing::error!(
                         "Failed to fail step machine_id={machine_id} drv={} e={e}",
-                        job.path
+                        job.drv
                     );
                 }
             }
@@ -319,8 +319,7 @@ impl State {
 
         let mut job = machine::Job::new(
             build_id,
-            drv.to_owned(),
-            step_info.resolved_drv_path.clone(),
+            step_info.resolved_drv_path.as_ref().unwrap_or(drv).clone(),
         );
         job.result.set_start_time_now();
         if self.check_cached_failure(step_info.step.clone()).await {
@@ -1133,7 +1132,7 @@ impl State {
                 self.uploader
                     .schedule_upload(
                         outputs_to_upload,
-                        format!("log/{}", job.path.to_string()),
+                        format!("log/{}", job.drv.to_string()),
                         job.result.log_file.clone(),
                     )
                     .await;
@@ -2087,7 +2086,7 @@ impl State {
                 continue;
             };
 
-            let mut job = machine::Job::new(build.id, drv.to_owned(), None);
+            let mut job = machine::Job::new(build.id, drv.to_owned());
             job.result.set_start_and_stop(now);
             job.result.step_status = BuildStatus::Unsupported;
             job.result.error_msg = Some(format!(

--- a/subprojects/proto/v1/streaming.proto
+++ b/subprojects/proto/v1/streaming.proto
@@ -124,7 +124,6 @@ message PresignedUploadOpts {
 message BuildMessage {
   string build_id = 1; // UUIDv4
   string drv = 2;
-  optional string resolved_drv = 3;
   uint64 max_log_size = 4;
   int32 max_silent_time = 5;
   int32 build_timeout = 6;


### PR DESCRIPTION
Whenever possible, only a resolved derivation should be passed around. Remove all the separation between "resolved" and "unresolved" derivation past `Job`, including in the builder.