### PR TITLE
Add unit tests for `Steps` create/remove and weak-ref cleanup

### DIFF
--- a/subprojects/hydra-queue-runner/src/state/step.rs
+++ b/subprojects/hydra-queue-runner/src/state/step.rs
@@ -537,3 +537,33 @@ impl Steps {
         steps.remove(drv_path);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn drv(name: &str) -> nix_utils::StorePath {
+        nix_utils::parse_store_path(&format!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-{name}.drv"))
+    }
+
+    #[test]
+    fn steps_create_and_remove() {
+        let steps = Steps::new();
+        let (step, is_new) = steps.create(&drv("test"), None, None);
+        assert!(is_new);
+        assert_eq!(steps.len(), 1);
+
+        steps.remove(step.get_drv_path());
+        assert_eq!(steps.len(), 0);
+    }
+
+    #[test]
+    fn steps_weak_ref_dies_without_strong_ref() {
+        let steps = Steps::new();
+        let (step, _) = steps.create(&drv("ephemeral"), None, None);
+        assert_eq!(steps.len(), 1);
+
+        drop(step);
+        assert_eq!(steps.len(), 0);
+    }
+}


### PR DESCRIPTION
Basic coverage for the `Steps` container: verify that `create` inserts and `remove` deletes, and that dropping the last strong `Arc<Step>` reference causes `len()` to reflect the cleanup (via its `retain`-on-read behavior).