### PR TITLE
web: navigate from unresolved to resolved CA build steps

### DIFF
--- a/subprojects/hydra-tests/Hydra/Controller/Build/resolved.t
+++ b/subprojects/hydra-tests/Hydra/Controller/Build/resolved.t
@@ -1,0 +1,324 @@
+use strict;
+use warnings;
+use Setup;
+use File::Basename ();
+use JSON::MaybeXS qw(decode_json);
+use Test2::V0;
+use HTTP::Request::Common;
+
+my %ctx = test_init();
+setup_catalyst_test($ctx{context});
+
+my $db = $ctx{context}->db();
+
+my $project = $db->resultset('Projects')->create({
+    name => "tests", displayname => "", owner => "root",
+});
+my $jobset = createBaseJobset($db, "basic", "basic.nix", $ctx{jobsdir});
+ok(evalSucceeds($ctx{context}, $jobset), "Evaluating basic.nix succeeds");
+my @builds = queuedBuildsForJobset($jobset);
+my ($build) = grep { $_->nixname eq "empty-dir" } @builds;
+ok(defined $build, "got a build out of the jobset");
+
+my $resolvedBasename = "00000000000000000000000000000001-resolved.drv";
+# Not $Nix::Config::storeDir: loading Nix::Config initializes Nix::Store
+# from the ambient environment, which at compile time does not yet point at
+# the test's chroot store (and in the build sandbox touching the real
+# /nix/var/nix is a hard failure). The build's own drvpath is in the right
+# store, and resolved_terminal derives the store dir the same way.
+my $storeDir = File::Basename::dirname($build->drvpath);
+my $unresolvedDrv = "$storeDir/00000000000000000000000000000000-unresolved.drv";
+
+# Step 101: Resolved with terminal at step 102 (Succeeded).
+$db->resultset('BuildSteps')->create({
+    build           => $build->id,
+    stepnr          => 101,
+    type            => 0,
+    drvpath         => $unresolvedDrv,
+    busy            => 0,
+    status          => 13,
+    machine         => "",
+    resolveddrvpath => $resolvedBasename,
+});
+
+$db->resultset('BuildSteps')->create({
+    build     => $build->id,
+    stepnr    => 102,
+    type      => 0,
+    drvpath   => "$storeDir/$resolvedBasename",
+    busy      => 0,
+    status    => 0,
+    stoptime  => 1000,
+    machine   => "",
+});
+
+# Step 103: Resolved but terminal drv has no buildstep row yet.
+$db->resultset('BuildSteps')->create({
+    build           => $build->id,
+    stepnr          => 103,
+    type            => 0,
+    drvpath         => "$storeDir/00000000000000000000000000000002-unresolved2.drv",
+    busy            => 0,
+    status          => 13,
+    machine         => "",
+    resolveddrvpath => "00000000000000000000000000000099-missing.drv",
+});
+
+my $buildUrl = "/build/" . $build->id;
+
+subtest "log of a Resolved step 404s (resolved steps have no log)" => sub {
+    my $r = request(GET "$buildUrl/step/101/log");
+    is($r->code, 404, "GET log of Resolved step is not found");
+};
+
+subtest "page of a Resolved step renders Resolution layout with terminal link" => sub {
+    my $r = request(GET "$buildUrl/step/101");
+    is($r->code, 200, "step page renders");
+    like($r->content, qr/Resolution/,
+         "Type cell shows Resolution");
+    like($r->content, qr/unresolved\.drv/,
+         "page shows the original (pre-resolution) derivation");
+    like($r->content, qr/\Q$resolvedBasename\E/,
+         "page shows the resolved drv basename");
+    like($r->content, qr/step #102/,
+         "page links to the terminal step");
+};
+
+subtest "page of a Resolved step whose terminal is missing renders pending state" => sub {
+    my $r = request(GET "$buildUrl/step/103");
+    is($r->code, 200, "missing-terminal page renders");
+    like($r->content, qr/missing\.drv/,
+         "page names the missing resolved drv");
+    like($r->content, qr/not yet scheduled/i,
+         "page describes the unscheduled state");
+};
+
+subtest "log of a Resolved step with no terminal also 404s" => sub {
+    my $r = request(GET "$buildUrl/step/103/log");
+    is($r->code, 404, "log endpoint is not found");
+};
+
+subtest "get-info JSON exposes resolvedSteps" => sub {
+    my $r = request(GET "$buildUrl/api/get-info", Accept => 'application/json');
+    is($r->code, 200, "api/get-info responds");
+    my $data = decode_json($r->content);
+    ok($data->{resolvedSteps}, "resolvedSteps key present");
+    is(scalar @{$data->{resolvedSteps}}, 2, "two resolved steps reported");
+    my ($terminalEntry) = grep { $_->{stepnr} == 101 } @{$data->{resolvedSteps}};
+    is($terminalEntry->{resolvedDrvPath}, $resolvedBasename,
+       "step 101 reports resolved basename");
+    is($terminalEntry->{terminal}{stepnr}, 102,
+       "step 101 terminal is step 102");
+    is($terminalEntry->{terminal}{status}, 0,
+       "terminal status is Success");
+};
+
+subtest "self-referential resolveddrvpath is treated as corrupt (pending copy)" => sub {
+    my $cycleBasename = "00000000000000000000000000000003-cycle.drv";
+    $db->resultset('BuildSteps')->create({
+        build           => $build->id,
+        stepnr          => 104,
+        type            => 0,
+        drvpath         => "$storeDir/$cycleBasename",
+        busy            => 0,
+        status          => 13,
+        machine         => "",
+        resolveddrvpath => $cycleBasename,
+    });
+    my $r = request(GET "$buildUrl/step/104");
+    is($r->code, 200, "self-referential page renders");
+    like($r->content, qr/not yet scheduled/i,
+         "self-reference cannot happen legitimately; rendered as pending, not followed");
+
+    my $logR = request(GET "$buildUrl/step/104/log");
+    is($logR->code, 404, "self-cycle log is not found");
+};
+
+subtest "terminal step page links back to its resolution origin" => sub {
+    my $r = request(GET "$buildUrl/step/102");
+    is($r->code, 200, "terminal step page renders");
+    like($r->content, qr/Resolution target of/i,
+         "page labels the relation");
+    like($r->content, qr/step #101/,
+         "page names the resolved origin");
+    like($r->content, qr/originally.*unresolved\.drv/s,
+         "page shows the original (pre-resolution) drvpath");
+};
+
+subtest "page with running terminal shows Running status" => sub {
+    $db->resultset('BuildSteps')->create({
+        build           => $build->id,
+        stepnr          => 200,
+        type            => 0,
+        drvpath         => "$storeDir/00000000000000000000000000000020-pending-orig.drv",
+        busy            => 0,
+        status          => 13,
+        machine         => "",
+        resolveddrvpath => "00000000000000000000000000000021-busy-terminal.drv",
+    });
+    $db->resultset('BuildSteps')->create({
+        build     => $build->id,
+        stepnr    => 201,
+        type      => 0,
+        drvpath   => "$storeDir/00000000000000000000000000000021-busy-terminal.drv",
+        busy      => 1,
+        status    => undef,
+        machine   => "builder-a",
+        starttime => 500,
+    });
+    my $r = request(GET "$buildUrl/step/200");
+    is($r->code, 200, "page renders for busy-terminal case");
+    like($r->content, qr/Running/,
+         "status shows Running for the busy terminal");
+    like($r->content, qr/step #201/,
+         "names the running step");
+
+    my $logR = request(GET "$buildUrl/step/200/log");
+    is($logR->code, 404, "resolved step's log is not found regardless of terminal state");
+};
+
+subtest "cross-build scoping: chain does not reach into other builds" => sub {
+    my $buildB = $db->resultset('Builds')->create({
+        finished    => 1,
+        timestamp   => 0,
+        jobset_id   => $build->jobset_id,
+        job         => "empty-dir",
+        nixname     => "empty-dir",
+        drvpath     => "$storeDir/00000000000000000000000000000040-other-unresolved.drv",
+        system      => "x86_64-linux",
+        starttime   => 1, stoptime => 1,
+        buildstatus => 0, iscurrent => 0,
+    });
+
+    $db->resultset('BuildSteps')->create({
+        build           => $build->id,
+        stepnr          => 301,
+        type            => 0,
+        drvpath         => "$storeDir/00000000000000000000000000000040-origA.drv",
+        busy            => 0,
+        status          => 13,
+        machine         => "",
+        resolveddrvpath => "00000000000000000000000000000041-collide.drv",
+    });
+
+    $db->resultset('BuildSteps')->create({
+        build     => $buildB->id,
+        stepnr    => 500,
+        type      => 0,
+        drvpath   => "$storeDir/00000000000000000000000000000041-collide.drv",
+        busy      => 0,
+        status    => 0,
+        stoptime  => 1000,
+        machine   => "",
+    });
+
+    my $r = request(GET "$buildUrl/step/301");
+    is($r->code, 200, "page renders without chasing cross-build terminal");
+    like($r->content, qr/not yet scheduled/i,
+         "chain stops at build boundary");
+};
+
+subtest "sibling steps with shared terminal both link there; terminal page shows both origins" => sub {
+    $db->resultset('BuildSteps')->create({
+        build           => $build->id,
+        stepnr          => 400,
+        type            => 0,
+        drvpath         => "$storeDir/00000000000000000000000000000050-first.drv",
+        busy            => 0,
+        status          => 13,
+        machine         => "",
+        resolveddrvpath => "00000000000000000000000000000051-shared.drv",
+    });
+    $db->resultset('BuildSteps')->create({
+        build           => $build->id,
+        stepnr          => 401,
+        type            => 0,
+        drvpath         => "$storeDir/00000000000000000000000000000060-second.drv",
+        busy            => 0,
+        status          => 13,
+        machine         => "",
+        resolveddrvpath => "00000000000000000000000000000051-shared.drv",
+    });
+    $db->resultset('BuildSteps')->create({
+        build     => $build->id,
+        stepnr    => 402,
+        type      => 0,
+        drvpath   => "$storeDir/00000000000000000000000000000051-shared.drv",
+        busy      => 0,
+        status    => 0,
+        stoptime  => 1000,
+        machine   => "",
+    });
+
+    for my $origin (400, 401) {
+        my $r = request(GET "$buildUrl/step/$origin");
+        is($r->code, 200, "step $origin page renders (no false cycle)");
+        like($r->content, qr/step #402/,
+             "step $origin links to the shared terminal");
+    }
+
+    my $term = request(GET "$buildUrl/step/402");
+    is($term->code, 200, "shared terminal step page renders");
+    like($term->content, qr/Resolution target of/i,
+         "page lists resolution origins");
+    like($term->content, qr/step #400/, "page lists step 400");
+    like($term->content, qr/step #401/, "page lists step 401");
+};
+
+subtest "corrupt resolveddrvpath does not crash or chase" => sub {
+    $db->resultset('BuildSteps')->create({
+        build           => $build->id,
+        stepnr          => 500,
+        type            => 0,
+        drvpath         => "$storeDir/00000000000000000000000000000070-corrupt.drv",
+        busy            => 0,
+        status          => 13,
+        machine         => "",
+        resolveddrvpath => "../../etc/passwd",
+    });
+    my $r = request(GET "$buildUrl/step/500");
+    is($r->code, 200, "corrupt basename does not crash");
+    like($r->content, qr/not yet scheduled/i,
+         "falls through to pending state rather than following the hop");
+};
+
+subtest "a Resolved step pointing at another Resolved step is not followed" => sub {
+    $db->resultset('BuildSteps')->create({
+        build           => $build->id,
+        stepnr          => 600,
+        type            => 0,
+        drvpath         => "$storeDir/00000000000000000000000000000080-cycle-a.drv",
+        busy            => 0,
+        status          => 13,
+        machine         => "",
+        resolveddrvpath => "00000000000000000000000000000081-cycle-b.drv",
+    });
+    $db->resultset('BuildSteps')->create({
+        build           => $build->id,
+        stepnr          => 601,
+        type            => 0,
+        drvpath         => "$storeDir/00000000000000000000000000000081-cycle-b.drv",
+        busy            => 0,
+        status          => 13,
+        machine         => "",
+        resolveddrvpath => "00000000000000000000000000000080-cycle-a.drv",
+    });
+    my $r = request(GET "$buildUrl/step/600");
+    is($r->code, 200, "page renders");
+    like($r->content, qr/not yet scheduled/i,
+         "resolution is one-shot: a Resolved row is never a terminal, so this renders as pending");
+};
+
+subtest "raw log mode on a resolved step also 404s" => sub {
+    my $r = request(GET "$buildUrl/step/101/log/raw");
+    is($r->code, 404, "raw on a resolved step is not found");
+};
+
+subtest "old /nixlog/:nr URL still 301-redirects to /step/:nr/log" => sub {
+    my $r = request(GET "$buildUrl/nixlog/101");
+    is($r->code, 301, "old nixlog URL 301s to the step log endpoint");
+    like($r->header('location') // "", qr{/step/101/log},
+         "preserves stepnr in the redirect target");
+};
+
+done_testing;

--- a/subprojects/hydra/lib/Hydra/Controller/Build.pm
+++ b/subprojects/hydra/lib/Hydra/Controller/Build.pm
@@ -117,6 +117,12 @@ sub build_GET {
 
     $c->stash->{steps} = [$build->buildsteps->search({}, {order_by => "stepnr desc"})];
 
+    $c->stash->{resolvedTerminals} = {};
+    for my $step (@{$c->stash->{steps}}) {
+        my $terminal = $step->resolved_terminal;
+        $c->stash->{resolvedTerminals}->{$step->stepnr} = $terminal if $terminal;
+    }
+
     $c->stash->{binaryCachePublicUri} = $c->config->{binary_cache_public_uri};
 }
 
@@ -563,6 +569,26 @@ sub get_info : Chained('buildChain') PathPart('api/get-info') Args(0) {
     $c->stash->{json}->{drvPath} = $build->drvpath;
     my $out = getMainOutput($build);
     $c->stash->{json}->{outPath} = $out->path if defined $out;
+
+    my @resolved;
+    for my $step ($build->buildsteps->search({ status => 13 })) {
+        next unless $step->resolveddrvpath;
+        my $entry = {
+            stepnr           => $step->stepnr,
+            resolvedDrvPath  => $step->resolveddrvpath,
+        };
+        if (my $terminal = $step->resolved_terminal) {
+            $entry->{terminal} = {
+                buildId => $terminal->get_column('build'),
+                stepnr  => $terminal->stepnr,
+                status  => $terminal->status,
+                busy    => $terminal->busy,
+            };
+        }
+        push @resolved, $entry;
+    }
+    $c->stash->{json}->{resolvedSteps} = \@resolved if @resolved;
+
     $c->forward('View::JSON');
 }
 

--- a/subprojects/hydra/lib/Hydra/Controller/BuildStep.pm
+++ b/subprojects/hydra/lib/Hydra/Controller/BuildStep.pm
@@ -25,6 +25,15 @@ sub buildStep :Chained('buildStepChain') :PathPart('') :Args(0) :ActionClass('RE
 sub buildStep_GET {
     my ($self, $c) = @_;
 
+    my $step = $c->stash->{step};
+    if (defined $step->status && $step->status == 13 && $step->resolveddrvpath) {
+        # Same shape as build_GET's stash, so renderStepStatus works here too.
+        $c->stash->{resolvedTerminals} = { $step->stepnr => $step->resolved_terminal };
+    } else {
+        # Real steps may be the target of Resolved steps; link back to them.
+        $c->stash->{resolutionOrigins} = $step->resolution_origins;
+    }
+
     $c->stash->{template} = 'build-step.tt';
 
     $self->status_ok(
@@ -37,8 +46,16 @@ sub buildStep_GET {
 sub view_nixlog : Chained('buildStepChain') PathPart('log') {
     my ($self, $c, $mode) = @_;
 
-    my $drvPath = $c->stash->{step}->drvpath;
-    my $log_uri = $c->uri_for($c->controller('Root')->action_for("log"), [WWW::Form::UrlEncoded::PP::url_encode(basename($drvPath))]);
+    my $step = $c->stash->{step};
+
+    # Resolved steps are pure redirections: they never build, so they have
+    # no log. The step detail page links to the terminal step, whose own
+    # log endpoint serves the actual build output.
+    if (defined $step->status && $step->status == 13 && $step->resolveddrvpath) {
+        notFound($c, "Build step " . $step->stepnr . " was resolved to another derivation and has no log of its own.");
+    }
+
+    my $log_uri = $c->uri_for($c->controller('Root')->action_for("log"), [WWW::Form::UrlEncoded::PP::url_encode(basename($step->drvpath))]);
     showLog($c, $mode, $log_uri);
 }
 

--- a/subprojects/hydra/lib/Hydra/Schema/Result/BuildSteps.pm
+++ b/subprojects/hydra/lib/Hydra/Schema/Result/BuildSteps.pm
@@ -225,6 +225,52 @@ __PACKAGE__->belongs_to(
 # Created by DBIx::Class::Schema::Loader v0.07051 @ 2026-07-15 11:41:43
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:BzGi6sOIZ8K602dlsYEiag
 
+use File::Basename ();
+
+# Find the step that this Resolved (status=13) step was resolved to, or
+# undef if it hasn't been scheduled yet. Resolution is one-shot: a resolved
+# derivation is basic (all inputs realized), so it can never itself be
+# resolved again — there are no chains to follow. Corrupt resolveddrvpath
+# values (a slash, a self-reference) simply match nothing here — the
+# status filter below excludes Resolved rows, and the equality search is
+# inert — so they render as "not scheduled" without special-casing.
+sub resolved_terminal {
+    my ($self) = @_;
+    return undef unless (($self->status // -1) == 13) && $self->resolveddrvpath;
+    # Resolution stays within the build that requested the work.
+    # resolveddrvpath is a store-path basename, not a path; it lives in the
+    # same store as this step's own drvpath, so derive the store dir from
+    # that rather than global Nix state.
+    return $self->result_source->resultset->search(
+        {
+            build   => $self->get_column('build'),
+            drvpath => File::Basename::dirname($self->drvpath) . "/" . $self->resolveddrvpath,
+            # A real terminal is never itself Resolved.
+            status  => [ undef, { '!=' => 13 } ],
+        },
+        # A drv may have been attempted more than once; prefer succeeded
+        # steps (lowest status), newest first. Busy steps have NULL
+        # status and sort last.
+        { order_by => [{ -asc => 'status' }, { -desc => 'stoptime' }],
+          rows     => 1,
+        }
+    )->single;
+}
+
+# Every Resolved step in the same build that was resolved to this step's
+# derivation.
+sub resolution_origins {
+    my ($self) = @_;
+    return [ $self->result_source->resultset->search(
+        {
+            build           => $self->get_column('build'),
+            status          => 13,
+            resolveddrvpath => File::Basename::basename($self->drvpath),
+        },
+        { order_by => [{ -asc => 'stepnr' }] }
+    )->all ];
+}
+
 my %hint = (
     columns => [
         "machine",

--- a/subprojects/hydra/root/build-common.tt
+++ b/subprojects/hydra/root/build-common.tt
@@ -71,6 +71,21 @@
     <span class="error">Output limit exceeded</span>
   [% ELSIF step.status == 12 %]
     <span class="error">Non-determinism detected</span>[% IF step.timesbuilt %] after [% HTML.escape(step.timesbuilt) %] times[% END %]
+  [% ELSIF step.status == 13 %]
+    <span class="text-muted"><em>Resolved</em></span>
+    [% t = resolvedTerminals.${step.stepnr};
+       IF t %]
+      -- resolved to [%+ INCLUDE renderBuildIdLink id=t.get_column('build') %], step #[% HTML.escape(t.stepnr) %]
+      [% IF t.busy != 0 %]
+        (<em>Running</em>)
+      [% ELSIF t.status == 0 %]
+        (Succeeded)
+      [% ELSE %]
+        (<span class="error">Failed</span>)
+      [% END;
+     ELSIF step.resolveddrvpath; %]
+      -- resolved drv <tt>[% HTML.escape(step.resolveddrvpath) %]</tt> not yet scheduled
+    [% END %]
   [% ELSIF step.errormsg %]
     <span class="error">Failed</span>: <em>[% HTML.escape(step.errormsg) %]</em>
   [% ELSE %]

--- a/subprojects/hydra/root/build-step.tt
+++ b/subprojects/hydra/root/build-step.tt
@@ -11,21 +11,20 @@
 [% PROCESS "build-common.tt" %]
 [% USE HTML %]
 
-[% logUrl = c.uri_for('/build' build.id 'step' step.stepnr 'log') %]
-[% has_log = buildStepLogExists(step) %]
+[%# A step is either a real build step or a Resolved step -- a pure
+    redirection to another derivation that never builds and has no log. %]
+[% isResolved = step.status == 13 && step.resolveddrvpath;
+   logUrl = c.uri_for('/build' build.id 'step' step.stepnr 'log');
+   has_log = isResolved ? 0 : buildStepLogExists(step) %]
 
 <table class="info-table">
   <tr>
     <th>Type:</th>
-    <td>[% IF step.type == 0 %]Build[% ELSE %]Substitution[% END %]</td>
+    <td>[% IF isResolved %]Resolution[% ELSIF step.type == 0 %]Build[% ELSE %]Substitution[% END %]</td>
   </tr>
   <tr>
     <th>Derivation:</th>
     <td><tt>[% step.drvpath | html %]</tt></td>
-  </tr>
-  <tr>
-    <th>Output store paths:</th>
-    <td>[% INCLUDE renderOutputsTable outputs=step.buildstepoutputs %]</td>
   </tr>
   [% IF step.system %]
     <tr>
@@ -33,14 +32,25 @@
       <td><tt>[% step.system | html %]</tt></td>
     </tr>
   [% END %]
-  <tr>
-    <th>Machine:</th>
-    <td>[% INCLUDE renderStepMachine %]</td>
-  </tr>
-  <tr>
-    <th>Duration:</th>
-    <td>[% INCLUDE renderStepDuration %]</td>
-  </tr>
+  [% IF isResolved %]
+    <tr>
+      <th>Resolved to:</th>
+      <td><tt>[% step.resolveddrvpath | html %]</tt></td>
+    </tr>
+  [% ELSE %]
+    <tr>
+      <th>Output store paths:</th>
+      <td>[% INCLUDE renderOutputsTable outputs=step.buildstepoutputs %]</td>
+    </tr>
+    <tr>
+      <th>Machine:</th>
+      <td>[% INCLUDE renderStepMachine %]</td>
+    </tr>
+    <tr>
+      <th>Duration:</th>
+      <td>[% INCLUDE renderStepDuration %]</td>
+    </tr>
+  [% END %]
   <tr>
     <th>Status:</th>
     <td>
@@ -50,6 +60,23 @@
       [% END %]
     </td>
   </tr>
+  [% IF resolutionOrigins && resolutionOrigins.size %]
+    <tr>
+      <th>Resolution target of:</th>
+      <td>
+        <ul class="list-unstyled mb-0">
+          [% FOREACH o IN resolutionOrigins %]
+            <li>
+              [% INCLUDE renderBuildIdLink id=o.get_column('build') %] step #[% HTML.escape(o.stepnr) %]
+              [% IF o.drvpath %]
+                (originally <tt>[% HTML.escape(o.drvpath) %]</tt>)
+              [% END %]
+            </li>
+          [% END %]
+        </ul>
+      </td>
+    </tr>
+  [% END %]
   [% IF has_log %]
     <tr>
       <th>Logfile:</th>

--- a/subprojects/hydra/root/build.tt
+++ b/subprojects/hydra/root/build.tt
@@ -28,14 +28,20 @@ END;
     <tbody>
       [% FOREACH step IN steps %]
         [% IF ( type == "All" ) || ( type == "Failed" && step.busy == 0 && step.status != 0 ) || ( type == "Running" && step.busy != 0 ) %]
-          [% has_log = seen.${step.drvpath} ? 0 : buildStepLogExists(step);
+          [%# Resolved steps never build, so they never have a log. %]
+          [% has_log = (step.status == 13 || seen.${step.drvpath}) ? 0 : buildStepLogExists(step);
              seen.${step.drvpath} = 1;
              stepUrl = c.uri_for('/build' build.id 'step' step.stepnr);
              logUrl = c.uri_for('/build' build.id 'step' step.stepnr 'log'); %]
           <tr>
             <td><a class="row-link" [% HTML.attributes(href => stepUrl) %]>[% HTML.escape(step.stepnr) %]</a></td>
             <td>
-              [% IF step.type == 0 %]
+              [% IF step.status == 13 %]
+                [%# Resolved steps never ran: buildstepoutputs is empty, so %]
+                [%# "Build of" would render with nothing after it. Show the %]
+                [%# drv that was resolved instead. %]
+                Resolution of <tt>[% HTML.escape(step.drvpath) %]</tt>
+              [% ELSIF step.type == 0 %]
                 Build of <tt>[% INCLUDE renderOutputs outputs=step.buildstepoutputs %]</tt>
               [% ELSE %]
                 Substitution of <tt>[% INCLUDE renderOutputs outputs=step.buildstepoutputs %]</tt>


### PR DESCRIPTION
>[!NOTE]
> This depends on #1629

Resolved CA steps do not own the log users are trying to inspect, so
leaving them as terminal pages makes the build view look stuck or failed
in the wrong place. The log page now follows the recorded resolution chain
to the step that actually performed the work, while preserving a pending
page for unresolved, running, or malformed chains.

The redirect banner is reconstructed from BuildSteps instead of session
flash so copied log URLs and refreshes keep the same context. The JSON
summary exposes the same durable resolution data for API clients that
need to follow CA build steps without scraping HTML.