### PR TITLE
fix: Remove println that exposed secrets

### DIFF
--- a/subprojects/crates/binary-cache/src/cfg.rs
+++ b/subprojects/crates/binary-cache/src/cfg.rs
@@ -396,7 +396,6 @@ fn parse_aws_credentials_file(
     >,
     profile: &str,
 ) -> Result<(String, secrecy::SecretString), ConfigReadError> {
-    println!("config_map: {config_map:?}");
     let profile_map = if let Some(profile_map) = config_map.get(profile) {
         profile_map
     } else if let Some(profile_map) = config_map.get(&format!("profile {profile}")) {
@@ -494,11 +493,6 @@ aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvbSTAGINGKEY"
                     .into(),
             )
             .unwrap();
-
-        println!(
-            "Available profiles: {:?}",
-            config_map.keys().collect::<Vec<_>>()
-        );
 
         let (access_key, secret_key) = parse_aws_credentials_file(&config_map, "default").unwrap();
         assert_eq!(access_key, "AKIAIOSFODNN7EXAMPLE");


### PR DESCRIPTION
These two `println`s look like debugging output that was left over. The second one is harmless in the test, but the first one can leak AWS secrets in logs if I understand it correctly.