### PR TITLE
Port non-trivial dynamic derivation test from Nix, fix builder upload closure

### DIFF
--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -879,6 +879,14 @@ async fn upload_nars_regular(
     metrics: Arc<crate::metrics::Metrics>,
     nars: Vec<nix_utils::StorePath>,
 ) -> anyhow::Result<()> {
+    // Compute the full closure of output paths so that all referenced
+    // store paths (e.g. dynamically-created derivations from recursive-nix)
+    // are uploaded alongside the direct outputs.
+    let nars = store
+        .query_requisites(&nars.iter().collect::<Vec<_>>(), true)
+        .await
+        .unwrap_or(nars);
+
     let nars = {
         use futures::stream::StreamExt as _;
 

--- a/subprojects/hydra-tests/content-addressed/dyn-drv-non-trivial.t
+++ b/subprojects/hydra-tests/content-addressed/dyn-drv-non-trivial.t
@@ -1,0 +1,44 @@
+use feature 'unicode_strings';
+use strict;
+use warnings;
+use Setup;
+use Test2::V0;
+
+# Adapted from https://github.com/NixOS/nix/blob/master/tests/functional/dyn-drv/non-trivial.nix
+#
+# A single derivation uses recursive-nix to dynamically create a DAG of
+# inner derivations (a through e) via `nix derivation add`, then outputs
+# the final .drv path.  A wrapper depends on building that
+# dynamically-produced .drv and using its output via builtins.outputOf.
+
+my $ctx = test_context(
+    nix_config => qq|
+    experimental-features = ca-derivations dynamic-derivations recursive-nix
+    extra-system-features = recursive-nix
+    |,
+);
+
+my $db = $ctx->db();
+
+my $jobset = createBaseJobset($db, "dyn-drv-non-trivial", "dyn-drv-non-trivial.nix", $ctx->jobsdir);
+
+ok(evalSucceeds($ctx, $jobset), "Evaluation of dyn-drv-non-trivial.nix should succeed");
+is(nrQueuedBuildsForJobset($jobset), 1, "Should queue 1 build (wrapper)");
+
+my @builds = queuedBuildsForJobset($jobset);
+ok(runBuilds($ctx, @builds), "All builds should complete");
+
+# wrapper is the dynamic derivation consumer.
+# It exercises the full chain: build makeDerivations (which uses
+# recursive-nix to create derivations a-e), discover the .drv at its
+# output, build that .drv (transitively building a through e), and use
+# its output.
+my ($wrapper) = grep { $_->job eq 'wrapper' } @builds;
+ok(defined $wrapper, "wrapper build should exist");
+if ($wrapper) {
+    $wrapper->discard_changes;
+    is($wrapper->finished, 1, "wrapper should be finished");
+    is($wrapper->buildstatus, 0, "wrapper should succeed");
+}
+
+done_testing;

--- a/subprojects/hydra-tests/jobs/config.nix.in
+++ b/subprojects/hydra-tests/jobs/config.nix.in
@@ -1,5 +1,7 @@
 rec {
   path = "@testPath@";
+  nixBinDir = "@nixBinDir@";
+  bash = "@bash@";
 
   mkDerivation = args:
     derivation ({

--- a/subprojects/hydra-tests/jobs/dyn-drv-non-trivial.nix
+++ b/subprojects/hydra-tests/jobs/dyn-drv-non-trivial.nix
@@ -1,0 +1,113 @@
+# Adapted from https://github.com/NixOS/nix/blob/master/tests/functional/dyn-drv/non-trivial.nix
+#
+# A single derivation uses recursive-nix to dynamically create a DAG of
+# inner derivations (a through e) via `nix derivation add`, then outputs
+# the final .drv path.  A wrapper depends on building that
+# dynamically-produced .drv and using its output via builtins.outputOf.
+let
+  cfg = import ./config.nix;
+
+  makeDerivations = cfg.mkDerivation {
+    name = "make-derivations.drv";
+
+    requiredSystemFeatures = [ "recursive-nix" ];
+
+    builder = cfg.bash;
+    args = [
+      "-c"
+      ''
+        set -e
+        set -u
+
+        PATH=${cfg.nixBinDir}:$PATH
+
+        export NIX_CONFIG='extra-experimental-features = nix-command ca-derivations dynamic-derivations'
+
+        declare -A deps=(
+          [a]=""
+          [b]="a"
+          [c]="a"
+          [d]="b c"
+          [e]="b c d"
+        )
+
+        # Cannot just literally include this, or Nix will think it is the
+        # *outer* derivation that's trying to refer to itself, and
+        # substitute the string too soon.
+        placeholder=$(nix eval --raw --expr 'builtins.placeholder "out"')
+
+        declare -A drvs=()
+        for word in a b c d e; do
+          inputDrvs=""
+          for dep in ''${deps[$word]}; do
+            if [[ "$inputDrvs" != "" ]]; then
+              inputDrvs+=","
+            fi
+            read -r -d "" line <<EOF || true
+            "''${drvs[$dep]}": {
+              "outputs": ["out"],
+              "dynamicOutputs": {}
+            }
+        EOF
+            inputDrvs+="$line"
+          done
+          read -r -d "" json <<EOF || true
+          {
+            "args": ["-c", "set -xeu; echo \"word env vav $word is \$$word\" >> \"\$out\""],
+            "builder": "/bin/sh",
+            "env": {
+              "out": "$placeholder",
+              "$word": "hello, from $word!",
+              "PATH": ${builtins.toJSON cfg.path}
+            },
+            "inputs": {
+              "drvs": {
+                $inputDrvs
+              },
+              "srcs": []
+            },
+            "name": "build-$word",
+            "outputs": {
+              "out": {
+                "method": "nar",
+                "hashAlgo": "sha256"
+              }
+            },
+            "system": "${builtins.currentSystem}",
+            "version": 4
+          }
+        EOF
+          drvPath=$(echo "$json" | nix derivation add)
+          storeDir=$(dirname "$drvPath")
+          drvs[$word]="$(basename "$drvPath")"
+        done
+        cp "''${storeDir}/''${drvs[e]}" $out
+      ''
+    ];
+
+    __contentAddressed = true;
+    outputHashMode = "text";
+    outputHashAlgo = "sha256";
+  };
+
+in
+{
+  # The dynamic derivation consumer: depends on the output of the .drv
+  # file that makeDerivations produces.  Nix must:
+  #   1. Build makeDerivations (creates derivations a-e, outputs e's .drv)
+  #   2. Discover the .drv at its output
+  #   3. Build that .drv (which transitively builds a, b, c, d, e)
+  #   4. Use its output here
+  wrapper = cfg.mkContentAddressedDerivation {
+    name = "dyn-drv-non-trivial-wrapper";
+    builder = "/bin/sh";
+    args = [
+      "-c"
+      ''
+        result=${builtins.outputOf makeDerivations.outPath "out"}
+        cat "$result"
+        cp -r "$result" $out
+      ''
+    ];
+  };
+}

--- a/subprojects/hydra-tests/lib/HydraTestContext.pm
+++ b/subprojects/hydra-tests/lib/HydraTestContext.pm
@@ -98,8 +98,14 @@ sub new {
     rcopy(abs_path(dirname(__FILE__) . "/../jobs"), $jobsdir);
 
     my $coreutils_path = dirname(which 'install');
-    replace_variable_in_file($jobsdir . "/config.nix", '@testPath@', $coreutils_path);
-    replace_variable_in_file($jobsdir . "/declarative/project.json", '@jobsPath@', $jobsdir);
+    my $nix_bin_dir = dirname(which 'nix');
+    my $bash_path = which 'bash';
+    replace_variable_in_file($jobsdir . "/config.nix",
+        '@testPath@' => $coreutils_path,
+        '@nixBinDir@' => $nix_bin_dir,
+        '@bash@' => $bash_path);
+    replace_variable_in_file($jobsdir . "/declarative/project.json",
+        '@jobsPath@' => $jobsdir);
 
     my $self = bless {
         _db => undef,
@@ -337,13 +343,16 @@ sub write_file {
 }
 
 sub replace_variable_in_file {
-    my ($fn, $var, $val) = @_;
+    my ($fn, %subs) = @_;
 
     open (my $input, '<', "$fn.in") or die $!;
     open (my $output, '>', $fn) or die $!;
 
     while (my $line = <$input>) {
-        $line =~ s/$var/$val/g;
+        for my $var (keys %subs) {
+            my $val = $subs{$var};
+            $line =~ s/\Q$var\E/$val/g;
+        }
         print $output $line;
     }
 }


### PR DESCRIPTION
Port `tests/functional/dyn-drv/non-trivial.nix` from the Nix test suite as a Hydra integration test. This exercises recursive-nix: a single derivation dynamically creates a DAG of inner derivations (a-e) via `nix derivation add`, outputs the final `.drv`, and a wrapper depends on building that `.drv` through `builtins.outputOf`.

Porting this test uncovered a bug in `upload_nars_regular`: it only uploaded the direct build outputs without computing their closure first. When the output is a `.drv` file whose references include other dynamically-created store paths (from recursive-nix), the queue runner's import would fail because those referenced paths were never uploaded. `upload_nars_presigned` already handled this correctly by calling `query_requisites` before uploading — this commit brings the regular path in line.

Supporting changes:
- Add `nixBinDir` to test `config.nix.in` so job expressions can find the `nix` CLI for recursive-nix builds
- Generalize `replace_variable_in_file` to accept multiple substitutions in a single pass (needed because it reads from `.in` each time)
- Add `extra-system-features = recursive-nix` to the test's nix.conf so the builder advertises the feature for scheduling