### PR TITLE
fix: re-check step outputs on re-encounter to unstick cached builds

### DIFF
--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -1761,6 +1761,24 @@ impl State {
             self.steps
                 .create(&drv_path, referring_build.as_ref(), referring_step.as_ref());
         if !is_new {
+            // Re-check whether the step's outputs have appeared in the store
+            // since it was first created. This handles the case where outputs
+            // became available between poll cycles (e.g. built by a concurrent
+            // step, substituted, or uploaded externally). Without this check,
+            // builds whose outputs are now cached get stuck in an infinite
+            // re-load loop: the DB says finished=0, the step already exists
+            // in memory, and create_build never reaches handle_cached_build.
+            if step.get_finished() {
+                return CreateStepResult::None;
+            }
+            if let Some(output_paths) = step.get_output_paths(self.store.store_dir()) {
+                let missing = self.store.query_missing_outputs(output_paths).await;
+                if missing.is_empty() {
+                    finished_drvs.write().insert(drv_path.clone());
+                    step.set_finished(true);
+                    return CreateStepResult::None;
+                }
+            }
             return CreateStepResult::Valid(step);
         }
         self.metrics.queue_steps_created.inc();


### PR DESCRIPTION
## Summary

Fixes an infinite re-load loop where builds whose outputs became available
between poll cycles (via concurrent builds, substitution, or external upload)
get stuck forever.

When a step is encountered that already exists (`is_new = false`), the code
previously just returned it as-is. If the step's outputs had become available
in the store since it was first created, it would be dispatched, the builder
would find nothing to do, and the cycle would repeat indefinitely.

## Fix

Add two checks when `is_new = false`:
1. If the step is already marked finished, return `None` (skip it)
2. Query the store for missing outputs — if all are present, mark the step
   finished and return `None`

## Origin

Originally developed and deployed in `zw3rk/hydra-queue-runner` (commit
`67ef4845`), adapted here to the upstream harmonia `StorePath` types.

## Test plan

- [ ] Verify that builds whose outputs appear in the store between poll
  cycles no longer get stuck in an infinite re-dispatch loop
- [ ] Verify normal build dispatch is unaffected