### PR TITLE
queue-runner-module: fix tokenListPath type

### DIFF
--- a/nixos-modules/queue-runner-module.nix
+++ b/nixos-modules/queue-runner-module.nix
@@ -123,7 +123,7 @@ in
             };
             tokenListPath = lib.mkOption {
               description = "Path to a list of allowed authentication tokens.";
-              type = lib.types.nullOr lib.types.path;
+              type = lib.types.nullOr (lib.types.listOf lib.types.path);
               default = null;
             };
             enableFodChecker = lib.mkOption {


### PR DESCRIPTION
```
error: A definition for option `services.hydra-queue-runner-dev.settings.tokenListPath' is not of type `null or absolute path'. Definition values:
       - In `/nix/store/i7mgnwhv201ynilyf4v7nlbb3haxxm00-source/build/hydra-queue-runner.nix':
           [
             "/run/agenix/elated-minsky-queue-runner-token"
             "/run/agenix/goofy-hopcroft-queue-runner-token"
             "/run/agenix/hopeful-rivest-queue-runner-token"
             "/run/agenix/sleepy-brown-queue-runner-token"
           ...
```

Was eventually a list in the original repo and is now a nullable path again. 