### PR TITLE
tests: add dynamic derivation integration test

### DIFF
--- a/subprojects/hydra-tests/content-addressed/dyn-drv.t
+++ b/subprojects/hydra-tests/content-addressed/dyn-drv.t
@@ -1,0 +1,53 @@
+use feature 'unicode_strings';
+use strict;
+use warnings;
+use Setup;
+use Test2::V0;
+
+# Based on https://github.com/NixOS/nix/blob/14ffc1787182b8702910788aea02bd5804afb32e/tests/functional/dyn-drv/text-hashed-output.nix
+#
+# A single derivation produces a .drv file as its output; another
+# derivation (wrapper) depends on building that dynamically-produced .drv
+# and using its output via builtins.outputOf.
+
+my $ctx = test_context(
+    nix_config => qq|
+    experimental-features = ca-derivations dynamic-derivations
+    |,
+);
+
+my $db = $ctx->db();
+
+my $jobset = createBaseJobset($db, "dyn-drv", "dyn-drv.nix", $ctx->jobsdir);
+
+ok(evalSucceeds($ctx, $jobset), "Evaluation of dyn-drv.nix should succeed");
+is(nrQueuedBuildsForJobset($jobset), 1, "Should queue 1 build (wrapper)");
+
+my @builds = queuedBuildsForJobset($jobset);
+ok(runBuilds($ctx, @builds), "All dynamic derivation builds should complete");
+
+# hello and producingDrv are standard CA derivations, so they must succeed.
+for my $build (grep { $_->job ne 'wrapper' } @builds) {
+    $build->discard_changes;
+    is($build->finished, 1, "Build '" . $build->job . "' should be finished");
+    is($build->buildstatus, 0, "Build '" . $build->job . "' should succeed");
+}
+
+# wrapper is the dynamic derivation consumer.
+# It exercises the full resolution path: build producingDrv, discover the .drv
+# at its output, resolve via try_resolve + flatten_chain, build the resolved drv.
+my ($wrapper) = grep { $_->job eq 'wrapper' } @builds;
+ok(defined $wrapper, "wrapper (dynamic derivation consumer) build should exist");
+if ($wrapper) {
+    $wrapper->discard_changes;
+    is($wrapper->finished, 1, "wrapper should be finished");
+    is($wrapper->buildstatus, 0, "wrapper should succeed");
+
+    # Hydra currently doesn't understand the dynamic derivation structure,
+    # so it only sees 2 build steps (producingDrv + wrapper itself) rather
+    # than the full chain (producingDrv + dynamic hello + wrapper).
+    my $nrSteps = $wrapper->buildsteps->count;
+    is($nrSteps, 2, "wrapper should have 2 build steps (dynamic structure not yet tracked)");
+}
+
+done_testing;

--- a/subprojects/hydra-tests/jobs/dyn-drv.nix
+++ b/subprojects/hydra-tests/jobs/dyn-drv.nix
@@ -1,0 +1,70 @@
+# Adapted from https://github.com/NixOS/nix/blob/14ffc1787182b8702910788aea02bd5804afb32e/tests/functional/dyn-drv/text-hashed-output.nix
+#
+# A derivation produces a .drv file as its output; another derivation depends
+# on building that dynamically-produced .drv and using its output.
+let
+  cfg = import ./config.nix;
+
+  # A CA derivation that writes content based on the GREETING env var.
+  # The GREETING contains 'X' which producingDrv rewrites to 'Y' via
+  # tr at build time, so the dynamically-produced .drv differs from
+  # the statically-known one.
+  hello = cfg.mkContentAddressedDerivation {
+    name = "hello";
+    builder = "/bin/sh";
+    args = [
+      "-c"
+      ''
+        mkdir -p "$out"
+        echo "greeting while builder: $GREETING" >&2
+        echo "saving greeting to output: $GREETING" > $out/result
+      ''
+    ];
+    GREETING = "XXXX derivation";
+  };
+
+  # A CA derivation whose output IS a .drv file.
+  # Copies hello's .drv then rewrites X→Y so the dynamic derivation
+  # builds with GREETING="YYYY derivation" instead of "XXXX derivation".
+  # tr is in coreutils so it's available on PATH.
+  producingDrv = cfg.mkDerivation {
+    name = "hello.drv";
+    builder = "/bin/sh";
+    args = [
+      "-c"
+      ''
+        drv=${builtins.unsafeDiscardOutputDependency hello.drvPath}
+        echo rewriting "$drv" >&2
+        tr X Y < "$drv" > "$out"
+      ''
+    ];
+    __contentAddressed = true;
+    outputHashMode = "text";
+    outputHashAlgo = "sha256";
+  };
+
+in
+{
+  # The actual dynamic derivation consumer: depends on the output of the
+  # .drv file that producingDrv produces. Nix must:
+  #   1. Build producingDrv (get the .drv file)
+  #   2. Discover the .drv at its output
+  #   3. Build THAT .drv (which runs dyn-drv-builder.sh with GREETING="YYYY derivation")
+  #   4. Use its output here
+  wrapper = cfg.mkContentAddressedDerivation {
+    name = "dyn-drv-wrapper";
+    builder = "/bin/sh";
+    args = [
+      "-c"
+      ''
+        result=${builtins.outputOf producingDrv.outPath "out"}
+        # Verify the dynamically-built derivation used the rewritten GREETING
+        case "$(cat "$result/result")" in
+          *YYYY*) ;;
+          *) echo "expected YYYY in result" >&2; exit 1 ;;
+        esac
+        cp -r "$result" $out
+      ''
+    ];
+  };
+}


### PR DESCRIPTION
This test is based on upstream Nix's test located at functional/dyn-drv/text-hashed-output.nix. A CA derivation (producingDrv) outputs a .drv file; another derivation (wrapper) depends on building that dynamically-produced .drv via builtins.outputOf.

This test "succeeds" but for the wrong reasons --- Hydra doesn't yet understand the dynamic derivation structure, and so a single job ends up building multiple derivations. That's not good, and will need to be fixed.