### PR TITLE
drv-in-db: port nix's derivation tables to postgres + standalone daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -384,6 +384,17 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -824,8 +835,10 @@ dependencies = [
  "anyhow",
  "futures",
  "harmonia-store-core",
+ "harmonia-utils-hash",
  "hashbrown 0.16.1",
  "jiff",
+ "serde",
  "serde_json",
  "sqlx",
  "test-utils",
@@ -943,7 +956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1252,9 +1265,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "harmonia-nar"
+version = "3.0.0"
+source = "git+https://github.com/nix-community/harmonia.git#b9ec6540251dae513a509f119bca78e1562cd084"
+dependencies = [
+ "bstr",
+ "bytes",
+ "derive_more",
+ "futures",
+ "harmonia-utils-io",
+ "nix",
+ "pin-project-lite",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
+name = "harmonia-protocol"
+version = "3.0.0"
+source = "git+https://github.com/nix-community/harmonia.git#b9ec6540251dae513a509f119bca78e1562cd084"
+dependencies = [
+ "async-stream",
+ "bstr",
+ "bytes",
+ "derive_more",
+ "futures",
+ "harmonia-nar",
+ "harmonia-protocol-derive",
+ "harmonia-store-core",
+ "harmonia-utils-hash",
+ "harmonia-utils-io",
+ "libc",
+ "num_enum",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "harmonia-protocol-derive"
+version = "3.0.0"
+source = "git+https://github.com/nix-community/harmonia.git#b9ec6540251dae513a509f119bca78e1562cd084"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#c4b32cfb36a39d57d07ea254ebb926cc37f30e48"
+source = "git+https://github.com/nix-community/harmonia.git#b9ec6540251dae513a509f119bca78e1562cd084"
 dependencies = [
  "bytes",
  "harmonia-store-core",
@@ -1267,7 +1336,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-core"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#c4b32cfb36a39d57d07ea254ebb926cc37f30e48"
+source = "git+https://github.com/nix-community/harmonia.git#b9ec6540251dae513a509f119bca78e1562cd084"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -1286,9 +1355,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "harmonia-store-remote"
+version = "3.0.0"
+source = "git+https://github.com/nix-community/harmonia.git#b9ec6540251dae513a509f119bca78e1562cd084"
+dependencies = [
+ "async-stream",
+ "futures",
+ "harmonia-nar",
+ "harmonia-protocol",
+ "harmonia-store-core",
+ "harmonia-utils-io",
+ "prometheus",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#c4b32cfb36a39d57d07ea254ebb926cc37f30e48"
+source = "git+https://github.com/nix-community/harmonia.git#b9ec6540251dae513a509f119bca78e1562cd084"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1298,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#c4b32cfb36a39d57d07ea254ebb926cc37f30e48"
+source = "git+https://github.com/nix-community/harmonia.git#b9ec6540251dae513a509f119bca78e1562cd084"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1308,6 +1393,18 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "harmonia-utils-io"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/nix-community/harmonia.git#b9ec6540251dae513a509f119bca78e1562cd084"
+dependencies = [
+ "bytes",
+ "futures",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1486,6 +1583,28 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "hydra-drv-daemon"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "db",
+ "futures",
+ "harmonia-protocol",
+ "harmonia-store-aterm",
+ "harmonia-store-core",
+ "harmonia-store-remote",
+ "harmonia-utils-hash",
+ "harmonia-utils-io",
+ "serde_json",
+ "sqlx",
+ "test-utils",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1848,7 +1967,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2177,7 +2296,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3171,7 +3290,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3542,7 +3661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3882,7 +4001,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4697,7 +4816,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 
-members  = [ "subprojects/hydra-builder", "subprojects/hydra-queue-runner", "subprojects/crates/*" ]
+members  = [ "subprojects/hydra-builder", "subprojects/hydra-queue-runner", "subprojects/hydra-drv-daemon", "subprojects/crates/*" ]
 resolver = "2"
 
 [workspace.package]
@@ -29,10 +29,13 @@ futures = "0.3"
 futures-util = "0.3"
 gethostname = "1"
 h2 = "0.4"
+harmonia-protocol = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-store-aterm = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-store-core = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-remote = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-hash = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-io = { git = "https://github.com/nix-community/harmonia.git" }
 hashbrown = "0.16"
 http = "1.1"
 http-body-util = "0.1"
@@ -94,7 +97,12 @@ uuid = "1.16"
 zerocopy = { version = "0.8", features = [ "derive" ] }
 
 [patch.crates-io]
+harmonia-nar                 = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-protocol            = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-protocol-derive     = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-store-aterm         = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-store-core          = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-remote        = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-hash          = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-io            = { git = "https://github.com/nix-community/harmonia.git" }

--- a/subprojects/crates/db/Cargo.toml
+++ b/subprojects/crates/db/Cargo.toml
@@ -9,10 +9,12 @@ rust-version.workspace = true
 anyhow.workspace              = true
 futures.workspace             = true
 harmonia-store-core.workspace = true
+harmonia-utils-hash.workspace = true
 hashbrown.workspace           = true
 tracing.workspace             = true
 
 jiff.workspace       = true
+serde.workspace      = true
 serde_json.workspace = true
 
 sqlx = { workspace = true, features = [ "runtime-tokio", "tls-rustls-ring-webpki", "postgres" ] }

--- a/subprojects/crates/db/src/connection.rs
+++ b/subprojects/crates/db/src/connection.rs
@@ -1,12 +1,42 @@
 use sqlx::Acquire;
 
+use harmonia_store_core::derivation::{Derivation, DerivationOutput};
+use harmonia_store_core::derived_path::SingleDerivedPath;
 use harmonia_store_core::store_path::StoreDir;
+use harmonia_utils_hash::fmt::CommonHash as _;
 
 use super::models::{
     Build, BuildSmall, BuildStatus, BuildSteps, InsertBuildMetric, InsertBuildProduct,
     InsertBuildStep, InsertBuildStepOutput, Jobset, UpdateBuild, UpdateBuildStep,
     UpdateBuildStepInFinish,
 };
+
+/// Serialize a SingleDerivedPath input into (path, outputs_json) for DerivationInputs.
+/// For Opaque inputs: path = store path, outputs = [].
+/// For Built inputs: path = root store path, outputs = ["out1", "out2", ...] chain.
+fn serialize_input(input: &SingleDerivedPath, store_dir: &StoreDir) -> (String, serde_json::Value) {
+    let mut outputs = Vec::new();
+    let mut current = input;
+    loop {
+        match current {
+            SingleDerivedPath::Opaque(sp) => {
+                let path = format!("{store_dir}/{sp}");
+                let json = serde_json::Value::Array(
+                    outputs
+                        .into_iter()
+                        .rev()
+                        .map(serde_json::Value::String)
+                        .collect(),
+                );
+                return (path, json);
+            }
+            SingleDerivedPath::Built { drv_path, output } => {
+                outputs.push(output.as_ref().to_owned());
+                current = drv_path.as_ref();
+            }
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct Connection {
@@ -371,7 +401,134 @@ impl Connection {
         Ok(results)
     }
 
-    #[tracing::instrument(skip(self), err)]
+    /// Insert a fully decomposed derivation into the 6 drv-in-db tables.
+    /// Returns the Derivations.id primary key, or None if the path already exists.
+    pub async fn insert_derivation(
+        &mut self,
+        drv_path: &str,
+        drv: &Derivation,
+        store_dir: &StoreDir,
+    ) -> sqlx::Result<Option<i32>> {
+        let first_output = drv.outputs.values().next();
+        let output_type = match first_output {
+            Some(DerivationOutput::InputAddressed(_)) => 0,
+            Some(DerivationOutput::CAFixed(_)) => 1,
+            Some(DerivationOutput::CAFloating(_)) => 2,
+            Some(DerivationOutput::Deferred) => 3,
+            Some(DerivationOutput::Impure(_)) => 4,
+            None => 0,
+        };
+        let has_sa = drv.structured_attrs.is_some();
+        let platform = String::from_utf8_lossy(&drv.platform);
+        let builder = String::from_utf8_lossy(&drv.builder);
+        let args = drv
+            .args
+            .iter()
+            .map(|a| String::from_utf8_lossy(a).into_owned())
+            .collect::<Vec<_>>();
+
+        let mut tx = self.conn.begin().await?;
+
+        let row = sqlx::query_as::<_, (i32,)>(
+            "INSERT INTO Derivations (path, platform, builder, args, outputType, hasStructuredAttrs)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             ON CONFLICT (path) DO NOTHING
+             RETURNING id",
+        )
+        .bind(drv_path)
+        .bind(platform.as_ref())
+        .bind(builder.as_ref())
+        .bind(&args)
+        .bind(output_type)
+        .bind(has_sa)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some((drv_id,)) = row else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+
+        for (name, output) in &drv.outputs {
+            let (path, method, hash_algo, hash) = match output {
+                DerivationOutput::InputAddressed(sp) => {
+                    (Some(format!("{store_dir}/{sp}")), None, None, None)
+                }
+                DerivationOutput::CAFixed(ca) => (
+                    None,
+                    Some(ca.method_algorithm().to_string()),
+                    Some(ca.algorithm().to_string()),
+                    Some(ca.hash().as_sri().to_string()),
+                ),
+                DerivationOutput::CAFloating(cam) => (
+                    None,
+                    Some(cam.to_string()),
+                    Some(cam.algorithm().to_string()),
+                    None,
+                ),
+                DerivationOutput::Deferred => (None, None, None, None),
+                DerivationOutput::Impure(cam) => (
+                    None,
+                    Some(cam.to_string()),
+                    Some(cam.algorithm().to_string()),
+                    None,
+                ),
+            };
+            sqlx::query(
+                "INSERT INTO DerivationOutputs (drv, id, outputType, path, method, hashAlgo, hash)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            )
+            .bind(drv_id)
+            .bind(name.as_ref())
+            .bind(output_type)
+            .bind(path.as_deref())
+            .bind(method.as_deref())
+            .bind(hash_algo.as_deref())
+            .bind(hash.as_deref())
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        for input in &drv.inputs {
+            // Encode the full SingleDerivedPath chain as jsonb.
+            // For Opaque: path is the store path, outputs is empty.
+            // For Built: path is the root store path, outputs encodes the chain.
+            let (path, outputs_json) = serialize_input(input, store_dir);
+            sqlx::query("INSERT INTO DerivationInputs (drv, path, outputs) VALUES ($1, $2, $3)")
+                .bind(drv_id)
+                .bind(&path)
+                .bind(&outputs_json)
+                .execute(&mut *tx)
+                .await?;
+        }
+
+        for (key, value) in &drv.env {
+            sqlx::query("INSERT INTO DerivationEnv (drv, key, value) VALUES ($1, $2, $3)")
+                .bind(drv_id)
+                .bind(String::from_utf8_lossy(key).as_ref())
+                .bind(String::from_utf8_lossy(value).as_ref())
+                .execute(&mut *tx)
+                .await?;
+        }
+
+        if let Some(sa) = &drv.structured_attrs {
+            for (key, value) in &sa.attrs {
+                sqlx::query(
+                    "INSERT INTO DerivationStructuredAttrs (drv, hasStructuredAttrs, key, value)
+                     VALUES ($1, true, $2, $3)",
+                )
+                .bind(drv_id)
+                .bind(key)
+                .bind(value)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+
+        tx.commit().await?;
+        Ok(Some(drv_id))
+    }
+
     pub async fn get_status(&mut self) -> sqlx::Result<Option<serde_json::Value>> {
         Ok(
             sqlx::query!("SELECT status FROM systemstatus WHERE what = 'queue-runner';",)

--- a/subprojects/crates/db/tests/schema_drv.rs
+++ b/subprojects/crates/db/tests/schema_drv.rs
@@ -1,0 +1,282 @@
+//! Tests for the drv-in-db schema (upgrade-86).
+//!
+//! Validates that the tables load, CHECK constraints enforce the
+//! outputType/hasStructuredAttrs composite-FK pattern, and basic CRUD works.
+
+#![allow(clippy::unwrap_used)]
+
+async fn setup() -> (test_utils::TestPg, sqlx::PgPool) {
+    test_utils::TestPg::new_drv_in_db().await
+}
+
+// -- Schema loads --
+
+#[tokio::test]
+async fn drv_schema_loads() {
+    let (_pg, pool) = setup().await;
+    let row: (i64,) = sqlx::query_as(
+        "SELECT count(*) FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name LIKE 'derivation%'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, 6, "expected 6 derivation tables, got {}", row.0);
+}
+
+// -- Derivations insert --
+
+async fn insert_drv(pool: &sqlx::PgPool, path: &str, output_type: i32, has_sa: bool) -> i32 {
+    let row: (i32,) = sqlx::query_as(
+        "INSERT INTO Derivations (path, platform, builder, args, outputType, hasStructuredAttrs)
+         VALUES ($1, 'x86_64-linux', '/bin/sh', '{-e,echo}', $2, $3)
+         RETURNING id",
+    )
+    .bind(path)
+    .bind(output_type)
+    .bind(has_sa)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    row.0
+}
+
+// -- outputType CHECK constraints on DerivationOutputs --
+
+#[tokio::test]
+async fn output_input_addressed_accepts_valid() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 0, false).await;
+    sqlx::query(
+        "INSERT INTO DerivationOutputs (drv, id, outputType, path)
+         VALUES ($1, 'out', 0, '/nix/store/bbb-result')",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn output_input_addressed_rejects_hash() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 0, false).await;
+    let result = sqlx::query(
+        "INSERT INTO DerivationOutputs (drv, id, outputType, path, hashAlgo)
+         VALUES ($1, 'out', 0, '/nix/store/bbb', 'sha256')",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await;
+    assert!(result.is_err(), "outputType=0 should reject hashAlgo");
+}
+
+#[tokio::test]
+async fn output_ca_fixed_accepts_valid() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 1, false).await;
+    sqlx::query(
+        "INSERT INTO DerivationOutputs (drv, id, outputType, method, hashAlgo, hash)
+         VALUES ($1, 'out', 1, 'r:sha256', 'sha256', 'sha256-abc123')",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn output_ca_fixed_rejects_missing_hash() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 1, false).await;
+    let result = sqlx::query(
+        "INSERT INTO DerivationOutputs (drv, id, outputType, method, hashAlgo)
+         VALUES ($1, 'out', 1, 'r:sha256', 'sha256')",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await;
+    assert!(result.is_err(), "outputType=1 should require hash");
+}
+
+#[tokio::test]
+async fn output_deferred_accepts_valid() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 3, false).await;
+    sqlx::query(
+        "INSERT INTO DerivationOutputs (drv, id, outputType)
+         VALUES ($1, 'out', 3)",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn output_deferred_rejects_path() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 3, false).await;
+    let result = sqlx::query(
+        "INSERT INTO DerivationOutputs (drv, id, outputType, path)
+         VALUES ($1, 'out', 3, '/nix/store/bbb')",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await;
+    assert!(result.is_err(), "outputType=3 should reject path");
+}
+
+#[tokio::test]
+async fn output_type_mismatch_rejected() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 0, false).await;
+    // Parent has outputType=0, try inserting outputType=3
+    let result = sqlx::query(
+        "INSERT INTO DerivationOutputs (drv, id, outputType)
+         VALUES ($1, 'out', 3)",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await;
+    assert!(
+        result.is_err(),
+        "composite FK should reject mismatched outputType"
+    );
+}
+
+// -- Composite FK for structured attrs --
+
+#[tokio::test]
+async fn structured_attrs_allowed_when_flag_set() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 3, true).await;
+    sqlx::query(
+        "INSERT INTO DerivationStructuredAttrs (drv, hasStructuredAttrs, key, value)
+         VALUES ($1, true, 'foo', '\"bar\"')",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn structured_attrs_rejected_when_flag_unset() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 3, false).await;
+    let result = sqlx::query(
+        "INSERT INTO DerivationStructuredAttrs (drv, hasStructuredAttrs, key, value)
+         VALUES ($1, true, 'foo', '\"bar\"')",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await;
+    assert!(
+        result.is_err(),
+        "composite FK should reject structured attrs when hasStructuredAttrs=false"
+    );
+}
+
+// -- Cascade delete --
+
+#[tokio::test]
+async fn cascade_deletes_children() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 0, false).await;
+
+    sqlx::query(
+        "INSERT INTO DerivationOutputs (drv, id, outputType, path)
+         VALUES ($1, 'out', 0, '/nix/store/bbb')",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query("INSERT INTO DerivationInputSrcs (drv, src) VALUES ($1, '/nix/store/ccc')")
+        .bind(drv)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "INSERT INTO DerivationEnv (drv, key, value) VALUES ($1, 'name', 'test')",
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query("DELETE FROM Derivations WHERE id = $1")
+        .bind(drv)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let count: (i64,) = sqlx::query_as("SELECT count(*) FROM DerivationOutputs WHERE drv = $1")
+        .bind(drv)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 0);
+
+    let count: (i64,) = sqlx::query_as("SELECT count(*) FROM DerivationInputSrcs WHERE drv = $1")
+        .bind(drv)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 0);
+
+    let count: (i64,) = sqlx::query_as("SELECT count(*) FROM DerivationEnv WHERE drv = $1")
+        .bind(drv)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 0);
+}
+
+// -- DerivationInputs jsonb check --
+
+#[tokio::test]
+async fn inputs_rejects_non_array_outputs() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 0, false).await;
+    let result = sqlx::query(
+        r#"INSERT INTO DerivationInputs (drv, path, outputs)
+         VALUES ($1, '/nix/store/dep.drv', '{"not": "array"}')"#,
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await;
+    assert!(result.is_err(), "outputs must be a JSON array");
+}
+
+#[tokio::test]
+async fn inputs_accepts_array_outputs() {
+    let (_pg, pool) = setup().await;
+    let drv = insert_drv(&pool, "/nix/store/aaa.drv", 0, false).await;
+    sqlx::query(
+        r#"INSERT INTO DerivationInputs (drv, path, outputs)
+         VALUES ($1, '/nix/store/dep.drv', '["out", "dev"]')"#,
+    )
+    .bind(drv)
+    .execute(&pool)
+    .await
+    .unwrap();
+}
+
+// -- Duplicate path rejection --
+
+#[tokio::test]
+async fn duplicate_drv_path_rejected() {
+    let (_pg, pool) = setup().await;
+    insert_drv(&pool, "/nix/store/aaa.drv", 0, false).await;
+    let result = sqlx::query(
+        "INSERT INTO Derivations (path, platform, builder, outputType)
+         VALUES ('/nix/store/aaa.drv', 'x86_64-linux', '/bin/sh', 0)",
+    )
+    .execute(&pool)
+    .await;
+    assert!(result.is_err(), "duplicate path should be rejected");
+}

--- a/subprojects/crates/test-utils/src/lib.rs
+++ b/subprojects/crates/test-utils/src/lib.rs
@@ -21,8 +21,7 @@ pub struct TestPg {
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 
 impl TestPg {
-    /// Spin up a fresh PG instance and load the hydra schema.
-    pub async fn new() -> (Self, sqlx::PgPool) {
+    async fn init_cluster() -> Self {
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
         let dir = std::env::temp_dir().join(format!("hydra-test-pg-{}-{id}", std::process::id()));
         let _ = fs_err::remove_dir_all(&dir);
@@ -83,10 +82,26 @@ impl TestPg {
             "createdb failed"
         );
 
-        let pg = Self { dir, port };
+        Self { dir, port }
+    }
+
+    /// Spin up a fresh PG instance and load the hydra v1 schema.
+    pub async fn new() -> (Self, sqlx::PgPool) {
+        let pg = Self::init_cluster().await;
         let pool = sqlx::PgPool::connect(&pg.url()).await.unwrap();
         let schema = include_str!("../../../hydra/sql/hydra.sql");
         sqlx::raw_sql(schema).execute(&pool).await.unwrap();
+        (pg, pool)
+    }
+
+    /// Spin up a fresh PG instance and load the hydra v1 schema + drv-in-db tables.
+    pub async fn new_drv_in_db() -> (Self, sqlx::PgPool) {
+        let pg = Self::init_cluster().await;
+        let pool = sqlx::PgPool::connect(&pg.url()).await.unwrap();
+        let base = include_str!("../../../hydra/sql/hydra.sql");
+        let drv = include_str!("../../../hydra/sql/upgrade-86.sql");
+        sqlx::raw_sql(base).execute(&pool).await.unwrap();
+        sqlx::raw_sql(drv).execute(&pool).await.unwrap();
         (pg, pool)
     }
 

--- a/subprojects/hydra-drv-daemon/Cargo.toml
+++ b/subprojects/hydra-drv-daemon/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name                   = "hydra-drv-daemon"
+version.workspace      = true
+edition                = "2024"
+license                = "GPL-3.0"
+rust-version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap             = { workspace = true, features = [ "derive", "env" ] }
+futures.workspace              = true
+tokio                          = { workspace = true, features = [ "full" ] }
+tracing.workspace              = true
+tracing-subscriber             = { workspace = true, features = [ "env-filter" ] }
+
+db                              = { path = "../crates/db" }
+harmonia-protocol.workspace     = true
+harmonia-store-aterm.workspace  = true
+harmonia-store-core.workspace   = true
+harmonia-store-remote.workspace = true
+harmonia-utils-io.workspace     = true
+
+[dev-dependencies]
+harmonia-utils-hash.workspace = true
+serde_json.workspace          = true
+sqlx                          = { workspace = true, features = [ "runtime-tokio", "postgres" ] }
+test-utils                    = { path = "../crates/test-utils" }

--- a/subprojects/hydra-drv-daemon/src/handler.rs
+++ b/subprojects/hydra-drv-daemon/src/handler.rs
@@ -1,0 +1,282 @@
+use std::future::{Future, ready};
+use std::pin::Pin;
+
+use tokio::io::AsyncBufRead;
+
+use harmonia_protocol::daemon::{
+    DaemonError as ProtocolError, DaemonResult, DaemonStore, FutureResultExt, HandshakeDaemonStore,
+    ResultLog, ResultLogExt, TrustLevel,
+};
+use harmonia_protocol::types::AddToStoreItem;
+use harmonia_protocol::valid_path_info::{UnkeyedValidPathInfo, ValidPathInfo};
+use harmonia_store_core::store_path::{
+    ContentAddressMethodAlgorithm, StorePath, StorePathHash, StorePathSet,
+};
+use harmonia_store_remote::pool::{ConnectionPool, PoolConfig};
+
+use db::StoreDir;
+
+/// Nix daemon handler that intercepts derivation writes and decomposes
+/// them into the drv-in-db Postgres tables, proxying read operations
+/// to the host nix daemon.
+#[derive(Clone)]
+pub struct DrvDaemonHandler {
+    store_dir: StoreDir,
+    db: db::Database,
+    upstream: ConnectionPool,
+}
+
+impl std::fmt::Debug for DrvDaemonHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DrvDaemonHandler")
+            .field("store_dir", &self.store_dir)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DrvDaemonHandler {
+    pub fn new(store_dir: StoreDir, db: db::Database, upstream_socket: &str) -> Self {
+        let upstream = ConnectionPool::new(upstream_socket, PoolConfig::default());
+        Self {
+            store_dir,
+            db,
+            upstream,
+        }
+    }
+
+    /// Read a .drv file from the store, parse it, and insert into the
+    /// drv-in-db tables (Derivations + 5 child tables).
+    async fn intercept_derivation(&self, path: &StorePath) -> Result<(), ProtocolError> {
+        let full_path = format!("{}/{}", self.store_dir, path);
+
+        let content = match tokio::fs::read_to_string(&full_path).await {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::warn!(
+                    path = %full_path,
+                    "drv file not on disk (upstream may have drv-in-db enabled), skipping"
+                );
+                return Ok(());
+            }
+            Err(e) => return Err(ProtocolError::custom(format!("read {full_path}: {e}"))),
+        };
+
+        let drv = harmonia_store_aterm::parse_derivation_aterm(
+            &self.store_dir,
+            &content,
+            path.name().clone(),
+        )
+        .map_err(|e| ProtocolError::custom(format!("parse {full_path}: {e}")))?;
+
+        let mut conn = self
+            .db
+            .get()
+            .await
+            .map_err(|e| ProtocolError::custom(format!("hydra db: {e}")))?;
+
+        match conn
+            .insert_derivation(&full_path, &drv, &self.store_dir)
+            .await
+        {
+            Ok(Some(id)) => {
+                tracing::info!(
+                    path = %full_path,
+                    drv_id = id,
+                    outputs = ?drv.outputs.keys().collect::<Vec<_>>(),
+                    "inserted derivation"
+                );
+            }
+            Ok(None) => {
+                tracing::debug!(path = %full_path, "derivation already exists, skipped");
+            }
+            Err(e) => return Err(ProtocolError::custom(format!("insert drv: {e}"))),
+        }
+
+        Ok(())
+    }
+}
+
+impl HandshakeDaemonStore for DrvDaemonHandler {
+    type Store = Self;
+
+    fn handshake(self) -> impl ResultLog<Output = DaemonResult<Self::Store>> + Send {
+        ready(Ok(self)).empty_logs()
+    }
+}
+
+impl DaemonStore for DrvDaemonHandler {
+    fn trust_level(&self) -> TrustLevel {
+        TrustLevel::Trusted
+    }
+
+    fn set_options<'a>(
+        &'a mut self,
+        _options: &'a harmonia_protocol::types::ClientOptions,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        ready(Ok(())).empty_logs()
+    }
+
+    fn is_valid_path<'a>(
+        &'a mut self,
+        path: &'a StorePath,
+    ) -> impl ResultLog<Output = DaemonResult<bool>> + Send + 'a {
+        let upstream = self.upstream.clone();
+        async move {
+            let mut guard = upstream
+                .acquire()
+                .await
+                .map_err(|e| ProtocolError::custom(format!("upstream pool: {e}")))?;
+            guard.client().is_valid_path(path).await
+        }
+        .empty_logs()
+    }
+
+    fn query_valid_paths<'a>(
+        &'a mut self,
+        paths: &'a StorePathSet,
+        substitute: bool,
+    ) -> impl ResultLog<Output = DaemonResult<StorePathSet>> + Send + 'a {
+        let upstream = self.upstream.clone();
+        async move {
+            let mut guard = upstream
+                .acquire()
+                .await
+                .map_err(|e| ProtocolError::custom(format!("upstream pool: {e}")))?;
+            guard.client().query_valid_paths(paths, substitute).await
+        }
+        .empty_logs()
+    }
+
+    fn query_path_info<'a>(
+        &'a mut self,
+        path: &'a StorePath,
+    ) -> impl ResultLog<Output = DaemonResult<Option<UnkeyedValidPathInfo>>> + Send + 'a {
+        let upstream = self.upstream.clone();
+        async move {
+            let mut guard = upstream
+                .acquire()
+                .await
+                .map_err(|e| ProtocolError::custom(format!("upstream pool: {e}")))?;
+            guard.client().query_path_info(path).await
+        }
+        .empty_logs()
+    }
+
+    fn query_path_from_hash_part<'a>(
+        &'a mut self,
+        hash: &'a StorePathHash,
+    ) -> impl ResultLog<Output = DaemonResult<Option<StorePath>>> + Send + 'a {
+        let upstream = self.upstream.clone();
+        async move {
+            let mut guard = upstream
+                .acquire()
+                .await
+                .map_err(|e| ProtocolError::custom(format!("upstream pool: {e}")))?;
+            guard.client().query_path_from_hash_part(hash).await
+        }
+        .empty_logs()
+    }
+
+    fn add_temp_root<'a>(
+        &'a mut self,
+        _path: &'a StorePath,
+    ) -> impl ResultLog<Output = DaemonResult<()>> + Send + 'a {
+        ready(Ok(())).empty_logs()
+    }
+
+    fn add_ca_to_store<'a, 'r, R>(
+        &'a mut self,
+        name: &'a str,
+        cam: ContentAddressMethodAlgorithm,
+        refs: &'a StorePathSet,
+        repair: bool,
+        source: R,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<ValidPathInfo>> + Send + 'r>>
+    where
+        R: AsyncBufRead + Send + Unpin + 'r,
+        'a: 'r,
+    {
+        let upstream = self.upstream.clone();
+        async move {
+            let mut guard = upstream
+                .acquire()
+                .await
+                .map_err(|e| ProtocolError::custom(format!("upstream pool: {e}")))?;
+            guard
+                .client()
+                .add_ca_to_store(name, cam, refs, repair, source)
+                .await
+        }
+        .empty_logs()
+        .boxed_result()
+    }
+
+    fn add_multiple_to_store<'s, 'i, 'r, S, R>(
+        &'s mut self,
+        repair: bool,
+        dont_check_sigs: bool,
+        stream: S,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<()>> + Send + 'r>>
+    where
+        S: futures::Stream<Item = Result<AddToStoreItem<R>, ProtocolError>> + Send + 'i,
+        R: AsyncBufRead + Send + Unpin + 'i,
+        's: 'r,
+        'i: 'r,
+    {
+        let upstream = self.upstream.clone();
+        async move {
+            let mut guard = upstream
+                .acquire()
+                .await
+                .map_err(|e| ProtocolError::custom(format!("upstream pool: {e}")))?;
+            guard
+                .client()
+                .add_multiple_to_store(repair, dont_check_sigs, stream)
+                .await
+        }
+        .empty_logs()
+        .boxed_result()
+    }
+
+    fn add_to_store_nar<'s, 'r, 'i, R>(
+        &'s mut self,
+        info: &'i ValidPathInfo,
+        source: R,
+        repair: bool,
+        dont_check_sigs: bool,
+    ) -> Pin<Box<dyn ResultLog<Output = DaemonResult<()>> + Send + 'r>>
+    where
+        R: AsyncBufRead + Send + Unpin + 'r,
+        's: 'r,
+        'i: 'r,
+    {
+        let is_drv = info.path.name().as_ref().ends_with(".drv");
+        let drv_path = info.path.clone();
+        let this = self.clone();
+        let upstream = self.upstream.clone();
+
+        async move {
+            let mut guard = upstream
+                .acquire()
+                .await
+                .map_err(|e| ProtocolError::custom(format!("upstream pool: {e}")))?;
+            guard
+                .client()
+                .add_to_store_nar(info, source, repair, dont_check_sigs)
+                .await?;
+            drop(guard);
+
+            if is_drv {
+                this.intercept_derivation(&drv_path).await?;
+            }
+
+            Ok(())
+        }
+        .empty_logs()
+        .boxed_result()
+    }
+
+    fn shutdown(&mut self) -> impl Future<Output = DaemonResult<()>> + Send + '_ {
+        ready(Ok(()))
+    }
+}

--- a/subprojects/hydra-drv-daemon/src/main.rs
+++ b/subprojects/hydra-drv-daemon/src/main.rs
@@ -1,0 +1,47 @@
+mod handler;
+mod server;
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use harmonia_store_core::store_path::StoreDir;
+
+#[derive(Parser, Debug)]
+#[command(about = "Nix daemon proxy that writes derivations to Postgres")]
+struct Args {
+    /// Unix socket to listen on for nix daemon connections.
+    #[arg(long, default_value = "/tmp/hydra-drv-daemon.sock")]
+    socket: PathBuf,
+
+    /// Upstream nix daemon socket to proxy read operations to.
+    #[arg(long, default_value = "/nix/var/nix/daemon-socket/socket")]
+    upstream_socket: String,
+
+    /// PostgreSQL connection URL.
+    #[arg(long, env = "HYDRA_DBA")]
+    db_url: String,
+
+    /// Nix store directory.
+    #[arg(long, default_value = "/nix/store")]
+    store_dir: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let args = Args::parse();
+    let store_dir = StoreDir::new(&args.store_dir)
+        .map_err(|e| anyhow::anyhow!("invalid store dir: {e}"))?;
+    let database = db::Database::new(&args.db_url, 4).await?;
+    let handler =
+        handler::DrvDaemonHandler::new(store_dir.clone(), database, &args.upstream_socket);
+    let server = server::DaemonServer::new(handler, args.socket, store_dir);
+    server.serve().await?;
+    Ok(())
+}

--- a/subprojects/hydra-drv-daemon/src/server.rs
+++ b/subprojects/hydra-drv-daemon/src/server.rs
@@ -1,0 +1,481 @@
+// Nix daemon server, using harmonia-protocol's wire types.
+//
+// Derived from harmonia-daemon::server (EUPL-1.2 OR MIT), adapted to
+// avoid the harmonia-store-db dependency (SQLite conflict with sqlx).
+
+use std::fmt::Debug;
+use std::path::PathBuf;
+use std::pin::pin;
+
+use futures::{FutureExt, StreamExt as _};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, copy_buf};
+use tokio::net::UnixListener;
+use tracing::{debug, error, info};
+
+use harmonia_protocol::ProtocolVersion;
+use harmonia_protocol::daemon::{
+    DaemonError, DaemonResult, DaemonStore, HandshakeDaemonStore, ResultLog,
+    wire::{
+        CLIENT_MAGIC, FramedReader, IgnoredOne, SERVER_MAGIC,
+        logger::RawLogMessage,
+        parse_add_multiple_to_store,
+        types2::{BaseStorePath, Request},
+    },
+};
+use harmonia_protocol::de::{NixRead, NixReader};
+use harmonia_protocol::log::LogMessage;
+use harmonia_protocol::ser::{NixWrite, NixWriter};
+use harmonia_store_core::store_path::StoreDir;
+use harmonia_utils_io::{AsyncBufReadCompat, BytesReader};
+
+const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(1, 37);
+const NIX_VERSION: &str = "2.24.0 (Hydra)";
+
+struct RecoverableError {
+    can_recover: bool,
+    source: DaemonError,
+}
+
+impl<T: Into<DaemonError>> From<T> for RecoverableError {
+    fn from(source: T) -> Self {
+        RecoverableError {
+            can_recover: false,
+            source: source.into(),
+        }
+    }
+}
+
+trait RecoverExt<T> {
+    fn recover(self) -> Result<T, RecoverableError>;
+}
+
+impl<T, E: Into<DaemonError>> RecoverExt<T> for Result<T, E> {
+    fn recover(self) -> Result<T, RecoverableError> {
+        self.map_err(|source| RecoverableError {
+            can_recover: true,
+            source: source.into(),
+        })
+    }
+}
+
+fn log_to_raw(msg: LogMessage) -> RawLogMessage {
+    match msg {
+        LogMessage::Message(m) => RawLogMessage::Next(m.text),
+        LogMessage::StartActivity(a) => RawLogMessage::StartActivity(a),
+        LogMessage::StopActivity(a) => RawLogMessage::StopActivity(a),
+        LogMessage::Result(r) => RawLogMessage::Result(r),
+    }
+}
+
+async fn write_log<W>(writer: &mut NixWriter<W>, msg: LogMessage) -> Result<(), RecoverableError>
+where
+    W: AsyncWrite + Send + Unpin,
+{
+    writer.write_value(&log_to_raw(msg)).await?;
+    Ok(())
+}
+
+async fn process_logs<'s, T: Send + 's, W>(
+    writer: &mut NixWriter<W>,
+    logs: impl ResultLog<Output = DaemonResult<T>> + Send + 's,
+) -> Result<T, RecoverableError>
+where
+    W: AsyncWrite + Send + Unpin,
+{
+    let mut logs = pin!(logs);
+    while let Some(msg) = logs.next().await {
+        write_log(writer, msg).await?;
+    }
+    logs.await.recover()
+}
+
+struct DaemonConnection<R, W> {
+    reader: NixReader<BytesReader<R>>,
+    writer: NixWriter<W>,
+}
+
+impl<R, W> DaemonConnection<R, W>
+where
+    R: AsyncRead + Debug + Send + Unpin,
+    W: AsyncWrite + Debug + Send + Unpin,
+{
+    async fn handshake(&mut self) -> DaemonResult<()> {
+        let magic: u64 = self.reader.read_number().await?;
+        if magic != CLIENT_MAGIC {
+            return Err(DaemonError::custom(format!("bad client magic: {magic:#x}")));
+        }
+        self.writer.write_number(SERVER_MAGIC).await?;
+        self.writer.write_value(&PROTOCOL_VERSION).await?;
+        self.writer.flush().await?;
+
+        let client_version: ProtocolVersion = self.reader.read_value().await?;
+        self.reader.set_version(client_version);
+        self.writer.set_version(client_version);
+
+        if client_version.minor() >= 14 {
+            let _: bool = self.reader.read_value().await?;
+        }
+        if client_version.minor() >= 11 {
+            let _: bool = self.reader.read_value().await?;
+        }
+        if client_version.minor() >= 33 {
+            self.writer.write_value(NIX_VERSION).await?;
+        }
+        if client_version.minor() >= 35 {
+            self.writer
+                .write_value(&harmonia_protocol::types::TrustLevel::Trusted)
+                .await?;
+        }
+        self.writer.flush().await?;
+        Ok(())
+    }
+
+    async fn process_logs_write<'s, T: Send + 's>(
+        &'s mut self,
+        logs: impl ResultLog<Output = DaemonResult<T>> + Send + 's,
+    ) -> Result<T, RecoverableError> {
+        let value = process_logs(&mut self.writer, logs).await?;
+        self.writer.write_value(&RawLogMessage::Last).await?;
+        Ok(value)
+    }
+
+    async fn process_requests<'s, S>(&'s mut self, mut store: S) -> Result<(), DaemonError>
+    where
+        S: DaemonStore + 's,
+    {
+        loop {
+            let fut = self.reader.try_read_value::<Request>().boxed();
+            let res = fut.await?;
+            let Some(request) = res else {
+                break;
+            };
+            let op = request.operation();
+            debug!("got op {}", op);
+            if let Err(mut err) = self.process_request(&mut store, request).await {
+                error!(error = ?err.source, recover=err.can_recover, "error processing request");
+                err.source = err.source.fill_operation(op);
+                if err.can_recover {
+                    self.writer
+                        .write_value(&RawLogMessage::Error(err.source.into()))
+                        .await?;
+                } else {
+                    return Err(err.source);
+                }
+            }
+            self.writer.flush().await?;
+        }
+        store.shutdown().await
+    }
+
+    async fn process_request<'s, S>(
+        &'s mut self,
+        store: &mut S,
+        request: Request,
+    ) -> Result<(), RecoverableError>
+    where
+        S: DaemonStore + 's,
+    {
+        use Request::*;
+        match request {
+            SetOptions(options) => {
+                let logs = store.set_options(&options);
+                self.process_logs_write(logs).await?;
+            }
+            IsValidPath(path) => {
+                let logs = store.is_valid_path(&path);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            QueryValidPaths(req) => {
+                let logs = store.query_valid_paths(&req.paths, req.substitute);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            QueryPathInfo(path) => {
+                let logs = store.query_path_info(&path);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            NarFromPath(path) => {
+                let logs = store.nar_from_path(&path);
+                let mut logs = pin!(logs);
+                while let Some(msg) = logs.next().await {
+                    write_log(&mut self.writer, msg).await?;
+                }
+                let mut reader = pin!(logs.await?);
+                self.writer.write_value(&RawLogMessage::Last).await?;
+                copy_buf(&mut reader, &mut self.writer)
+                    .await
+                    .map_err(DaemonError::from)?;
+            }
+            QueryReferrers(path) => {
+                let logs = store.query_referrers(&path);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            AddToStore(req) => {
+                let buf_reader = AsyncBufReadCompat::new(&mut self.reader);
+                let mut framed = FramedReader::new(buf_reader);
+                let logs =
+                    store.add_ca_to_store(&req.name, req.cam, &req.refs, req.repair, &mut framed);
+                let res = process_logs(&mut self.writer, logs).await;
+                let err = framed.drain_all().await;
+                let value = res?;
+                err?;
+                self.writer.write_value(&RawLogMessage::Last).await?;
+                self.writer.write_value(&value).await?;
+            }
+            BuildPaths(req) => {
+                let logs = store.build_paths(&req.paths, req.mode);
+                self.process_logs_write(logs).await?;
+                self.writer.write_value(&IgnoredOne).await?;
+            }
+            EnsurePath(path) => {
+                let logs = store.ensure_path(&path);
+                self.process_logs_write(logs).await?;
+                self.writer.write_value(&IgnoredOne).await?;
+            }
+            AddTempRoot(path) => {
+                let logs = store.add_temp_root(&path);
+                self.process_logs_write(logs).await?;
+                self.writer.write_value(&IgnoredOne).await?;
+            }
+            AddIndirectRoot(path) => {
+                let logs = store.add_indirect_root(&path);
+                self.process_logs_write(logs).await?;
+                self.writer.write_value(&IgnoredOne).await?;
+            }
+            FindRoots => {
+                let logs = store.find_roots();
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            CollectGarbage(req) => {
+                let logs = store.collect_garbage(
+                    req.action,
+                    &req.paths_to_delete,
+                    req.ignore_liveness,
+                    req.max_freed,
+                );
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            QueryAllValidPaths => {
+                let logs = store.query_all_valid_paths();
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            QueryPathFromHashPart(hash) => {
+                let logs = store.query_path_from_hash_part(&hash);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            QuerySubstitutablePaths(paths) => {
+                let logs = store.query_substitutable_paths(&paths);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            QueryValidDerivers(path) => {
+                let logs = store.query_valid_derivers(&path);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            OptimiseStore => {
+                let logs = store.optimise_store();
+                self.process_logs_write(logs).await?;
+                self.writer.write_value(&IgnoredOne).await?;
+            }
+            VerifyStore(req) => {
+                let logs = store.verify_store(req.check_contents, req.repair);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            BuildDerivation(req) => {
+                let (drv_path, drv) = &req.drv;
+                let logs = store.build_derivation(drv_path, drv, req.mode);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            AddSignatures(req) => {
+                let logs = store.add_signatures(&req.path, &req.signatures);
+                self.process_logs_write(logs).await?;
+                self.writer.write_value(&IgnoredOne).await?;
+            }
+            AddToStoreNar(req) => {
+                let buf_reader = AsyncBufReadCompat::new(&mut self.reader);
+                let mut framed = FramedReader::new(buf_reader);
+                let logs = store.add_to_store_nar(
+                    &req.path_info,
+                    &mut framed,
+                    req.repair,
+                    req.dont_check_sigs,
+                );
+                let res: Result<(), RecoverableError> = async {
+                    let mut logs = pin!(logs);
+                    while let Some(msg) = logs.next().await {
+                        write_log(&mut self.writer, msg).await?;
+                    }
+                    logs.await.recover()?;
+                    Ok(())
+                }
+                .await;
+                let err = framed.drain_all().await;
+                res?;
+                err?;
+                self.writer.write_value(&RawLogMessage::Last).await?;
+            }
+            QueryMissing(paths) => {
+                let logs = store.query_missing(&paths);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            QueryDerivationOutputMap(path) => {
+                let logs = store.query_derivation_output_map(&path);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            RegisterDrvOutput(realisation) => {
+                let logs = store.register_drv_output(&realisation);
+                self.process_logs_write(logs).await?;
+            }
+            QueryRealisation(output_id) => {
+                let logs = store.query_realisation(&output_id);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            AddMultipleToStore(req) => {
+                let builder = NixReader::builder().set_version(self.reader.version());
+                let buf_reader = AsyncBufReadCompat::new(&mut self.reader);
+                let mut framed = FramedReader::new(buf_reader);
+                let source = builder.build_buffered(&mut framed);
+                let stream = parse_add_multiple_to_store(source).await?;
+                let logs = store.add_multiple_to_store(req.repair, req.dont_check_sigs, stream);
+                let res: Result<(), RecoverableError> = async {
+                    let mut logs = pin!(logs);
+                    while let Some(msg) = logs.next().await {
+                        write_log(&mut self.writer, msg).await?;
+                    }
+                    logs.await.recover()?;
+                    self.writer.write_value(&RawLogMessage::Last).await?;
+                    Ok(())
+                }
+                .await;
+                let err = framed.drain_all().await;
+                res?;
+                err?;
+            }
+            AddBuildLog(BaseStorePath(path)) => {
+                let buf_reader = AsyncBufReadCompat::new(&mut self.reader);
+                let mut framed = FramedReader::new(buf_reader);
+                let logs = store.add_build_log(&path, &mut framed);
+                let res = process_logs(&mut self.writer, logs).await;
+                let err = framed.drain_all().await;
+                res?;
+                err?;
+                self.writer.write_value(&RawLogMessage::Last).await?;
+                self.writer.write_value(&IgnoredOne).await?;
+            }
+            BuildPathsWithResults(req) => {
+                let logs = store.build_paths_with_results(&req.paths, req.mode);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+            AddPermRoot(req) => {
+                let logs = store.add_perm_root(&req.store_path, &req.gc_root);
+                let value = self.process_logs_write(logs).await?;
+                self.writer.write_value(&value).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct DaemonServer<H> {
+    handler: H,
+    socket_path: PathBuf,
+    store_dir: StoreDir,
+}
+
+impl<H> DaemonServer<H>
+where
+    H: HandshakeDaemonStore + Clone + Send + Sync + 'static,
+{
+    pub fn new(handler: H, socket_path: PathBuf, store_dir: StoreDir) -> Self {
+        Self {
+            handler,
+            socket_path,
+            store_dir,
+        }
+    }
+
+    pub async fn serve(&self) -> Result<(), std::io::Error> {
+        if self.socket_path.exists() {
+            std::fs::remove_file(&self.socket_path)?;
+        }
+        if let Some(parent) = self.socket_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let listener = UnixListener::bind(&self.socket_path)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o666);
+            std::fs::set_permissions(&self.socket_path, perms)?;
+        }
+
+        info!("nix daemon listening on {:?}", self.socket_path);
+
+        loop {
+            let (stream, _addr) = listener.accept().await?;
+            let handler = self.handler.clone();
+            let store_dir = self.store_dir.clone();
+
+            tokio::spawn(async move {
+                let (reader, writer) = stream.into_split();
+                let reader = NixReader::builder()
+                    .set_store_dir(&store_dir)
+                    .build_buffered(reader);
+                let writer = NixWriter::builder().set_store_dir(&store_dir).build(writer);
+                let mut conn = DaemonConnection { reader, writer };
+
+                if let Err(e) = conn.handshake().await {
+                    error!("handshake error: {e:?}");
+                    return;
+                }
+
+                let store = {
+                    let logs = handler.handshake();
+                    let mut logs = std::pin::pin!(logs);
+                    while let Some(msg) = futures::StreamExt::next(&mut logs).await {
+                        if let Err(e) = conn.writer.write_value(&log_to_raw(msg)).await {
+                            error!("handshake log error: {e:?}");
+                            return;
+                        }
+                    }
+                    if let Err(e) = conn.writer.write_value(&RawLogMessage::Last).await {
+                        error!("handshake terminator error: {e:?}");
+                        return;
+                    }
+                    match logs.await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!("store handshake error: {e:?}");
+                            return;
+                        }
+                    }
+                };
+                if let Err(e) = conn.writer.flush().await {
+                    error!("handshake flush error: {e:?}");
+                    return;
+                }
+
+                if let Err(e) = conn.process_requests(store).await {
+                    error!("connection error: {e:?}");
+                }
+            });
+        }
+    }
+}

--- a/subprojects/hydra-drv-daemon/tests/decompose.rs
+++ b/subprojects/hydra-drv-daemon/tests/decompose.rs
@@ -1,0 +1,345 @@
+//! Tests for insert_derivation: decomposing Derivation structs into the 6 drv-in-db tables.
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::BTreeSet;
+
+use harmonia_store_core::derivation::{Derivation, DerivationOutput};
+use harmonia_store_core::derived_path::SingleDerivedPath;
+use harmonia_store_core::store_path::{StoreDir, StorePath};
+
+fn store_dir() -> StoreDir {
+    StoreDir::new("/nix/store").unwrap()
+}
+
+fn sp(hash_name: &str) -> StorePath {
+    store_dir()
+        .parse::<StorePath>(&format!("/nix/store/{hash_name}"))
+        .unwrap()
+}
+
+fn make_drv(
+    outputs: Vec<(&str, DerivationOutput)>,
+    inputs: BTreeSet<SingleDerivedPath>,
+    env: Vec<(&str, &str)>,
+) -> Derivation {
+    use harmonia_store_core::ByteString;
+
+    let output_map = outputs
+        .into_iter()
+        .map(|(k, v)| (k.parse().unwrap(), v))
+        .collect();
+    let env_map = env
+        .into_iter()
+        .map(|(k, v)| {
+            (
+                ByteString::from(k.to_owned().into_bytes()),
+                ByteString::from(v.to_owned().into_bytes()),
+            )
+        })
+        .collect();
+    Derivation {
+        name: "test-drv".parse().unwrap(),
+        outputs: output_map,
+        inputs,
+        platform: ByteString::from(b"x86_64-linux" as &[u8]),
+        builder: ByteString::from(b"/bin/sh" as &[u8]),
+        args: vec![
+            ByteString::from(b"-e" as &[u8]),
+            ByteString::from(b"echo hello" as &[u8]),
+        ],
+        env: env_map,
+        structured_attrs: None,
+    }
+}
+
+async fn setup() -> (test_utils::TestPg, sqlx::PgPool) {
+    test_utils::TestPg::new_drv_in_db().await
+}
+
+#[tokio::test]
+async fn input_addressed_drv() {
+    let (pg, pool) = setup().await;
+    let sd = store_dir();
+    let mut conn = db::Connection::new(pool.acquire().await.unwrap());
+
+    let out_path = sp("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-result");
+    let drv = make_drv(
+        vec![("out", DerivationOutput::InputAddressed(out_path))],
+        BTreeSet::new(),
+        vec![("name", "test")],
+    );
+
+    let drv_id = conn
+        .insert_derivation(
+            "/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-test.drv",
+            &drv,
+            &sd,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    let verify = sqlx::PgPool::connect(&pg.url()).await.unwrap();
+
+    let row: (String, String, i32) = sqlx::query_as(
+        "SELECT platform, builder, outputType FROM Derivations WHERE id = $1",
+    )
+    .bind(drv_id)
+    .fetch_one(&verify)
+    .await
+    .unwrap();
+    assert_eq!(row.0, "x86_64-linux");
+    assert_eq!(row.1, "/bin/sh");
+    assert_eq!(row.2, 0);
+
+    let out: (String, Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT id, path, hash FROM DerivationOutputs WHERE drv = $1",
+    )
+    .bind(drv_id)
+    .fetch_one(&verify)
+    .await
+    .unwrap();
+    assert_eq!(out.0, "out");
+    assert!(out.1.unwrap().contains("result"));
+    assert!(out.2.is_none());
+
+    let env: (String,) = sqlx::query_as(
+        "SELECT value FROM DerivationEnv WHERE drv = $1 AND key = 'name'",
+    )
+    .bind(drv_id)
+    .fetch_one(&verify)
+    .await
+    .unwrap();
+    assert_eq!(env.0, "test");
+}
+
+#[tokio::test]
+async fn deferred_drv() {
+    let (_pg, pool) = setup().await;
+    let sd = store_dir();
+    let mut conn = db::Connection::new(pool.acquire().await.unwrap());
+
+    let drv = make_drv(
+        vec![("out", DerivationOutput::Deferred)],
+        BTreeSet::new(),
+        vec![],
+    );
+
+    let id = conn
+        .insert_derivation(
+            "/nix/store/cccccccccccccccccccccccccccccccc-deferred.drv",
+            &drv,
+            &sd,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    let row: (i32, Option<String>, Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT outputType, path, method, hash FROM DerivationOutputs WHERE drv = $1",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, 3);
+    assert!(row.1.is_none());
+    assert!(row.2.is_none());
+    assert!(row.3.is_none());
+}
+
+#[tokio::test]
+async fn ca_floating_drv() {
+    let (_pg, pool) = setup().await;
+    let sd = store_dir();
+    let mut conn = db::Connection::new(pool.acquire().await.unwrap());
+
+    use harmonia_store_core::store_path::ContentAddressMethodAlgorithm;
+    use harmonia_utils_hash::Algorithm;
+
+    let cam = ContentAddressMethodAlgorithm::Recursive(Algorithm::SHA256);
+    let drv = make_drv(
+        vec![("out", DerivationOutput::CAFloating(cam))],
+        BTreeSet::new(),
+        vec![],
+    );
+
+    let id = conn
+        .insert_derivation(
+            "/nix/store/dddddddddddddddddddddddddddddddd-cafloat.drv",
+            &drv,
+            &sd,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    let row: (i32, Option<String>, Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT outputType, method, hashAlgo, hash FROM DerivationOutputs WHERE drv = $1",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, 2);
+    assert_eq!(row.1.unwrap(), "r:sha256");
+    assert_eq!(row.2.unwrap(), "sha256");
+    assert!(row.3.is_none());
+}
+
+#[tokio::test]
+async fn duplicate_path_returns_none() {
+    let (_pg, pool) = setup().await;
+    let sd = store_dir();
+    let mut conn = db::Connection::new(pool.acquire().await.unwrap());
+
+    let drv = make_drv(
+        vec![("out", DerivationOutput::Deferred)],
+        BTreeSet::new(),
+        vec![],
+    );
+
+    let first = conn
+        .insert_derivation(
+            "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-dup.drv",
+            &drv,
+            &sd,
+        )
+        .await
+        .unwrap();
+    assert!(first.is_some());
+
+    let second = conn
+        .insert_derivation(
+            "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-dup.drv",
+            &drv,
+            &sd,
+        )
+        .await
+        .unwrap();
+    assert!(second.is_none(), "duplicate insert should return None");
+}
+
+#[tokio::test]
+async fn env_vars_round_trip() {
+    let (_pg, pool) = setup().await;
+    let sd = store_dir();
+    let mut conn = db::Connection::new(pool.acquire().await.unwrap());
+
+    let env = vec![
+        ("name", "my-package"),
+        ("system", "x86_64-linux"),
+        ("src", "/nix/store/fff-source"),
+    ];
+    let drv = make_drv(
+        vec![("out", DerivationOutput::Deferred)],
+        BTreeSet::new(),
+        env,
+    );
+
+    let id = conn
+        .insert_derivation(
+            "/nix/store/gggggggggggggggggggggggggggggggg-envtest.drv",
+            &drv,
+            &sd,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT key, value FROM DerivationEnv WHERE drv = $1 ORDER BY key",
+    )
+    .bind(id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0], ("name".into(), "my-package".into()));
+    assert_eq!(rows[1], ("src".into(), "/nix/store/fff-source".into()));
+    assert_eq!(rows[2], ("system".into(), "x86_64-linux".into()));
+}
+
+#[tokio::test]
+async fn inputs_stored() {
+    let (_pg, pool) = setup().await;
+    let sd = store_dir();
+    let mut conn = db::Connection::new(pool.acquire().await.unwrap());
+
+    let src = sp("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh-source");
+    let mut inputs = BTreeSet::new();
+    inputs.insert(SingleDerivedPath::Opaque(src));
+
+    let drv = make_drv(vec![("out", DerivationOutput::Deferred)], inputs, vec![]);
+
+    let id = conn
+        .insert_derivation(
+            "/nix/store/iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii-withsrc.drv",
+            &drv,
+            &sd,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT path FROM DerivationInputs WHERE drv = $1")
+            .bind(id)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].0.contains("source"));
+}
+
+#[tokio::test]
+async fn structured_attrs_stored() {
+    let (_pg, pool) = setup().await;
+    let sd = store_dir();
+    let mut conn = db::Connection::new(pool.acquire().await.unwrap());
+
+    use harmonia_store_core::derivation::StructuredAttrs;
+
+    let mut attrs = serde_json::Map::new();
+    attrs.insert("allowedReferences".into(), serde_json::json!([]));
+    attrs.insert("version".into(), serde_json::json!("1.0"));
+
+    let mut drv = make_drv(
+        vec![("out", DerivationOutput::Deferred)],
+        BTreeSet::new(),
+        vec![],
+    );
+    drv.structured_attrs = Some(StructuredAttrs { attrs });
+
+    let id = conn
+        .insert_derivation(
+            "/nix/store/jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj-sa.drv",
+            &drv,
+            &sd,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    let sa_flag: (bool,) = sqlx::query_as(
+        "SELECT hasStructuredAttrs FROM Derivations WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(sa_flag.0);
+
+    let rows: Vec<(String, serde_json::Value)> = sqlx::query_as(
+        "SELECT key, value FROM DerivationStructuredAttrs WHERE drv = $1 ORDER BY key",
+    )
+    .bind(id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].0, "allowedReferences");
+    assert_eq!(rows[1].0, "version");
+    assert_eq!(rows[1].1, serde_json::json!("1.0"));
+}

--- a/subprojects/hydra/sql/upgrade-86.sql
+++ b/subprojects/hydra/sql/upgrade-86.sql
@@ -1,0 +1,127 @@
+-- Core derivation metadata (1:1 with ValidPaths for .drv store paths)
+create table if not exists Derivations (
+    id                 serial primary key not null,
+    path               text unique not null
+        check (path like '%.drv'),
+    -- BasicDerivation::platform
+    platform           text not null,
+    -- BasicDerivation::builder
+    builder            text not null,
+    -- BasicDerivation::args
+    args               text[] not null default '{}',
+    -- DerivationOutput variant type (applies to all outputs):
+    --   0 = inputAddressed  (outputs have path)
+    --   1 = caFixed         (outputs have method, hashAlgo, hash)
+    --   2 = caFloating      (outputs have method, hashAlgo)
+    --   3 = deferred        (outputs have no extra fields)
+    --   4 = impure          (outputs have method, hashAlgo)
+    outputType         integer not null
+        check (outputType between 0 and 4),
+    -- false = nullopt, true = Some({...})
+    -- Distinguishes "no structured attrs" from "empty structured attrs object"
+    hasStructuredAttrs boolean not null default false,
+    unique (id, outputType),
+    unique (id, hasStructuredAttrs)
+);
+
+-- BasicDerivation::outputs (DerivationOutput variant)
+create table if not exists DerivationOutputs (
+    drv        integer not null,
+    -- output name, e.g. "out"
+    id         text not null,
+    -- must match parent Derivations.outputType (composite FK enforced)
+    --
+    -- That means is only pseduo-denormalized from Derivations, because
+    -- the via composite FK ensures they never get out of sync.
+    --
+    -- Why do we do this? so per-row CHECK constraints can enforce the
+    -- right columns per type. (Check constraints cannot follow foreign
+    -- keys.)
+    outputType integer not null
+        check (outputType between 0 and 4),
+    -- store path (inputAddressed only)
+    path       text,
+    -- ContentAddressMethod (caFixed/caFloating/impure)
+    method     text,
+    -- HashAlgorithm (caFixed/caFloating/impure)
+    hashAlgo   text,
+    -- hash value (caFixed only)
+    hash       text,
+    primary key (drv, id),
+    foreign key (drv, outputType) references Derivations(id, outputType) on delete cascade,
+    -- Enforce exactly one valid column shape per output type:
+    check (
+        (outputType = 0 -- inputAddressed
+            and path is not null
+            and method is null and hashAlgo is null and hash is null)
+        or (outputType = 1 -- caFixed
+            and path is null
+            and method is not null and hashAlgo is not null and hash is not null)
+        or (outputType = 2 -- caFloating
+            and path is null and hash is null
+            and method is not null and hashAlgo is not null)
+        or (outputType = 3 -- deferred
+            and path is null and method is null and hashAlgo is null and hash is null)
+        or (outputType = 4 -- impure
+            and path is null and hash is null
+            and method is not null and hashAlgo is not null)
+    )
+);
+
+-- Derivation::inputDrvs (top-level DerivedPathMap entries)
+--
+-- This encodes a member of the set of inputs which is a SingleDerivedPath.
+create table if not exists DerivationInputs (
+    drv        integer not null,
+    -- store path of the input
+    path       text not null,
+    -- JSON array of output names needed from this input.
+    --
+    -- The encoding is like this:
+    --
+    -- []: Opaque(path)
+    -- [output0]: Built(Opaque(path), output0)
+    -- [output0, output1]: Built(Built(Opaque path, output0), output1)
+    -- [..., outputN]: Built(..., outputN)
+    outputs    jsonb not null
+        check (jsonb_typeof(outputs) = 'array'),
+    primary key (drv, path, outputs),
+    foreign key (drv) references Derivations(id) on delete cascade
+);
+
+-- BasicDerivation::inputSrcs
+create table if not exists DerivationInputSrcs (
+    drv        integer not null,
+    -- store path
+    src        text not null,
+    primary key (drv, src),
+    foreign key (drv) references Derivations(id) on delete cascade
+);
+
+-- BasicDerivation::env
+create table if not exists DerivationEnv (
+    drv        integer not null,
+    key        text not null,
+    value      text not null,
+    primary key (drv, key),
+    foreign key (drv) references Derivations(id) on delete cascade
+);
+
+-- BasicDerivation::structuredAttrs (key -> JSON value pairs)
+-- Rows can only exist when parent Derivations.hasStructuredAttrs = true.
+-- nullopt vs empty object: if hasStructuredAttrs = false, no rows possible
+-- (FK constraint). If true, zero rows = empty object {}.
+create table if not exists DerivationStructuredAttrs (
+    drv                integer not null,
+    -- Always true; enforced by CHECK. Part of composite FK to ensure
+    -- parent Derivations row has hasStructuredAttrs = true.
+    --
+    -- This is the same pseudo-denormalization trick that we did with
+    -- DerivationOutputs::outputType.
+    hasStructuredAttrs boolean not null check (hasStructuredAttrs = true),
+    key                text not null,
+    value              jsonb not null,
+    primary key (drv, hasStructuredAttrs, key),
+    foreign key (drv, hasStructuredAttrs)
+        references Derivations(id, hasStructuredAttrs) on delete cascade
+);


### PR DESCRIPTION
## Summary

The first commit is a direct port of the 6 normalized tables from NixOS/nix's [`drv-in-db`](https://github.com/NixOS/nix/tree/drv-in-db)
branch, and is adapted for Postgres: `jsonb_typeof` instead of `json_type`, native `text[]`
for args, boolean `hasStructuredAttrs`, and serial PK since hydra has no
`ValidPaths` table.

The second commit adds a separate crate/exe that sits between the evaluator
and the real nix daemon. It speaks the daemon protocol, proxies reads
through to the host store, and when a .drv lands via add_to_store_nar
it parses the ATerm and fans the result out into the 6 drv-in-db tables.