### PR TITLE
binary-cache: honour AWS_SHARED_CREDENTIALS_FILE

### DIFF
--- a/subprojects/crates/binary-cache/src/cfg.rs
+++ b/subprojects/crates/binary-cache/src/cfg.rs
@@ -379,8 +379,16 @@ pub(crate) enum ConfigReadError {
 pub(crate) fn read_aws_credentials_file(
     profile: &str,
 ) -> Result<(String, secrecy::SecretString), ConfigReadError> {
-    let home_dir = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE"))?;
-    let credentials_path = format!("{home_dir}/.aws/credentials");
+    // Honour the standard AWS env var so callers (e.g. the NixOS module's
+    // `awsCredentialsFile` option) can point at a credentials file outside
+    // of $HOME. Falls back to the conventional ~/.aws/credentials location.
+    let credentials_path = match std::env::var("AWS_SHARED_CREDENTIALS_FILE") {
+        Ok(p) if !p.is_empty() => p,
+        _ => {
+            let home_dir = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE"))?;
+            format!("{home_dir}/.aws/credentials")
+        }
+    };
 
     let mut config = configparser::ini::Ini::new();
     let config_map = config


### PR DESCRIPTION
The queue-runner NixOS module exposes an `awsCredentialsFile` option that sets `AWS_SHARED_CREDENTIALS_FILE`, but `read_aws_credentials_file()` only ever looked at `$HOME/.aws/credentials`. On non-EC2 hosts this caused the object_store client to fall through to the IMDS endpoint (169.254.169.254) and stall every narinfo lookup in retry loops.

Check `AWS_SHARED_CREDENTIALS_FILE` first and fall back to the default location, matching the behaviour of the official AWS SDKs.