### PR TITLE
fix(queue-runner): single threaded zstd compression in tonic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,9 +1453,11 @@ name = "hydra-builder"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-compression",
  "async-stream",
  "backon",
  "binary-cache",
+ "bytes",
  "clap",
  "fs-err",
  "futures",
@@ -1479,6 +1481,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -1494,6 +1497,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-compression",
  "atomic_float",
  "backon",
  "binary-cache",
@@ -1529,6 +1533,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tonic",
  "tonic-health",
@@ -4150,7 +4155,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "webpki-roots 1.0.6",
- "zstd",
 ]
 
 [[package]]

--- a/subprojects/hydra-builder/Cargo.toml
+++ b/subprojects/hydra-builder/Cargo.toml
@@ -17,14 +17,17 @@ parking_lot.workspace = true
 thiserror.workspace   = true
 uuid                  = { workspace = true, features = [ "v4" ] }
 
+async-compression      = { workspace = true, features = [ "tokio", "zstd" ] }
 async-stream.workspace = true
 backon.workspace       = true
+bytes.workspace        = true
 futures.workspace      = true
 hyper-util.workspace   = true
 prost.workspace        = true
 tokio                  = { workspace = true, features = [ "full" ] }
 tokio-stream.workspace = true
-tonic                  = { workspace = true, features = [ "zstd", "tls-webpki-roots" ] }
+tokio-util             = { workspace = true, features = [ "io", "io-util" ] }
+tonic                  = { workspace = true, features = [ "tls-webpki-roots" ] }
 tonic-prost.workspace  = true
 tower.workspace        = true
 url.workspace          = true

--- a/subprojects/hydra-builder/src/grpc.rs
+++ b/subprojects/hydra-builder/src/grpc.rs
@@ -147,8 +147,6 @@ pub async fn init_client(cli: &crate::config::Cli) -> anyhow::Result<BuilderClie
     };
 
     Ok(RunnerServiceClient::with_interceptor(channel, interceptor)
-        .send_compressed(tonic::codec::CompressionEncoding::Zstd)
-        .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
         .max_decoding_message_size(50 * 1024 * 1024)
         .max_encoding_message_size(50 * 1024 * 1024))
 }

--- a/subprojects/hydra-builder/src/lib.rs
+++ b/subprojects/hydra-builder/src/lib.rs
@@ -19,3 +19,4 @@ pub mod metrics;
 pub mod state;
 pub mod system;
 pub mod types;
+pub mod utils;

--- a/subprojects/hydra-builder/src/main.rs
+++ b/subprojects/hydra-builder/src/main.rs
@@ -18,6 +18,7 @@ mod metrics;
 mod state;
 mod system;
 mod types;
+mod utils;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -9,7 +9,6 @@ use binary_cache::harmonia_utils_hash::fmt::CommonHash as _;
 use futures::TryFutureExt as _;
 use hashbrown::HashMap;
 use tonic::Request;
-use tracing::Instrument as _;
 
 use crate::grpc::{BuilderClient, runner_v1};
 use crate::types::BuildTimings;
@@ -17,7 +16,7 @@ use binary_cache::{Compression, PresignedUpload, PresignedUploadClient};
 use nix_utils::{BaseStore as _, OutputName};
 use runner_v1::{
     AbortMessage, BuildMessage, BuildMetric, BuildProduct, BuildResultInfo, BuildResultState,
-    FetchRequisitesRequest, JoinMessage, LogChunk, NarData, NixSupport, Output, OutputNameOnly,
+    FetchRequisitesRequest, JoinMessage, NarData, NixSupport, Output, OutputNameOnly,
     OutputWithPath, PingMessage, PressureState, StepStatus, StepUpdate, StorePaths, output,
 };
 use shared::proto::ProtoStorePath;
@@ -397,9 +396,7 @@ impl State {
         m: BuildMessage,
         timings: &mut BuildTimings,
     ) -> Result<(), JobFailure> {
-        // we dont use anyhow here because we manually need to write the correct build status
-        // to the queue runner.
-        use tokio_stream::StreamExt as _;
+        use tokio_stream::StreamExt;
 
         let store = nix_utils::LocalStore::init();
 
@@ -457,7 +454,7 @@ impl State {
             })
             .await;
         let before_build = Instant::now();
-        let (mut child, stdout, mut stderr) = nix_utils::realise_drv(
+        let (mut child, stdout, stderr) = nix_utils::realise_drv(
             &store,
             maybe_resolved_drv,
             &nix_utils::BuildOptions::complete(m.max_log_size, m.max_silent_time, m.build_timeout),
@@ -465,21 +462,6 @@ impl State {
         )
         .await
         .map_err(|e| JobFailure::Build(e.into()))?;
-        let drv2 = drv.clone();
-        let log_stream = async_stream::stream! {
-            while let Some(chunk) = stderr.next().await {
-                match chunk {
-                    Ok(chunk) => yield LogChunk {
-                        drv: Some(ProtoStorePath::from(drv2.clone())),
-                        data: format!("{chunk}\n").into(),
-                    },
-                    Err(e) => {
-                        tracing::error!("Failed to write log chunk to queue-runner: {e}");
-                        break
-                    }
-                }
-            }
-        };
         // The build_log RPC streams stderr to the queue-runner and only
         // resolves once the child closes stderr (i.e. the build finished).
         // A transport error here (e.g. nginx sending an HTTP/2 GOAWAY after
@@ -494,7 +476,9 @@ impl State {
         // build_log stream (the queue-runner appends to the same log file
         // keyed by drv path), and keep the child running.
         client
-            .build_log(Request::new(log_stream))
+            .build_log(Request::new(crate::utils::compressed_log_stream(
+                &drv, stderr,
+            )))
             .await
             .map_err(|e| {
                 JobFailure::Upload(
@@ -709,6 +693,17 @@ async fn substitute_paths(
     Ok(())
 }
 
+fn decode_stream<S>(
+    stream: S,
+) -> impl tokio_stream::Stream<Item = Result<bytes::Bytes, std::io::Error>>
+where
+    S: tokio_stream::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Unpin,
+{
+    let reader = tokio_util::io::StreamReader::new(stream);
+    let decoder = crate::utils::CompressionDecoder::new(reader);
+    tokio_util::io::ReaderStream::new(decoder)
+}
+
 #[tracing::instrument(skip(client, store, metrics), fields(%gcroot), err)]
 async fn import_paths(
     mut client: BuilderClient,
@@ -764,15 +759,12 @@ async fn import_paths(
         .into_inner();
 
     metrics.add_downloading_path(paths.len() as u64);
-    let import_result = store
-        .import_paths(
-            tokio_stream::StreamExt::map(stream, |s| {
-                s.map(|v| v.chunk.into())
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e))
-            }),
-            false,
-        )
-        .await;
+
+    let byte_stream = tokio_stream::StreamExt::map(stream, |s| {
+        s.map(|v| bytes::Bytes::from(v.chunk))
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e))
+    });
+    let import_result = store.import_paths(decode_stream(byte_stream), false).await;
     metrics.sub_downloading_path(paths.len() as u64);
     import_result?;
     tracing::debug!("Finished importing paths");
@@ -914,30 +906,56 @@ async fn upload_nars_regular(
     }
 
     tracing::info!("Start uploading paths to queue runner directly");
+    let (raw_writer, raw_reader) = tokio::io::duplex(crate::utils::DUPLEX_BUFFER_SIZE);
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<NarData>();
     let before_upload = Instant::now();
     let nars_len = nars.len() as u64;
 
     metrics.add_uploading_path(nars_len);
-    let closure = move |data: &[u8]| {
-        let data = Vec::from(data);
-        tx.send(NarData { chunk: data }).is_ok()
-    };
+
+    tokio::task::spawn(async move {
+        use tokio_stream::StreamExt as _;
+        let encoder = crate::utils::CompressionEncoder::new(tokio::io::BufReader::new(raw_reader));
+        let mut encoded_stream = tokio_util::io::ReaderStream::new(encoder);
+        while let Some(chunk) = encoded_stream.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    if tx
+                        .send(NarData {
+                            chunk: bytes.into(),
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to compress NAR chunk: {e}");
+                    break;
+                }
+            }
+        }
+    });
+
     let a = client
         .build_result(tokio_stream::wrappers::UnboundedReceiverStream::new(rx))
         .map_err(Into::<anyhow::Error>::into);
 
     let b = tokio::task::spawn_blocking(move || {
-        async move {
-            store.export_paths(&nars, closure)?;
-            tracing::debug!("Finished exporting paths");
-            Ok::<(), anyhow::Error>(())
-        }
-        .in_current_span()
-    })
-    .await?
-    .map_err(Into::<anyhow::Error>::into);
-    futures::future::try_join(a, b).await?;
+        let mut sync_writer = tokio_util::io::SyncIoBridge::new(raw_writer);
+        let closure = move |data: &[u8]| {
+            use std::io::Write as _;
+            sync_writer.write_all(data).is_ok()
+        };
+
+        store.export_paths(&nars, closure)?;
+        tracing::debug!("Finished exporting paths");
+        Ok::<(), anyhow::Error>(())
+    });
+    let (a, b) = futures::future::join(a, b).await;
+    a?;
+    b??;
+
     tracing::info!(
         "Finished uploading paths to queue runner directly. elapsed={:?}",
         before_upload.elapsed()

--- a/subprojects/hydra-builder/src/utils.rs
+++ b/subprojects/hydra-builder/src/utils.rs
@@ -1,0 +1,62 @@
+use tokio::io::BufReader;
+use tokio_stream::wrappers::LinesStream;
+use tokio_util::io::ReaderStream;
+
+use crate::grpc::runner_v1::LogChunk;
+use shared::proto::ProtoStorePath;
+
+pub(crate) type CompressionEncoder<R> = async_compression::tokio::bufread::ZstdEncoder<R>;
+pub(crate) type CompressionDecoder<R> = async_compression::tokio::bufread::ZstdDecoder<R>;
+pub(crate) const DUPLEX_BUFFER_SIZE: usize = 256 * 1024;
+
+pub(crate) fn compressed_log_stream(
+    drv: &nix_utils::StorePath,
+    log_output: LinesStream<BufReader<tokio::process::ChildStderr>>,
+) -> impl tokio_stream::Stream<Item = LogChunk> + use<> {
+    let (raw_writer, raw_reader) = tokio::io::duplex(DUPLEX_BUFFER_SIZE);
+
+    tokio::task::spawn(async move {
+        use tokio::io::AsyncWriteExt as _;
+        use tokio_stream::StreamExt as _;
+
+        let mut log_output = log_output;
+        let mut raw_writer = raw_writer;
+
+        while let Some(chunk) = log_output.next().await {
+            match chunk {
+                Ok(line) => {
+                    let data = format!("{line}\n");
+                    if raw_writer.write_all(data.as_bytes()).await.is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to read log chunk: {e}");
+                    break;
+                }
+            }
+        }
+    });
+
+    let encoder = CompressionEncoder::new(BufReader::new(raw_reader));
+    let mut encoded_stream = ReaderStream::new(encoder);
+    let drv = ProtoStorePath::from(drv.clone());
+
+    async_stream::stream! {
+        use tokio_stream::StreamExt as _;
+        let mut first = true;
+        while let Some(chunk) = encoded_stream.next().await {
+            match chunk {
+                Ok(bytes) => yield LogChunk {
+                    // Only the first chunk needs the drv; server reads it once
+                    drv: if first { first = false; Some(drv.clone()) } else {None},
+                    data: bytes.into(),
+                },
+                Err(e) => {
+                    tracing::error!("Failed to compress log chunk: {e}");
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/subprojects/hydra-queue-runner/Cargo.toml
+++ b/subprojects/hydra-queue-runner/Cargo.toml
@@ -30,12 +30,14 @@ byte-unit.workspace    = true
 futures.workspace      = true
 futures-util.workspace = true
 tokio                  = { workspace = true, features = [ "full" ] }
+tokio-stream.workspace = true
+tokio-util             = { workspace = true, features = [ "io", "io-util" ] }
 
+async-compression          = { workspace = true, features = [ "tokio", "zstd" ] }
 h2.workspace               = true
 listenfd.workspace         = true
 prost.workspace            = true
-tokio-stream.workspace     = true
-tonic                      = { workspace = true, features = [ "zstd", "tls-webpki-roots" ] }
+tonic                      = { workspace = true, features = [ "tls-webpki-roots" ] }
 tonic-health.workspace     = true
 tonic-prost.workspace      = true
 tonic-reflection.workspace = true

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use tokio::{io::AsyncWriteExt as _, sync::mpsc};
+use tokio::sync::mpsc;
 use tonic::service::interceptor::InterceptedService;
 use tower::ServiceBuilder;
 use tracing::Instrument as _;
@@ -27,6 +27,57 @@ type OpenTunnelResponseStream =
     std::pin::Pin<Box<dyn futures::Stream<Item = Result<RunnerRequest, tonic::Status>> + Send>>;
 type StreamFileResponseStream =
     std::pin::Pin<Box<dyn futures::Stream<Item = Result<NarData, tonic::Status>> + Send>>;
+
+type CompressionEncoder<R> = async_compression::tokio::bufread::ZstdEncoder<R>;
+type CompressionDecoder<R> = async_compression::tokio::bufread::ZstdDecoder<R>;
+
+const DUPLEX_BUFFER_SIZE: usize = 256 * 1024;
+
+fn decode_stream<S>(
+    stream: S,
+) -> impl tokio_stream::Stream<Item = Result<bytes::Bytes, std::io::Error>>
+where
+    S: tokio_stream::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Unpin,
+{
+    let reader = tokio_util::io::StreamReader::new(stream);
+    let decoder = CompressionDecoder::new(reader);
+    tokio_util::io::ReaderStream::new(decoder)
+}
+
+fn compression_encode_channel() -> (
+    tokio::io::DuplexStream,
+    mpsc::UnboundedReceiver<Result<NarData, tonic::Status>>,
+) {
+    let (raw_writer, raw_reader) = tokio::io::duplex(DUPLEX_BUFFER_SIZE);
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    tokio::task::spawn(async move {
+        use tokio_stream::StreamExt as _;
+        let encoder = CompressionEncoder::new(tokio::io::BufReader::new(raw_reader));
+        let mut stream = tokio_util::io::ReaderStream::new(encoder);
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    if tx
+                        .send(Ok(NarData {
+                            chunk: bytes.into(),
+                        }))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to compress chunk: {e}");
+                    let _ = tx.send(Err(tonic::Status::internal("Compression error")));
+                    break;
+                }
+            }
+        }
+    });
+
+    (raw_writer, rx)
+}
 
 // there is no reason to make this configurable, it only exists so we ensure the channel is not
 // closed. we dont use this to write any actual information.
@@ -132,8 +183,6 @@ impl Server {
         let service = RunnerServiceServer::new(Self {
             state: state.clone(),
         })
-        .send_compressed(tonic::codec::CompressionEncoding::Zstd)
-        .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
         .max_decoding_message_size(50 * 1024 * 1024)
         .max_encoding_message_size(50 * 1024 * 1024);
         let intercepted_service = InterceptedService::new(
@@ -373,27 +422,39 @@ impl RunnerService for Server {
     ) -> BuilderResult<runner_v1::Empty> {
         use tokio_stream::StreamExt as _;
 
-        let mut stream = req.into_inner();
+        let stream = req.into_inner();
         let state = self.state.clone();
 
-        let mut out_file: Option<fs_err::tokio::File> = None;
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk?;
+        let mut mapped = stream.map(|result| {
+            result
+                .map(|chunk| (chunk.drv, bytes::Bytes::from(chunk.data)))
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e))
+        });
 
-            if let Some(ref mut file) = out_file {
-                file.write_all(&chunk.data).await?;
-            } else {
-                let drv = chunk
-                    .drv
-                    .ok_or_else(|| tonic::Status::invalid_argument("missing drv"))?;
-                let mut file = state
-                    .new_log_file(&drv)
-                    .await
-                    .map_err(|_| tonic::Status::internal("Failed to create log file."))?;
-                file.write_all(&chunk.data).await?;
-                out_file = Some(file);
-            }
-        }
+        let (drv, first_data) = mapped
+            .next()
+            .await
+            .ok_or_else(|| tonic::Status::internal("Empty stream"))??;
+
+        let file = state
+            .new_log_file(
+                &drv.ok_or_else(|| tonic::Status::invalid_argument("missing drv"))?
+                    .into(),
+            )
+            .await
+            .map_err(|_| tonic::Status::internal("Failed to create log file."))?;
+
+        let first = tokio_stream::iter(vec![Ok::<_, std::io::Error>(first_data)]);
+        let rest = mapped.map(|r| r.map(|(_, data)| data));
+        let full_stream = first.chain(rest);
+
+        let reader = tokio_util::io::StreamReader::new(full_stream);
+        let mut decoder = CompressionDecoder::new(reader);
+        let mut file: fs_err::tokio::File = file;
+
+        tokio::io::copy(&mut decoder, &mut file)
+            .await
+            .map_err(|_| tonic::Status::internal("Failed to write log file."))?;
 
         Ok(tonic::Response::new(runner_v1::Empty {}))
     }
@@ -409,16 +470,13 @@ impl RunnerService for Server {
         // connection for each import. This sucks but using the state.store will result in the path
         // not being closed!
         {
+            let data_stream = tokio_stream::StreamExt::map(stream, |s| {
+                s.map(|v| bytes::Bytes::from(v.chunk))
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e))
+            });
+
             let store = nix_utils::LocalStore::init();
-            store
-                .import_paths(
-                    tokio_stream::StreamExt::map(stream, |s| {
-                        s.map(|v| v.chunk.into())
-                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e))
-                    }),
-                    false,
-                )
-                .await
+            store.import_paths(decode_stream(data_stream), false).await
         }
         .map_err(|_| tonic::Status::internal("Failed to import path."))?;
         Ok(tonic::Response::new(runner_v1::Empty {}))
@@ -569,15 +627,15 @@ impl RunnerService for Server {
         req: tonic::Request<ProtoStorePath>,
     ) -> BuilderResult<Self::StreamFileStream> {
         let path = req.into_inner().0;
-        let store = nix_utils::LocalStore::init();
-        let (tx, rx) = mpsc::unbounded_channel::<Result<NarData, tonic::Status>>();
+        let (raw_writer, rx) = compression_encode_channel();
 
-        let closure = move |data: &[u8]| {
-            let data = Vec::from(data);
-            tx.send(Ok(NarData { chunk: data })).is_ok()
-        };
-
-        tokio::task::spawn(async move {
+        tokio::task::spawn_blocking(move || {
+            let store = nix_utils::LocalStore::init();
+            let mut sync_writer = tokio_util::io::SyncIoBridge::new(raw_writer);
+            let closure = move |data: &[u8]| {
+                use std::io::Write;
+                sync_writer.write_all(data).is_ok()
+            };
             let _ = store.export_paths(&[path], closure);
         });
 
@@ -594,17 +652,16 @@ impl RunnerService for Server {
     ) -> BuilderResult<Self::StreamFilesStream> {
         let req = req.into_inner();
         let paths = req.paths.into_iter().map(|p| p.0).collect::<Vec<_>>();
+        let (raw_writer, rx) = compression_encode_channel();
 
-        let store = nix_utils::LocalStore::init();
-        let (tx, rx) = mpsc::unbounded_channel::<Result<NarData, tonic::Status>>();
-
-        let closure = move |data: &[u8]| {
-            let data = Vec::from(data);
-            tx.send(Ok(NarData { chunk: data })).is_ok()
-        };
-
-        tokio::task::spawn(async move {
-            let _ = store.export_paths(&paths, closure.clone());
+        tokio::task::spawn_blocking(move || {
+            let store = nix_utils::LocalStore::init();
+            let mut sync_writer = tokio_util::io::SyncIoBridge::new(raw_writer);
+            let closure = move |data: &[u8]| {
+                use std::io::Write;
+                sync_writer.write_all(data).is_ok()
+            };
+            let _ = store.export_paths(&paths, closure);
         });
 
         Ok(tonic::Response::new(


### PR DESCRIPTION
Tonic uses single threaded zstd compression, see
https://github.com/hyperium/tonic/blob/368361b54c1f09bf652d87b11833860b016be872/tonic/src/codec/compression.rs#L203-L295. To resolve this issue we no longer use compression with tonic and just directly encode/decode the log stream as well as the streaming of nars using async-compression.

I am not 100% sure that this solves the poor single core performance but it might explain it. I'm currently testing this locally, by streaming nars in a second nix store