### PR TITLE
foreman: default to debug builds, share constants, and add builder

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,6 @@
 hydra-evaluator: ./foreman/start-evaluator.sh
 hydra-queue-runner: ./foreman/start-queue-runner.sh
+hydra-builder: ./foreman/start-builder.sh
 hydra-notify: ./foreman/start-notify.sh
 hydra-server: ./foreman/start-hydra.sh
 manual: ./foreman/start-manual.sh

--- a/foreman/common.sh
+++ b/foreman/common.sh
@@ -1,0 +1,39 @@
+# Shared constants and helpers for the foreman scripts.
+# Sourced (not executed) by start-*.sh.
+
+# Ports
+HYDRA_PG_PORT=64444
+HYDRA_SERVER_PORT=63333
+HYDRA_PROMETHEUS_PORT=64445
+HYDRA_QUEUE_RUNNER_GRPC_PORT=50051
+
+# Paths
+HYDRA_DATA=$(pwd)/.hydra-data
+HYDRA_HOME=$(pwd)/subprojects/hydra
+HYDRA_PG_SOCKET_DIR=$HYDRA_DATA/postgres
+
+# Connection strings
+HYDRA_DBI="dbi:Pg:dbname=hydra;host=localhost;port=$HYDRA_PG_PORT"
+
+# Cargo target dir picked from the meson build type set in the dev shell.
+if [ "${mesonBuildType:-}" = "debug" ]; then
+    cargo_profile=debug
+else
+    cargo_profile=release
+fi
+HYDRA_CARGO_TARGET_DIR=$(pwd)/target/$cargo_profile
+
+export PATH=$HYDRA_HOME/script:$HYDRA_CARGO_TARGET_DIR:$(pwd)/build/subprojects/hydra/hydra-evaluator:$PATH
+export PERL5LIB=$(pwd)/subprojects/hydra/lib:$PERL5LIB
+
+wait_for_postgres() {
+    while ! pg_isready -h "$HYDRA_PG_SOCKET_DIR" -p "$HYDRA_PG_PORT"; do sleep 1; done
+}
+
+wait_for_hydra_server() {
+    while ! nc -z localhost "$HYDRA_SERVER_PORT"; do sleep 1; done
+}
+
+wait_for_queue_runner_grpc() {
+    while ! nc -z ::1 "$HYDRA_QUEUE_RUNNER_GRPC_PORT" 2>/dev/null; do sleep 1; done
+}

--- a/foreman/start-builder.sh
+++ b/foreman/start-builder.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+. ./foreman/common.sh
+
+wait_for_queue_runner_grpc
+
+export RUST_BACKTRACE="${RUST_BACKTRACE:-1}"
+
+exec hydra-builder

--- a/foreman/start-evaluator.sh
+++ b/foreman/start-evaluator.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-export PATH=$(pwd)/build/subprojects/hydra/hydra-evaluator:$PATH
+. ./foreman/common.sh
 
-export HYDRA_DBI="dbi:Pg:dbname=hydra;host=localhost;port=64444"
+export HYDRA_DBI
+export HYDRA_DATA
 
-# wait for postgresql and hydra-server
-while ! pg_isready -h $(pwd)/.hydra-data/postgres -p 64444; do sleep 1; done
-while ! nc -z localhost 63333; do sleep 1; done
+wait_for_postgres
+wait_for_hydra_server
 
-HYDRA_CONFIG=$(pwd)/.hydra-data/hydra.conf exec hydra-evaluator
+HYDRA_CONFIG=$HYDRA_DATA/hydra.conf exec hydra-evaluator

--- a/foreman/start-hydra.sh
+++ b/foreman/start-hydra.sh
@@ -1,38 +1,38 @@
 #!/bin/sh
 
-export PATH=$(pwd)/subprojects/hydra/script:$PATH
-export PERL5LIB=$(pwd)/subprojects/hydra/lib:$PERL5LIB
-export HYDRA_HOME=$(pwd)/subprojects/hydra
+. ./foreman/common.sh
 
-export HYDRA_DATA=$(pwd)/.hydra-data
-export HYDRA_DBI="dbi:Pg:dbname=hydra;host=localhost;port=64444"
+export HYDRA_HOME
+export HYDRA_DATA
+export HYDRA_DBI
 
-# wait for postgresql to listen
-while ! pg_isready -h $(pwd)/.hydra-data/postgres -p 64444; do sleep 1; done
+wait_for_postgres
 
-createdb -h $(pwd)/.hydra-data/postgres -p 64444 hydra
+createdb -h "$HYDRA_PG_SOCKET_DIR" -p "$HYDRA_PG_PORT" hydra
 
 # create a db for the default user. Not sure why, but
 # the terminal is otherwise spammed with:
 #
 #     FATAL:  database "USERNAME" does not exist
-createdb -h $(pwd)/.hydra-data/postgres -p 64444 "$(whoami)" || true
+createdb -h "$HYDRA_PG_SOCKET_DIR" -p "$HYDRA_PG_PORT" "$(whoami)" || true
+
+ln -sf ../../../../build/subprojects/hydra/{bootstrap,fontawesome} subprojects/hydra/root/static
 
 hydra-init
 hydra-create-user alice --password foobar --role admin
 
-if [ ! -f ./.hydra-data/hydra.conf ]; then
+if [ ! -f "$HYDRA_DATA/hydra.conf" ]; then
     echo "Creating a default hydra.conf"
-    cat << EOF > .hydra-data/hydra.conf
+    cat << EOF > "$HYDRA_DATA/hydra.conf"
 # test-time instances likely don't want to bootstrap nixpkgs from scratch
 use-substitutes = true
 
 <hydra_notify>
   <prometheus>
     listen_address = 127.0.0.1
-    port = 64445
+    port = $HYDRA_PROMETHEUS_PORT
   </prometheus>
 </hydra_notify>
 EOF
 fi
-HYDRA_CONFIG=$(pwd)/.hydra-data/hydra.conf exec hydra-dev-server --port 63333 --restart --debug
+HYDRA_CONFIG=$HYDRA_DATA/hydra.conf exec hydra-dev-server --port "$HYDRA_SERVER_PORT" --restart --debug

--- a/foreman/start-notify.sh
+++ b/foreman/start-notify.sh
@@ -1,14 +1,12 @@
 #!/bin/sh
 
-export PATH=$(pwd)/subprojects/hydra/script:$PATH
-export PERL5LIB=$(pwd)/subprojects/hydra/lib:$PERL5LIB
-export HYDRA_HOME=$(pwd)/subprojects/hydra
+. ./foreman/common.sh
 
-export HYDRA_DATA=$(pwd)/.hydra-data
-export HYDRA_DBI="dbi:Pg:dbname=hydra;host=localhost;port=64444"
+export HYDRA_HOME
+export HYDRA_DATA
+export HYDRA_DBI
 
-# wait for postgresql and hydra-server
-while ! pg_isready -h $(pwd)/.hydra-data/postgres -p 64444; do sleep 1; done
-while ! nc -z localhost 63333; do sleep 1; done
+wait_for_postgres
+wait_for_hydra_server
 
-HYDRA_CONFIG=$(pwd)/.hydra-data/hydra.conf exec hydra-notify
+HYDRA_CONFIG=$HYDRA_DATA/hydra.conf exec hydra-notify

--- a/foreman/start-postgres.sh
+++ b/foreman/start-postgres.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-initdb ./.hydra-data/postgres
-exec postgres -D ./.hydra-data/postgres -k $(pwd)/.hydra-data/postgres -p 64444
+. ./foreman/common.sh
+
+initdb "$HYDRA_PG_SOCKET_DIR"
+exec postgres -D "$HYDRA_PG_SOCKET_DIR" -k "$HYDRA_PG_SOCKET_DIR" -p "$HYDRA_PG_PORT"

--- a/foreman/start-queue-runner.sh
+++ b/foreman/start-queue-runner.sh
@@ -1,16 +1,14 @@
 #!/bin/sh
 
-# wait for postgresql
-while ! pg_isready -h $(pwd)/.hydra-data/postgres -p 64444; do sleep 1; done
+. ./foreman/common.sh
+
+wait_for_postgres
 
 # wait until the hydra database exists (hydra-server creates it)
-while ! psql -h $(pwd)/.hydra-data/postgres -p 64444 -d hydra -c 'SELECT 1' >/dev/null 2>&1; do sleep 1; done
+while ! psql -h "$HYDRA_PG_SOCKET_DIR" -p "$HYDRA_PG_PORT" -d hydra -c 'SELECT 1' >/dev/null 2>&1; do sleep 1; done
 
-# wait until hydra-server is listening
-while ! nc -z localhost 63333; do sleep 1; done
+wait_for_hydra_server
 
-HYDRA_DATA=$(pwd)/.hydra-data
-PATH="$(pwd)/target/release:$PATH"
 CONFIG="$HYDRA_DATA/queue-runner.toml"
 
 # Generate a config for the Rust queue-runner if it doesn't exist
@@ -22,7 +20,7 @@ useSubstitutes = true
 EOF
 fi
 
-export HYDRA_DATABASE_URL="postgres://${USER}@localhost:64444/hydra"
+export HYDRA_DATABASE_URL="postgres://${USER}@localhost:$HYDRA_PG_PORT/hydra"
 export LOGNAME="${LOGNAME:-$USER}"
 
 exec hydra-queue-runner -c "$CONFIG"

--- a/packaging/dev-shell.nix
+++ b/packaging/dev-shell.nix
@@ -52,6 +52,11 @@ hydra.overrideAttrs (
 
     inherit (hydra-tests) OPENLDAP_ROOT;
 
+    # Better default for local development: build with debug info and
+    # without optimizations. Foreman scripts also read this to pick the
+    # right cargo target directory.
+    mesonBuildType = "debug";
+
     # TODO: use factored-out Nix packaging infra to combine mesonFlags
     # from each component (transforming `-Dfoo=bar` to `-Dsubproject:foo=bar`)
     mesonFlags = [ ];


### PR DESCRIPTION
Although foreman has been somewhat working since #1646, it didn't have a functioning builder and required a release build of the queue runner. We fixed that, while also cleaning up the code somewhat to reduce duplication