### PR TITLE
crates/db: Use harmonia types for store paths

### DIFF
--- a/subprojects/crates/db/src/connection.rs
+++ b/subprojects/crates/db/src/connection.rs
@@ -1,6 +1,10 @@
+use std::collections::BTreeMap;
+
+use anyhow::Context;
 use sqlx::Acquire;
 
-use harmonia_store_core::store_path::StoreDir;
+use harmonia_store_core::derived_path::OutputName;
+use harmonia_store_core::store_path::{StoreDir, StorePath};
 
 use super::models::{
     Build, BuildSmall, BuildStatus, BuildSteps, InsertBuildMetric, InsertBuildProduct,
@@ -144,9 +148,17 @@ impl Connection {
     }
 
     #[tracing::instrument(skip(self, paths), err)]
-    pub async fn check_if_paths_failed(&mut self, paths: &[String]) -> sqlx::Result<bool> {
+    pub async fn check_if_paths_failed(
+        &mut self,
+        store_dir: &StoreDir,
+        paths: &[StorePath],
+    ) -> sqlx::Result<bool> {
+        let paths: Vec<String> = paths
+            .iter()
+            .map(|p| store_dir.display(p).to_string())
+            .collect();
         Ok(
-            !sqlx::query!("SELECT path FROM failedpaths where path = ANY($1)", paths)
+            !sqlx::query!("SELECT path FROM failedpaths where path = ANY($1)", &paths)
                 .fetch_all(&mut *self.conn)
                 .await?
                 .is_empty(),
@@ -180,10 +192,12 @@ impl Connection {
 
     pub async fn insert_debug_build(
         &mut self,
+        store_dir: &StoreDir,
         jobset_id: i32,
-        drv_path: &str,
+        drv_path: &StorePath,
         system: &str,
     ) -> sqlx::Result<()> {
+        let drv_path = store_dir.display(drv_path).to_string();
         sqlx::query!(
             r#"INSERT INTO builds (
               finished,
@@ -226,8 +240,10 @@ impl Connection {
 
     pub async fn get_build_output_for_path(
         &mut self,
-        out_path: &str,
+        store_dir: &StoreDir,
+        out_path: &StorePath,
     ) -> sqlx::Result<Option<super::models::BuildOutput>> {
+        let out_path = store_dir.display(out_path).to_string();
         sqlx::query_as!(
             super::models::BuildOutput,
             r#"
@@ -236,7 +252,7 @@ impl Connection {
             FROM builds b
             JOIN buildoutputs o on b.id = o.build
             WHERE finished = 1 and (buildStatus = 0 or buildStatus = 6) and path = $1;"#,
-            out_path,
+            out_path.as_str(),
         )
         .fetch_optional(&mut *self.conn)
         .await
@@ -299,8 +315,9 @@ impl Connection {
     /// Panics if the SQL `ordinality` column is negative (should never happen).
     pub async fn resolve_drv_output_chains(
         &mut self,
-        chains: &[(&str, &[&str])],
-    ) -> sqlx::Result<Vec<Option<String>>> {
+        store_dir: &StoreDir,
+        chains: &[(&StorePath, &[&OutputName])],
+    ) -> sqlx::Result<Vec<Option<StorePath>>> {
         if chains.is_empty() {
             return Ok(Vec::new());
         }
@@ -311,8 +328,8 @@ impl Connection {
                 .iter()
                 .map(|(root, outputs)| {
                     serde_json::json!({
-                        "root": root,
-                        "chain": outputs,
+                        "root": store_dir.display(*root).to_string(),
+                        "chain": outputs.iter().map(AsRef::as_ref).collect::<Vec<&str>>(),
                     })
                 })
                 .collect(),
@@ -364,9 +381,16 @@ impl Connection {
 
         let mut results = vec![None; chains.len()];
         for (idx, path) in rows {
-            #[allow(clippy::expect_used)]
-            let i = usize::try_from(idx - 1).expect("SQL ordinality is always positive");
-            results[i] = path;
+            let i = usize::try_from(idx - 1)
+                .context("SQL ordinality is always positive")
+                .map_err(|e| sqlx::Error::Decode(e.into_boxed_dyn_error()))?;
+            results[i] = path
+                .map(|p| {
+                    store_dir
+                        .parse(&p)
+                        .map_err(|e| sqlx::Error::Decode(Box::new(e)))
+                })
+                .transpose()?;
         }
         Ok(results)
     }
@@ -480,16 +504,18 @@ impl Transaction<'_> {
     #[tracing::instrument(skip(self, name, path), err)]
     pub async fn update_build_output(
         &mut self,
+        store_dir: &StoreDir,
         build_id: i32,
         name: &str,
-        path: &str,
+        path: &StorePath,
     ) -> sqlx::Result<()> {
+        let path = store_dir.display(path).to_string();
         // TODO: support inserting multiple at the same time
         sqlx::query!(
             "UPDATE buildoutputs SET path = $3 WHERE build = $1 AND name = $2",
             build_id,
             name,
-            path,
+            path.as_str(),
         )
         .execute(&mut *self.tx)
         .await?;
@@ -497,8 +523,13 @@ impl Transaction<'_> {
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_last_build_step_id(&mut self, path: &str) -> sqlx::Result<Option<i32>> {
-        Ok(sqlx::query!("SELECT MAX(build) FROM buildsteps WHERE drvPath = $1 and startTime != 0 and stopTime != 0 and status = 1", path)
+    pub async fn get_last_build_step_id(
+        &mut self,
+        store_dir: &StoreDir,
+        path: &StorePath,
+    ) -> sqlx::Result<Option<i32>> {
+        let path = store_dir.display(path).to_string();
+        Ok(sqlx::query!("SELECT MAX(build) FROM buildsteps WHERE drvPath = $1 and startTime != 0 and stopTime != 0 and status = 1", path.as_str())
             .fetch_optional(&mut *self.tx)
             .await?
             .and_then(|v| v.max))
@@ -507,8 +538,10 @@ impl Transaction<'_> {
     #[tracing::instrument(skip(self), err)]
     pub async fn get_last_build_step_id_for_output_path(
         &mut self,
-        path: &str,
+        store_dir: &StoreDir,
+        path: &StorePath,
     ) -> sqlx::Result<Option<i32>> {
+        let path = store_dir.display(path).to_string();
         Ok(sqlx::query!(
             r#"
                   SELECT MAX(s.build) FROM buildsteps s
@@ -518,7 +551,7 @@ impl Transaction<'_> {
                     AND status = 1
                     AND path = $1
                 "#,
-            path,
+            path.as_str(),
         )
         .fetch_optional(&mut *self.tx)
         .await?
@@ -528,9 +561,11 @@ impl Transaction<'_> {
     #[tracing::instrument(skip(self, drv_path, name), err)]
     pub async fn get_last_build_step_id_for_output_with_drv(
         &mut self,
-        drv_path: &str,
+        store_dir: &StoreDir,
+        drv_path: &StorePath,
         name: &str,
     ) -> sqlx::Result<Option<i32>> {
+        let drv_path = store_dir.display(drv_path).to_string();
         Ok(sqlx::query!(
             r#"
                   SELECT MAX(s.build) FROM buildsteps s
@@ -552,8 +587,10 @@ impl Transaction<'_> {
     #[tracing::instrument(skip(self, step), err)]
     pub async fn insert_build_step(
         &mut self,
+        store_dir: &StoreDir,
         step: InsertBuildStep<'_>,
     ) -> sqlx::Result<Option<i32>> {
+        let drv_path = store_dir.display(step.drv_path).to_string();
         let success = sqlx::query!(
             r#"
               WITH max AS (SELECT MAX(stepnr) AS val FROM buildsteps WHERE build = $1),
@@ -584,7 +621,7 @@ impl Transaction<'_> {
             "#,
             step.build_id,
             step.r#type as i32,
-            step.drv_path,
+            drv_path.as_str(),
             i32::from(step.busy),
             step.start_time,
             step.stop_time,
@@ -607,7 +644,8 @@ impl Transaction<'_> {
     #[tracing::instrument(skip(self, outputs), err)]
     pub async fn insert_build_step_outputs(
         &mut self,
-        outputs: &[InsertBuildStepOutput<String>],
+        store_dir: &StoreDir,
+        outputs: &[InsertBuildStepOutput],
     ) -> sqlx::Result<()> {
         if outputs.is_empty() {
             return Ok(());
@@ -619,8 +657,13 @@ impl Transaction<'_> {
         query_builder.push_values(outputs, |mut b, output| {
             b.push_bind(output.build_id)
                 .push_bind(output.step_nr)
-                .push_bind(&output.name)
-                .push_bind(&output.path);
+                .push_bind(output.name.as_ref())
+                .push_bind(
+                    output
+                        .path
+                        .as_ref()
+                        .map(|p| store_dir.display(p).to_string()),
+                );
         });
         let query = query_builder.build();
         query.execute(&mut *self.tx).await?;
@@ -630,18 +673,20 @@ impl Transaction<'_> {
     #[tracing::instrument(skip(self, name, path), err)]
     pub async fn update_build_step_output(
         &mut self,
+        store_dir: &StoreDir,
         build_id: i32,
         step_nr: i32,
         name: &str,
-        path: &str,
+        path: &StorePath,
     ) -> sqlx::Result<()> {
+        let path = store_dir.display(path).to_string();
         // TODO: support inserting multiple at the same time
         sqlx::query!(
             "UPDATE buildstepoutputs SET path = $4 WHERE build = $1 AND stepnr = $2 AND name = $3",
             build_id,
             step_nr,
             name,
-            path,
+            path.as_str(),
         )
         .execute(&mut *self.tx)
         .await?;
@@ -687,17 +732,24 @@ impl Transaction<'_> {
     #[tracing::instrument(skip(self, build_id, step_nr), err)]
     pub async fn get_drv_path_from_build_step(
         &mut self,
+        store_dir: &StoreDir,
         build_id: i32,
         step_nr: i32,
-    ) -> sqlx::Result<Option<String>> {
-        Ok(sqlx::query!(
+    ) -> sqlx::Result<Option<StorePath>> {
+        sqlx::query!(
             "SELECT drvPath FROM BuildSteps WHERE build = $1 AND stepnr = $2",
             build_id,
             step_nr
         )
         .fetch_optional(&mut *self.tx)
         .await?
-        .and_then(|v| v.drvpath))
+        .and_then(|v| v.drvpath)
+        .map(|p| {
+            store_dir
+                .parse(&p)
+                .map_err(|e| sqlx::Error::Decode(Box::new(e)))
+        })
+        .transpose()
     }
 
     #[tracing::instrument(skip(self, build_id), err)]
@@ -792,7 +844,12 @@ impl Transaction<'_> {
     }
 
     #[tracing::instrument(skip(self, path), err)]
-    pub async fn insert_failed_paths(&mut self, path: &str) -> sqlx::Result<()> {
+    pub async fn insert_failed_paths(
+        &mut self,
+        store_dir: &StoreDir,
+        path: &StorePath,
+    ) -> sqlx::Result<()> {
+        let path = store_dir.display(path).to_string();
         sqlx::query!(
             r#"
               INSERT INTO failedpaths (
@@ -801,7 +858,7 @@ impl Transaction<'_> {
                 $1
               )
             "#,
-            path,
+            path.as_str(),
         )
         .execute(&mut *self.tx)
         .await?;
@@ -824,35 +881,39 @@ impl Transaction<'_> {
     )]
     pub async fn create_build_step(
         &mut self,
+        store_dir: &StoreDir,
         start_time: Option<i32>,
         build_id: crate::models::BuildID,
-        drv_path: &str,
+        drv_path: &StorePath,
         platform: Option<&str>,
         machine: String,
         status: BuildStatus,
         error_msg: Option<String>,
         propagated_from: Option<crate::models::BuildID>,
-        outputs: Vec<(String, Option<String>)>,
+        outputs: BTreeMap<OutputName, Option<StorePath>>,
     ) -> sqlx::Result<i32> {
         let step_nr = loop {
             if let Some(step_nr) = self
-                .insert_build_step(InsertBuildStep {
-                    build_id,
-                    r#type: crate::models::BuildType::Build,
-                    drv_path,
-                    status,
-                    busy: status == BuildStatus::Busy,
-                    start_time,
-                    stop_time: if status == BuildStatus::Busy {
-                        None
-                    } else {
-                        start_time
+                .insert_build_step(
+                    store_dir,
+                    InsertBuildStep {
+                        build_id,
+                        r#type: crate::models::BuildType::Build,
+                        drv_path,
+                        status,
+                        busy: status == BuildStatus::Busy,
+                        start_time,
+                        stop_time: if status == BuildStatus::Busy {
+                            None
+                        } else {
+                            start_time
+                        },
+                        platform,
+                        propagated_from,
+                        error_msg: error_msg.as_deref(),
+                        machine: &machine,
                     },
-                    platform,
-                    propagated_from,
-                    error_msg: error_msg.as_deref(),
-                    machine: &machine,
-                })
+                )
                 .await?
             {
                 break step_nr;
@@ -860,9 +921,10 @@ impl Transaction<'_> {
         };
 
         self.insert_build_step_outputs(
+            store_dir,
             &outputs
                 .into_iter()
-                .map(|(name, path)| InsertBuildStepOutput::<String> {
+                .map(|(name, path)| InsertBuildStepOutput {
                     build_id,
                     step_nr,
                     name,
@@ -886,39 +948,46 @@ impl Transaction<'_> {
     )]
     pub async fn create_substitution_step(
         &mut self,
+        store_dir: &StoreDir,
         start_time: i32,
         stop_time: i32,
         build_id: crate::models::BuildID,
-        drv_path: &str,
-        output: (String, Option<String>),
+        drv_path: &StorePath,
+        output: (OutputName, Option<StorePath>),
     ) -> anyhow::Result<i32> {
         let step_nr = loop {
             if let Some(step_nr) = self
-                .insert_build_step(InsertBuildStep {
-                    build_id,
-                    r#type: crate::models::BuildType::Substitution,
-                    drv_path,
-                    status: BuildStatus::Success,
-                    busy: false,
-                    start_time: Some(start_time),
-                    stop_time: Some(stop_time),
-                    platform: None,
-                    propagated_from: None,
-                    error_msg: None,
-                    machine: "",
-                })
+                .insert_build_step(
+                    store_dir,
+                    InsertBuildStep {
+                        build_id,
+                        r#type: crate::models::BuildType::Substitution,
+                        drv_path,
+                        status: BuildStatus::Success,
+                        busy: false,
+                        start_time: Some(start_time),
+                        stop_time: Some(stop_time),
+                        platform: None,
+                        propagated_from: None,
+                        error_msg: None,
+                        machine: "",
+                    },
+                )
                 .await?
             {
                 break step_nr;
             }
         };
 
-        self.insert_build_step_outputs(&[InsertBuildStepOutput::<String> {
-            build_id,
-            step_nr,
-            name: output.0,
-            path: output.1,
-        }])
+        self.insert_build_step_outputs(
+            store_dir,
+            &[InsertBuildStepOutput {
+                build_id,
+                step_nr,
+                name: output.0,
+                path: output.1,
+            }],
+        )
         .await?;
 
         Ok(step_nr)
@@ -963,12 +1032,8 @@ impl Transaction<'_> {
         .await?;
 
         for (name, path) in &build.outputs {
-            self.update_build_output(
-                build.id,
-                name.as_ref(),
-                &store_dir.display(path).to_string(),
-            )
-            .await?;
+            self.update_build_output(store_dir, build.id, name.as_ref(), path)
+                .await?;
         }
 
         self.delete_build_products_by_build_id(build.id).await?;
@@ -1101,6 +1166,20 @@ mod tests {
 
     use super::*;
 
+    fn test_store_dir() -> StoreDir {
+        StoreDir::new("/nix/store").unwrap()
+    }
+
+    fn sp(s: &str) -> StorePath {
+        format!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0-{s}")
+            .parse()
+            .unwrap()
+    }
+
+    fn on(s: &str) -> OutputName {
+        s.parse().unwrap()
+    }
+
     async fn setup() -> (test_utils::TestPg, Connection) {
         let (pg, pool) = test_utils::TestPg::new().await;
         let mut conn = Connection::new(pool.acquire().await.unwrap());
@@ -1111,24 +1190,31 @@ mod tests {
         (pg, conn)
     }
 
-    async fn insert_step(conn: &mut Connection, build: i32, stepnr: i32, drv_path: &str) {
+    async fn insert_step(conn: &mut Connection, build: i32, stepnr: i32, drv_path: &StorePath) {
+        let sd = test_store_dir();
         sqlx::query("INSERT INTO BuildSteps (build, stepnr, type, busy, drvPath, status) VALUES ($1, $2, 0, 0, $3, 0)")
             .bind(build)
             .bind(stepnr)
-            .bind(drv_path)
+            .bind(sd.display(drv_path).to_string())
             .execute(&mut *conn.conn)
             .await
             .unwrap();
     }
 
-    async fn insert_output(conn: &mut Connection, build: i32, stepnr: i32, name: &str, path: &str) {
+    async fn insert_output(
+        conn: &mut Connection,
+        build: i32,
+        stepnr: i32,
+        name: &str,
+        path: &StorePath,
+    ) {
         sqlx::query(
             "INSERT INTO BuildStepOutputs (build, stepnr, name, path) VALUES ($1, $2, $3, $4)",
         )
         .bind(build)
         .bind(stepnr)
         .bind(name)
-        .bind(path)
+        .bind(test_store_dir().display(path).to_string())
         .execute(&mut *conn.conn)
         .await
         .unwrap();
@@ -1137,91 +1223,114 @@ mod tests {
     #[tokio::test]
     async fn resolve_depth_1() {
         let (_pg, mut conn) = setup().await;
-        insert_step(&mut conn, 1, 1, "/nix/store/aaa-foo.drv").await;
-        insert_output(&mut conn, 1, 1, "out", "/nix/store/bbb-result").await;
+        insert_step(&mut conn, 1, 1, &sp("foo.drv")).await;
+        insert_output(&mut conn, 1, 1, "out", &sp("result")).await;
 
         let results = conn
-            .resolve_drv_output_chains(&[("/nix/store/aaa-foo.drv", &["out"])])
+            .resolve_drv_output_chains(&test_store_dir(), &[(&sp("foo.drv"), &[&on("out")])])
             .await
             .unwrap();
-        assert_eq!(results, vec![Some("/nix/store/bbb-result".into())]);
+        assert_eq!(results, vec![Some(sp("result"))]);
     }
 
     #[tokio::test]
     async fn resolve_depth_2() {
         let (_pg, mut conn) = setup().await;
-        insert_step(&mut conn, 1, 1, "/nix/store/aaa-foo.drv").await;
-        insert_output(&mut conn, 1, 1, "out", "/nix/store/bbb-bar.drv").await;
-        insert_step(&mut conn, 2, 1, "/nix/store/bbb-bar.drv").await;
-        insert_output(&mut conn, 2, 1, "dev", "/nix/store/ccc-final").await;
+        insert_step(&mut conn, 1, 1, &sp("foo.drv")).await;
+        insert_output(&mut conn, 1, 1, "out", &sp("bar.drv")).await;
+        insert_step(&mut conn, 2, 1, &sp("bar.drv")).await;
+        insert_output(&mut conn, 2, 1, "dev", &sp("final")).await;
 
         let results = conn
-            .resolve_drv_output_chains(&[("/nix/store/aaa-foo.drv", &["out", "dev"])])
+            .resolve_drv_output_chains(
+                &test_store_dir(),
+                &[(&sp("foo.drv"), &[&on("out"), &on("dev")])],
+            )
             .await
             .unwrap();
-        assert_eq!(results, vec![Some("/nix/store/ccc-final".into())]);
+        assert_eq!(results, vec![Some(sp("final"))]);
     }
 
     #[tokio::test]
     async fn resolve_batch() {
         let (_pg, mut conn) = setup().await;
-        insert_step(&mut conn, 1, 1, "/nix/store/aaa-foo.drv").await;
-        insert_output(&mut conn, 1, 1, "out", "/nix/store/bbb-foo-out").await;
-        insert_step(&mut conn, 2, 1, "/nix/store/ccc-bar.drv").await;
-        insert_output(&mut conn, 2, 1, "lib", "/nix/store/ddd-bar-lib").await;
+        insert_step(&mut conn, 1, 1, &sp("foo.drv")).await;
+        insert_output(&mut conn, 1, 1, "out", &sp("foo-out")).await;
+        insert_step(&mut conn, 2, 1, &sp("bar.drv")).await;
+        insert_output(&mut conn, 2, 1, "lib", &sp("bar-lib")).await;
 
         let results = conn
-            .resolve_drv_output_chains(&[
-                ("/nix/store/aaa-foo.drv", &["out"]),
-                ("/nix/store/ccc-bar.drv", &["lib"]),
-            ])
+            .resolve_drv_output_chains(
+                &test_store_dir(),
+                &[
+                    (&sp("foo.drv"), &[&on("out")]),
+                    (&sp("bar.drv"), &[&on("lib")]),
+                ],
+            )
             .await
             .unwrap();
-        assert_eq!(
-            results,
-            vec![
-                Some("/nix/store/bbb-foo-out".into()),
-                Some("/nix/store/ddd-bar-lib".into()),
-            ]
-        );
+        assert_eq!(results, vec![Some(sp("foo-out")), Some(sp("bar-lib")),]);
     }
 
     #[tokio::test]
     async fn resolve_missing() {
         let (_pg, mut conn) = setup().await;
-        insert_step(&mut conn, 1, 1, "/nix/store/aaa-foo.drv").await;
-        insert_output(&mut conn, 1, 1, "out", "/nix/store/bbb-result").await;
+        insert_step(&mut conn, 1, 1, &sp("foo.drv")).await;
+        insert_output(&mut conn, 1, 1, "out", &sp("result")).await;
 
         let results = conn
-            .resolve_drv_output_chains(&[
-                ("/nix/store/aaa-foo.drv", &["out"]),
-                ("/nix/store/nonexistent.drv", &["out"]),
-            ])
+            .resolve_drv_output_chains(
+                &test_store_dir(),
+                &[
+                    (&sp("foo.drv"), &[&on("out")]),
+                    (&sp("nonexistent.drv"), &[&on("out")]),
+                ],
+            )
             .await
             .unwrap();
-        assert_eq!(results, vec![Some("/nix/store/bbb-result".into()), None]);
+        assert_eq!(results, vec![Some(sp("result")), None]);
     }
 
     #[tokio::test]
     async fn resolve_empty() {
         let (_pg, mut conn) = setup().await;
-        let results = conn.resolve_drv_output_chains(&[]).await.unwrap();
+        let results = conn
+            .resolve_drv_output_chains(&test_store_dir(), &[])
+            .await
+            .unwrap();
         assert!(results.is_empty());
     }
 
     #[tokio::test]
     async fn resolve_picks_latest_build() {
         let (_pg, mut conn) = setup().await;
-        insert_step(&mut conn, 1, 1, "/nix/store/aaa-foo.drv").await;
-        insert_output(&mut conn, 1, 1, "out", "/nix/store/old-result").await;
-        insert_step(&mut conn, 5, 1, "/nix/store/aaa-foo.drv").await;
-        insert_output(&mut conn, 5, 1, "out", "/nix/store/new-result").await;
+        insert_step(&mut conn, 1, 1, &sp("foo.drv")).await;
+        insert_output(
+            &mut conn,
+            1,
+            1,
+            "out",
+            &sp("aldaldaldaldaldaldaldaldaldaldal-result"),
+        )
+        .await;
+        insert_step(&mut conn, 5, 1, &sp("foo.drv")).await;
+        insert_output(
+            &mut conn,
+            5,
+            1,
+            "out",
+            &sp("nawnawnawnawnawnawnawnawnawnawna-result"),
+        )
+        .await;
 
         let results = conn
-            .resolve_drv_output_chains(&[("/nix/store/aaa-foo.drv", &["out"])])
+            .resolve_drv_output_chains(&test_store_dir(), &[(&sp("foo.drv"), &[&on("out")])])
             .await
             .unwrap();
-        assert_eq!(results, vec![Some("/nix/store/new-result".into())]);
+        assert_eq!(
+            results,
+            vec![Some(sp("nawnawnawnawnawnawnawnawnawnawna-result"))]
+        );
     }
 
     /// Batch with ragged depths: one depth-1 (Opaque), one depth-2 (Built),
@@ -1231,37 +1340,40 @@ mod tests {
         let (_pg, mut conn) = setup().await;
 
         // Depth 1: aaa.drv ^out => result-a
-        insert_step(&mut conn, 1, 1, "/nix/store/aaa.drv").await;
-        insert_output(&mut conn, 1, 1, "out", "/nix/store/result-a").await;
+        insert_step(&mut conn, 1, 1, &sp("aaa.drv")).await;
+        insert_output(&mut conn, 1, 1, "out", &sp("result-a")).await;
 
         // Depth 2: bbb.drv ^out => ccc.drv, ccc.drv ^lib => result-b
-        insert_step(&mut conn, 2, 1, "/nix/store/bbb.drv").await;
-        insert_output(&mut conn, 2, 1, "out", "/nix/store/ccc.drv").await;
-        insert_step(&mut conn, 3, 1, "/nix/store/ccc.drv").await;
-        insert_output(&mut conn, 3, 1, "lib", "/nix/store/result-b").await;
+        insert_step(&mut conn, 2, 1, &sp("bbb.drv")).await;
+        insert_output(&mut conn, 2, 1, "out", &sp("ccc.drv")).await;
+        insert_step(&mut conn, 3, 1, &sp("ccc.drv")).await;
+        insert_output(&mut conn, 3, 1, "lib", &sp("result-b")).await;
 
         // Depth 3: ddd.drv ^out => eee.drv, eee.drv ^dev => fff.drv, fff.drv ^bin => result-c
-        insert_step(&mut conn, 4, 1, "/nix/store/ddd.drv").await;
-        insert_output(&mut conn, 4, 1, "out", "/nix/store/eee.drv").await;
-        insert_step(&mut conn, 5, 1, "/nix/store/eee.drv").await;
-        insert_output(&mut conn, 5, 1, "dev", "/nix/store/fff.drv").await;
-        insert_step(&mut conn, 6, 1, "/nix/store/fff.drv").await;
-        insert_output(&mut conn, 6, 1, "bin", "/nix/store/result-c").await;
+        insert_step(&mut conn, 4, 1, &sp("ddd.drv")).await;
+        insert_output(&mut conn, 4, 1, "out", &sp("eee.drv")).await;
+        insert_step(&mut conn, 5, 1, &sp("eee.drv")).await;
+        insert_output(&mut conn, 5, 1, "dev", &sp("fff.drv")).await;
+        insert_step(&mut conn, 6, 1, &sp("fff.drv")).await;
+        insert_output(&mut conn, 6, 1, "bin", &sp("result-c")).await;
 
         let results = conn
-            .resolve_drv_output_chains(&[
-                ("/nix/store/aaa.drv", &["out"]),
-                ("/nix/store/bbb.drv", &["out", "lib"]),
-                ("/nix/store/ddd.drv", &["out", "dev", "bin"]),
-            ])
+            .resolve_drv_output_chains(
+                &test_store_dir(),
+                &[
+                    (&sp("aaa.drv"), &[&on("out")]),
+                    (&sp("bbb.drv"), &[&on("out"), &on("lib")]),
+                    (&sp("ddd.drv"), &[&on("out"), &on("dev"), &on("bin")]),
+                ],
+            )
             .await
             .unwrap();
         assert_eq!(
             results,
             vec![
-                Some("/nix/store/result-a".into()),
-                Some("/nix/store/result-b".into()),
-                Some("/nix/store/result-c".into()),
+                Some(sp("result-a")),
+                Some(sp("result-b")),
+                Some(sp("result-c")),
             ]
         );
     }

--- a/subprojects/crates/db/src/models.rs
+++ b/subprojects/crates/db/src/models.rs
@@ -1,5 +1,5 @@
 use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::store_path::{ParseStorePathError, StoreDir};
+use harmonia_store_core::store_path::{ParseStorePathError, StoreDir, StorePath};
 use hashbrown::HashMap;
 
 pub type BuildID = i32;
@@ -130,7 +130,7 @@ pub struct UpdateBuild<'a> {
 pub struct InsertBuildStep<'a> {
     pub build_id: BuildID,
     pub r#type: BuildType,
-    pub drv_path: &'a str,
+    pub drv_path: &'a StorePath,
     pub status: BuildStatus,
     pub busy: bool,
     pub start_time: Option<i32>,
@@ -145,7 +145,7 @@ pub struct InsertBuildStep<'a> {
 pub struct InsertBuildStepOutput<StorePath = harmonia_store_core::store_path::StorePath> {
     pub build_id: BuildID,
     pub step_nr: i32,
-    pub name: String,
+    pub name: OutputName,
     pub path: Option<StorePath>,
 }
 

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -335,9 +335,10 @@ impl State {
 
             let step_nr = tx
                 .create_build_step(
+                    self.store.store_dir(),
                     Some(job.result.get_start_time_as_i32()?),
                     build_id,
-                    &self.store.print_store_path(step_info.step.get_drv_path()),
+                    step_info.step.get_drv_path(),
                     step_info.step.get_system().as_deref(),
                     machine.hostname.clone(),
                     BuildStatus::Busy,
@@ -348,12 +349,6 @@ impl State {
                         .get_output_paths(self.store.store_dir())
                         .unwrap_or_default()
                         .into_iter()
-                        .map(|(name, path)| {
-                            (
-                                name.to_string(),
-                                path.map(|p| self.store.print_store_path(&p)),
-                            )
-                        })
                         .collect(),
                 )
                 .await?;
@@ -551,8 +546,9 @@ impl State {
             .await?
             .ok_or_else(|| anyhow::anyhow!("drv not found"))?;
         db.insert_debug_build(
+            self.store.store_dir(),
             jobset_id,
-            &self.store.print_store_path(drv_path),
+            drv_path,
             std::str::from_utf8(&drv.platform).expect("platform must be valid UTF-8"),
         )
         .await?;
@@ -1394,9 +1390,10 @@ impl State {
                     }
 
                     tx.create_build_step(
+                        self.store.store_dir(),
                         None,
                         b.id,
-                        &self.store.print_store_path(step.get_drv_path()),
+                        step.get_drv_path(),
                         step.get_system().as_deref(),
                         machine
                             .as_deref()
@@ -1412,12 +1409,6 @@ impl State {
                         step.get_output_paths(self.store.store_dir())
                             .unwrap_or_default()
                             .into_iter()
-                            .map(|(name, path)| {
-                                (
-                                    name.to_string(),
-                                    path.map(|p| self.store.print_store_path(&p)),
-                                )
-                            })
                             .collect(),
                     )
                     .await?;
@@ -1456,7 +1447,7 @@ impl State {
                         .unwrap_or_default()
                     {
                         if let Some(path) = path {
-                            tx.insert_failed_paths(&self.store.print_store_path(&path))
+                            tx.insert_failed_paths(self.store.store_dir(), &path)
                                 .await?;
                         }
                     }
@@ -1532,7 +1523,7 @@ impl State {
         // Find the previous build step record, first by derivation path, then by output
         // path.
         let mut propagated_from = tx
-            .get_last_build_step_id(&self.store.print_store_path(step.get_drv_path()))
+            .get_last_build_step_id(self.store.store_dir(), step.get_drv_path())
             .await?
             .unwrap_or_default();
 
@@ -1545,11 +1536,12 @@ impl State {
                 .unwrap_or_default();
             for (name, path) in &outputs {
                 let res = if let Some(path) = path {
-                    tx.get_last_build_step_id_for_output_path(&self.store.print_store_path(path))
+                    tx.get_last_build_step_id_for_output_path(self.store.store_dir(), path)
                         .await
                 } else {
                     tx.get_last_build_step_id_for_output_with_drv(
-                        &self.store.print_store_path(step.get_drv_path()),
+                        self.store.store_dir(),
+                        step.get_drv_path(),
                         name.as_ref(),
                     )
                     .await
@@ -1562,9 +1554,10 @@ impl State {
         }
 
         tx.create_build_step(
+            self.store.store_dir(),
             None,
             build.id,
-            &self.store.print_store_path(step.get_drv_path()),
+            step.get_drv_path(),
             step.get_system().as_deref(),
             String::new(),
             BuildStatus::CachedFailure,
@@ -1573,12 +1566,6 @@ impl State {
             step.get_output_paths(self.store.store_dir())
                 .unwrap_or_default()
                 .into_iter()
-                .map(|(name, path)| {
-                    (
-                        name.to_string(),
-                        path.map(|p| self.store.print_store_path(&p)),
-                    )
-                })
                 .collect(),
         )
         .await?;
@@ -1964,9 +1951,10 @@ impl State {
         };
 
         conn.check_if_paths_failed(
+            self.store.store_dir(),
             &drv_outputs
                 .iter()
-                .filter_map(|(_, path)| path.as_ref().map(|p| self.store.print_store_path(p)))
+                .filter_map(|(_, path)| path.clone())
                 .collect::<Vec<_>>(),
         )
         .await
@@ -2018,7 +2006,7 @@ impl State {
                     continue;
                 };
                 let Some(db_build_output) = db
-                    .get_build_output_for_path(&self.store.print_store_path(out_path))
+                    .get_build_output_for_path(self.store.store_dir(), out_path)
                     .await?
                 else {
                     continue;

--- a/subprojects/hydra-queue-runner/src/state/step_info.rs
+++ b/subprojects/hydra-queue-runner/src/state/step_info.rs
@@ -11,26 +11,25 @@ use super::Step;
 /// The output chain is in resolution order: for `Built { Opaque(A), "out" }` with
 /// final output `"dev"`, returns `(A, ["out", "dev"])`.
 fn flatten_chain(
-    store_dir: &nix_utils::StoreDir,
     drv_path: &SingleDerivedPath,
     output_name: &nix_utils::OutputName,
-) -> (String, Vec<String>) {
-    let mut outputs = Vec::<String>::new();
+) -> (nix_utils::StorePath, Vec<nix_utils::OutputName>) {
+    let mut outputs = Vec::<nix_utils::OutputName>::new();
     let mut current = drv_path;
     let root = loop {
         match current {
-            SingleDerivedPath::Opaque(p) => break store_dir.display(p).to_string(),
+            SingleDerivedPath::Opaque(p) => break p.clone(),
             SingleDerivedPath::Built {
                 drv_path: parent,
                 output,
             } => {
-                outputs.push(output.to_string());
+                outputs.push(output.clone());
                 current = parent;
             }
         }
     };
     outputs.reverse();
-    outputs.push(output_name.to_string());
+    outputs.push(output_name.clone());
     (root, outputs)
 }
 
@@ -112,23 +111,17 @@ impl StepInfo {
         let mut conn = db.get().await.ok()?;
 
         drv.try_resolve(store_dir, &mut |inputs| {
-            let store_dir_str = store_dir.to_str();
             tokio::task::block_in_place(|| {
                 // Flatten each SingleDerivedPath chain into (root, [outputs...])
                 // and resolve everything in a single recursive SQL query.
                 let chains = inputs
                     .iter()
-                    .map(|(drv_path, output_name)| flatten_chain(store_dir, drv_path, output_name))
+                    .map(|(drv_path, output_name)| flatten_chain(drv_path, output_name))
                     .collect::<Vec<_>>();
 
                 let chain_refs = chains
                     .iter()
-                    .map(|(root, outputs)| {
-                        (
-                            root.as_str(),
-                            outputs.iter().map(String::as_str).collect::<Vec<_>>(),
-                        )
-                    })
+                    .map(|(root, outputs)| (root, outputs.iter().collect::<Vec<_>>()))
                     .collect::<Vec<_>>();
 
                 let sql_input = chain_refs
@@ -136,24 +129,12 @@ impl StepInfo {
                     .map(|(root, outputs)| (*root, outputs.as_slice()))
                     .collect::<Vec<_>>();
 
-                let db_results = tokio::runtime::Handle::current()
-                    .block_on(conn.resolve_drv_output_chains(&sql_input))
+                tokio::runtime::Handle::current()
+                    .block_on(conn.resolve_drv_output_chains(store_dir, &sql_input))
                     .unwrap_or_else(|e| {
                         tracing::warn!("resolve_drv_output_chains failed: {e}");
                         vec![None; inputs.len()]
-                    });
-
-                db_results
-                    .into_iter()
-                    .map(|path| {
-                        path.and_then(|p| {
-                            let base = p
-                                .strip_prefix(store_dir_str)
-                                .and_then(|s| s.strip_prefix('/'))?;
-                            Some(nix_utils::parse_store_path(base))
-                        })
                     })
-                    .collect()
             })
         })
     }

--- a/subprojects/hydra-queue-runner/src/utils.rs
+++ b/subprojects/hydra-queue-runner/src/utils.rs
@@ -49,13 +49,8 @@ pub async fn finish_build_step(
         && let Some(output_paths) = output_paths
     {
         for (name, path) in output_paths {
-            tx.update_build_step_output(
-                build_id,
-                step_nr,
-                name.as_ref(),
-                &store.print_store_path(path),
-            )
-            .await?;
+            tx.update_build_step_output(store.store_dir(), build_id, step_nr, name.as_ref(), path)
+                .await?;
         }
     }
 
@@ -100,11 +95,12 @@ pub async fn substitute_output(
     let mut db = db.get().await?;
     let mut tx = db.begin_transaction().await?;
     tx.create_substitution_step(
+        store.store_dir(),
         starttime,
         stoptime,
         build_id,
-        &store.print_store_path(drv_path),
-        (name.to_string(), Some(store.print_store_path(&path))),
+        drv_path,
+        (name.clone(), Some(path.clone())),
     )
     .await?;
     tx.commit().await?;


### PR DESCRIPTION
We should use nice types for all core logic. It is easiest to do so when only converting to raw types at i/o boundaries.

This requires passing a `StoreDir` to database functions, although in the future the DB could store only the hash/name and not the store directory.

this was originally part of #1629, but this is not closely related to the rest of the code and is best done separately.