### PR TITLE
Fix foreman development

### DIFF
--- a/foreman/start-evaluator.sh
+++ b/foreman/start-evaluator.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-export PATH=$(pwd)/src/script:$PATH
+export PATH=$(pwd)/build/subprojects/hydra/hydra-evaluator:$PATH
+
+export HYDRA_DBI="dbi:Pg:dbname=hydra;host=localhost;port=64444"
 
 # wait for postgresql and hydra-server
 while ! pg_isready -h $(pwd)/.hydra-data/postgres -p 64444; do sleep 1; done

--- a/foreman/start-hydra.sh
+++ b/foreman/start-hydra.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-export PATH=$(pwd)/src/script:$PATH
+export PATH=$(pwd)/subprojects/hydra/script:$PATH
+export PERL5LIB=$(pwd)/subprojects/hydra/lib:$PERL5LIB
+export HYDRA_HOME=$(pwd)/subprojects/hydra
+
+export HYDRA_DATA=$(pwd)/.hydra-data
+export HYDRA_DBI="dbi:Pg:dbname=hydra;host=localhost;port=64444"
 
 # wait for postgresql to listen
 while ! pg_isready -h $(pwd)/.hydra-data/postgres -p 64444; do sleep 1; done

--- a/foreman/start-notify.sh
+++ b/foreman/start-notify.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-export PATH=$(pwd)/src/script:$PATH
+export PATH=$(pwd)/subprojects/hydra/script:$PATH
+export PERL5LIB=$(pwd)/subprojects/hydra/lib:$PERL5LIB
+export HYDRA_HOME=$(pwd)/subprojects/hydra
+
+export HYDRA_DATA=$(pwd)/.hydra-data
+export HYDRA_DBI="dbi:Pg:dbname=hydra;host=localhost;port=64444"
 
 # wait for postgresql and hydra-server
 while ! pg_isready -h $(pwd)/.hydra-data/postgres -p 64444; do sleep 1; done


### PR DESCRIPTION
It was broken since moving hydra to subprojects. Doesn't entirely fix static files in hydra, but basic functionality works for testing.

Mostly involved setting environment variables. Some of this might be refactorable to reduce duplication, but I can do that later.