### PR TITLE
Add partial early cutoff test for content-addressed builds

### DIFF
--- a/subprojects/hydra-tests/content-addressed/basic.t
+++ b/subprojects/hydra-tests/content-addressed/basic.t
@@ -24,7 +24,7 @@ my $project = $db->resultset('Projects')->create({name => "tests", displayname =
 my $jobset = createBaseJobset($db, "content-addressed", "content-addressed.nix", $ctx{jobsdir});
 
 ok(evalSucceeds($ctx{context}, $jobset), "Evaluating jobs/content-addressed.nix should exit with return code 0");
-is(nrQueuedBuildsForJobset($jobset), 10, "Evaluating jobs/content-addressed.nix should result in 6 builds");
+is(nrQueuedBuildsForJobset($jobset), 14, "Evaluating jobs/content-addressed.nix should result in 14 builds");
 
 my @builds = queuedBuildsForJobset($jobset);
 ok(runBuilds($ctx{context}, @builds), "Building all jobs from jobs/content-addressed.nix should exit with code 0");
@@ -57,6 +57,47 @@ for my $build (@builds) {
 # XXX: deststoredir is undefined: Use of uninitialized value $ctx{"deststoredir"} in concatenation (.) or string at t/content-addressed/basic.t line 58.
 # XXX: This test seems to not do what it seems to be doing. See documentation: https://metacpan.org/pod/Test2::V0#isnt($got,-$do_not_want,-$name)
 isnt(<$ctx{deststoredir}/realisations/*>, "", "The destination store should have the realisations of the built derivations registered");
+
+# Early cutoff: earlyCutoffUpstream1 and earlyCutoffUpstream2 have
+# different derivations but produce the same content-addressed output.
+# After building earlyCutoffDownstream1, earlyCutoffDownstream2 should
+# be cached because its resolved input is identical.
+my $upstream1 = $db->resultset('Builds')->find({
+    jobset_id => $jobset->id,
+    job => "earlyCutoffUpstream1",
+});
+my $upstream2 = $db->resultset('Builds')->find({
+    jobset_id => $jobset->id,
+    job => "earlyCutoffUpstream2",
+});
+
+my $upstream1_out = $upstream1->buildoutputs->find({ name => "out" });
+my $upstream2_out = $upstream2->buildoutputs->find({ name => "out" });
+is($upstream1_out->path, $upstream2_out->path,
+    "Both upstream builds should resolve to the same content-addressed output path");
+
+my $downstream1 = $db->resultset('Builds')->find({
+    jobset_id => $jobset->id,
+    job => "earlyCutoffDownstream1",
+});
+my $downstream2 = $db->resultset('Builds')->find({
+    jobset_id => $jobset->id,
+    job => "earlyCutoffDownstream2",
+});
+
+my $downstream1_out = $downstream1->buildoutputs->find({ name => "out" });
+my $downstream2_out = $downstream2->buildoutputs->find({ name => "out" });
+is($downstream1_out->path, $downstream2_out->path,
+    "Both downstream builds should resolve to the same content-addressed output path");
+
+# TODO: Once the queue runner deduplicates steps by resolved derivation
+# path (not just original drv path), we should also verify that both
+# original steps resolve to steps with the same derivation. (Might even
+# be the same step, but that doesn't matter as much).
+#
+# If there are multiple steps for the single resolved derivation,
+# additionally, only one should get built, and the other should be a
+# cached successes (as is normal for duplicative build steps).
 
 done_testing;
 

--- a/subprojects/hydra-tests/jobs/content-addressed.nix
+++ b/subprojects/hydra-tests/jobs/content-addressed.nix
@@ -64,4 +64,33 @@ rec {
       "lib"
     ];
   };
+
+  # Early-cutoff test: two upstream derivations that differ in a dummy
+  # attribute but produce the same output (an empty directory).  Because
+  # they are content-addressed, they resolve to the same output path.
+  # Both downstreams depend on a different upstream, but since the
+  # resolved input is identical, the second downstream should be cached.
+  earlyCutoffUpstream1 = cfg.mkContentAddressedDerivation {
+    name = "early-cutoff-upstream";
+    builder = ./empty-dir-builder.sh;
+    dummy = "1";
+  };
+
+  earlyCutoffUpstream2 = cfg.mkContentAddressedDerivation {
+    name = "early-cutoff-upstream";
+    builder = ./empty-dir-builder.sh;
+    dummy = "2";
+  };
+
+  earlyCutoffDownstream1 = cfg.mkContentAddressedDerivation {
+    name = "early-cutoff-downstream";
+    builder = ./dir-with-file-builder.sh;
+    FOO = earlyCutoffUpstream1;
+  };
+
+  earlyCutoffDownstream2 = cfg.mkContentAddressedDerivation {
+    name = "early-cutoff-downstream";
+    builder = ./dir-with-file-builder.sh;
+    FOO = earlyCutoffUpstream2;
+  };
 }


### PR DESCRIPTION
Two upstream CA derivations differ only in a dummy attribute but produce the same output, so whne built they produce the same content-addressed output path. Their respective downstream derivations therefore also resolve to the same derivation.

For now we only verify that the CA output paths converge as expected. The full early cutoff assertion left as a TODO until the queue runner materializes derivation resolution into the database as new steps.