### PR TITLE
fix(darwin): align builder module CLI flag with binary

### DIFF
--- a/darwin-modules/builder-module.nix
+++ b/darwin-modules/builder-module.nix
@@ -39,8 +39,8 @@ in
         default = 4;
       };
 
-      tmpAvailThreshold = lib.mkOption {
-        description = "Threshold in percent for /tmp before jobs are no longer scheduled on the machine";
+      buildDirAvailThreshold = lib.mkOption {
+        description = "Threshold in percent for nix build dir before jobs are no longer scheduled on the machine";
         type = lib.types.float;
         default = 10.0;
       };
@@ -160,8 +160,8 @@ in
               cfg.speedFactor
               "--max-jobs"
               cfg.maxJobs
-              "--tmp-avail-threshold"
-              cfg.tmpAvailThreshold
+              "--build-dir-avail-threshold"
+              cfg.buildDirAvailThreshold
               "--store-avail-threshold"
               cfg.storeAvailThreshold
               "--load1-threshold"

--- a/darwin-modules/builder-module.nix
+++ b/darwin-modules/builder-module.nix
@@ -211,6 +211,10 @@ in
       environment = {
         RUST_BACKTRACE = "1";
         NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+        # The builder execs `nix build` to realise derivations.  The linux
+        # module sets `path = [ config.nix.package ]` on the systemd service;
+        # launchd has no equivalent, so we set PATH explicitly.
+        PATH = "${config.nix.package}/bin:/usr/bin:/bin:/usr/sbin:/sbin";
       };
 
       serviceConfig = {


### PR DESCRIPTION
## Summary

- The darwin builder module (`darwin-modules/builder-module.nix`) passed `--tmp-avail-threshold` to the `hydra-builder` binary, but the binary expects `--build-dir-avail-threshold`
- The linux module (`nixos-modules/builder-module.nix`) already uses the correct option name `buildDirAvailThreshold` and flag `--build-dir-avail-threshold`
- This aligns the darwin module to match

The mismatch has existed since the original `feat: hydra-queue-runner` commit (7d9f5364). The linux module was fixed at some point, but the darwin module was never updated.

## Impact

All darwin gRPC builders crash-loop on startup, leaving the queue runner with zero connected darwin machines and all darwin builds aborted with "Unsupported system type".

Fixes #1672

## Test plan

- [x] Deploy darwin builders with updated module — verify `hydra-builder` starts and connects to queue runner
- [x] Confirm `--build-dir-avail-threshold` appears in process args instead of `--tmp-avail-threshold`