### PR TITLE
Fix perlcritic warnings in `nix-perl` modules

### DIFF
--- a/subprojects/hydra-linters/perlcritic.pl
+++ b/subprojects/hydra-linters/perlcritic.pl
@@ -16,7 +16,5 @@ exec(
     "subprojects/hydra/",
     "subprojects/hydra-tests/",
     "subprojects/hydra-linters/",
-    # We'll deal with this later, after the initial moving over from the
-    # Nix repo.
-    # "subprojects/nix-perl",
+    "subprojects/nix-perl",
 ) or die "Failed to execute perlcritic.";

--- a/subprojects/nix-perl/lib/Nix/CopyClosure.pm
+++ b/subprojects/nix-perl/lib/Nix/CopyClosure.pm
@@ -2,6 +2,7 @@ package Nix::CopyClosure;
 
 use utf8;
 use strict;
+use warnings;
 use Nix::Config;
 use Nix::Store;
 use Nix::SSH;

--- a/subprojects/nix-perl/lib/Nix/Manifest.pm
+++ b/subprojects/nix-perl/lib/Nix/Manifest.pm
@@ -2,6 +2,7 @@ package Nix::Manifest;
 
 use utf8;
 use strict;
+use warnings;
 use DBI;
 use DBD::SQLite;
 use Cwd;
@@ -58,11 +59,12 @@ sub readManifest_ {
     my ($manifest, $addNAR, $addPatch) = @_;
 
     # Decompress the manifest if necessary.
+    my $manifest_fh;
     if ($manifest =~ /\.bz2$/) {
-        open MANIFEST, "$Nix::Config::bzip2 -d < $manifest |"
+        open $manifest_fh, "-|", "$Nix::Config::bzip2", "-d", "-c", $manifest
             or die "cannot decompress '$manifest': $!";
     } else {
-        open MANIFEST, "<$manifest"
+        open $manifest_fh, "<", $manifest
             or die "cannot open '$manifest': $!";
     }
 
@@ -74,7 +76,8 @@ sub readManifest_ {
     my ($storePath, $url, $hash, $size, $basePath, $baseHash, $patchType);
     my ($narHash, $narSize, $references, $deriver, $copyFrom, $system, $compressionType);
 
-    while (<MANIFEST>) {
+    while (my $line = <$manifest_fh>) {
+        $_ = $line;
         chomp;
         s/\#.*$//g;
         next if (/^$/);
@@ -150,7 +153,7 @@ sub readManifest_ {
         }
     }
 
-    close MANIFEST;
+    close $manifest_fh;
 
     return $manifestVersion;
 }
@@ -167,51 +170,52 @@ sub readManifest {
 sub writeManifest {
     my ($manifest, $narFiles, $patches, $noCompress) = @_;
 
-    open MANIFEST, ">$manifest.tmp"; # !!! check exclusive
+    open my $manifest_fh, ">", "$manifest.tmp" # !!! check exclusive
+        or die "cannot create '$manifest.tmp': $!";
 
-    print MANIFEST "version {\n";
-    print MANIFEST "  ManifestVersion: 3\n";
-    print MANIFEST "}\n";
+    print $manifest_fh "version {\n";
+    print $manifest_fh "  ManifestVersion: 3\n";
+    print $manifest_fh "}\n";
 
     foreach my $storePath (sort (keys %{$narFiles})) {
         my $narFileList = $$narFiles{$storePath};
         foreach my $narFile (@{$narFileList}) {
-            print MANIFEST "{\n";
-            print MANIFEST "  StorePath: $storePath\n";
-            print MANIFEST "  NarURL: $narFile->{url}\n";
-            print MANIFEST "  Compression: $narFile->{compressionType}\n";
-            print MANIFEST "  Hash: $narFile->{hash}\n" if defined $narFile->{hash};
-            print MANIFEST "  Size: $narFile->{size}\n" if defined $narFile->{size};
-            print MANIFEST "  NarHash: $narFile->{narHash}\n";
-            print MANIFEST "  NarSize: $narFile->{narSize}\n" if $narFile->{narSize};
-            print MANIFEST "  References: $narFile->{references}\n"
+            print $manifest_fh "{\n";
+            print $manifest_fh "  StorePath: $storePath\n";
+            print $manifest_fh "  NarURL: $narFile->{url}\n";
+            print $manifest_fh "  Compression: $narFile->{compressionType}\n";
+            print $manifest_fh "  Hash: $narFile->{hash}\n" if defined $narFile->{hash};
+            print $manifest_fh "  Size: $narFile->{size}\n" if defined $narFile->{size};
+            print $manifest_fh "  NarHash: $narFile->{narHash}\n";
+            print $manifest_fh "  NarSize: $narFile->{narSize}\n" if $narFile->{narSize};
+            print $manifest_fh "  References: $narFile->{references}\n"
                 if defined $narFile->{references} && $narFile->{references} ne "";
-            print MANIFEST "  Deriver: $narFile->{deriver}\n"
+            print $manifest_fh "  Deriver: $narFile->{deriver}\n"
                 if defined $narFile->{deriver} && $narFile->{deriver} ne "";
-            print MANIFEST "  System: $narFile->{system}\n" if defined $narFile->{system};
-            print MANIFEST "}\n";
+            print $manifest_fh "  System: $narFile->{system}\n" if defined $narFile->{system};
+            print $manifest_fh "}\n";
         }
     }
 
     foreach my $storePath (sort (keys %{$patches})) {
         my $patchList = $$patches{$storePath};
         foreach my $patch (@{$patchList}) {
-            print MANIFEST "patch {\n";
-            print MANIFEST "  StorePath: $storePath\n";
-            print MANIFEST "  NarURL: $patch->{url}\n";
-            print MANIFEST "  Hash: $patch->{hash}\n";
-            print MANIFEST "  Size: $patch->{size}\n";
-            print MANIFEST "  NarHash: $patch->{narHash}\n";
-            print MANIFEST "  NarSize: $patch->{narSize}\n" if $patch->{narSize};
-            print MANIFEST "  BasePath: $patch->{basePath}\n";
-            print MANIFEST "  BaseHash: $patch->{baseHash}\n";
-            print MANIFEST "  Type: $patch->{patchType}\n";
-            print MANIFEST "}\n";
+            print $manifest_fh "patch {\n";
+            print $manifest_fh "  StorePath: $storePath\n";
+            print $manifest_fh "  NarURL: $patch->{url}\n";
+            print $manifest_fh "  Hash: $patch->{hash}\n";
+            print $manifest_fh "  Size: $patch->{size}\n";
+            print $manifest_fh "  NarHash: $patch->{narHash}\n";
+            print $manifest_fh "  NarSize: $patch->{narSize}\n" if $patch->{narSize};
+            print $manifest_fh "  BasePath: $patch->{basePath}\n";
+            print $manifest_fh "  BaseHash: $patch->{baseHash}\n";
+            print $manifest_fh "  Type: $patch->{patchType}\n";
+            print $manifest_fh "}\n";
         }
     }
 
 
-    close MANIFEST;
+    close $manifest_fh;
 
     rename("$manifest.tmp", $manifest)
         or die "cannot rename $manifest.tmp: $!";

--- a/subprojects/nix-perl/lib/Nix/SSH.pm
+++ b/subprojects/nix-perl/lib/Nix/SSH.pm
@@ -2,6 +2,7 @@ package Nix::SSH;
 
 use utf8;
 use strict;
+use warnings;
 use File::Temp qw(tempdir);
 use IPC::Open2;
 

--- a/subprojects/nix-perl/lib/Nix/Store.pm
+++ b/subprojects/nix-perl/lib/Nix/Store.pm
@@ -31,10 +31,10 @@ our @EXPORT = qw(
 our $VERSION = '0.15';
 
 sub backtick {
-    open(RES, "-|", @_) or die;
+    open(my $fh, "-|", @_) or die;
     local $/;
-    my $res = <RES> || "";
-    close RES or die;
+    my $res = <$fh> || "";
+    close $fh or die;
     return $res;
 }
 

--- a/subprojects/nix-perl/lib/Nix/Utils.pm
+++ b/subprojects/nix-perl/lib/Nix/Utils.pm
@@ -1,12 +1,14 @@
 package Nix::Utils;
 
 use utf8;
+use strict;
+use warnings;
 use File::Temp qw(tempdir);
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(checkURL uniq writeFile readFile mkTempDir);
 
-$urlRE = "(?: [a-zA-Z][a-zA-Z0-9\+\-\.]*\:[a-zA-Z0-9\%\/\?\:\@\&\=\+\$\,\-\_\.\!\~\*]+ )";
+our $urlRE = "(?: [a-zA-Z][a-zA-Z0-9\+\-\.]*\:[a-zA-Z0-9\%\/\?\:\@\&\=\+\$\,\-\_\.\!\~\*]+ )";
 
 sub checkURL {
     my ($url) = @_;
@@ -26,17 +28,17 @@ sub uniq {
 
 sub writeFile {
     my ($fn, $s) = @_;
-    open TMP, ">$fn" or die "cannot create file '$fn': $!";
-    print TMP "$s" or die;
-    close TMP or die;
+    open my $fh, ">", $fn or die "cannot create file '$fn': $!";
+    print $fh "$s" or die;
+    close $fh or die;
 }
 
 sub readFile {
     local $/ = undef;
     my ($fn) = @_;
-    open TMP, "<$fn" or die "cannot open file '$fn': $!";
-    my $s = <TMP>;
-    close TMP or die;
+    open my $fh, "<", $fn or die "cannot open file '$fn': $!";
+    my $s = <$fh>;
+    close $fh or die;
     return $s;
 }
 

--- a/subprojects/nix-perl/t/init.t
+++ b/subprojects/nix-perl/t/init.t
@@ -4,7 +4,7 @@ use Test2::V0;
 
 use Nix::Store;
 
-my $s = new Nix::Store("dummy://");
+my $s = Nix::Store->new("dummy://");
 
 my $res = $s->isValidPath("/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar");
 


### PR DESCRIPTION
Now that the Perl bindings are moved into this repo, they should pass our linter. These are all mechanical fixes to pre-existing code quality issues:

- Add `use strict` and `use warnings` to modules that were missing them (`Manifest.pm`, `SSH.pm`, `CopyClosure.pm`, `Utils.pm`)

- Replace bareword filehandles (`MANIFEST`, `TMP`, `RES`) with lexical ones (`$manifest_fh`, `$fh`)

- Switch 2-arg `open` calls to 3-arg form

- Declare package variable `$urlRE` with `our`

- Assign `readline` result to a lexical in while condition

- Use `Nix::Store->new(...)` instead of indirect `new Nix::Store(...)`