### PR TITLE
Extract `QueueRunnerContext` from `QueueRunnerBuildOne`

### DIFF
--- a/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
@@ -2,46 +2,16 @@ use warnings;
 use strict;
 
 package QueueRunnerBuildOne;
-use IO::Socket::IP;
 use IPC::Run;
 use JSON::PP;
 use LWP::UserAgent;
 use HTTP::Request;
-use Hydra::Config;
+use QueueRunnerContext;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
     runBuild
     runBuilds
 );
-
-sub _get_random_port {
-    my ($min, $max) = @_;
-    while (1) {
-        my $port = $min + int(rand($max - $min + 1));
-        my $sock = IO::Socket::IP->new(
-            LocalAddr => '::',
-            LocalPort => $port,
-            Proto     => 'tcp',
-            ReuseAddr => 0,
-        );
-        if ($sock) {
-            close($sock);
-            return $port;
-        }
-    }
-}
-
-sub _wait_for {
-    my ($ua, $url, $check) = @_;
-    for my $i (1..30) {
-        my $resp = $ua->get($url);
-        if ($resp->is_success) {
-            return 1 if !$check || $check->($resp);
-        }
-        select(undef, undef, undef, 0.5);
-    }
-    return 0;
-}
 
 sub _flush_stream {
     my ($label, $stream, $buf_ref, $final) = @_;
@@ -70,52 +40,11 @@ sub runBuilds {
     ref $ctx eq 'HydraTestContext' or die "runBuilds requires a HydraTestContext as first argument\n";
     my @build_ids = map { $_->id } @builds;
 
-    my $grpc_port = _get_random_port(5000, 9999);
-    my $http_port = _get_random_port(10000, 19999);
+    my ($qr_harness, $base_url, $grpc_port, $qr_out_ref, $qr_err_ref) = start_queue_runner($ctx,
+        rust_log => "queue_runner=debug,info",
+    );
 
-    my $config_dir = $ENV{T2_HARNESS_TEMP_DIR}
-        // $ctx->{central}{hydra_data};
-    my $config_file = "$config_dir/config.toml";
-
-    # Read store settings from the Hydra config file.
-    my $hydra_config_file = $ctx->{central}{hydra_config_file};
-    my $hydra_config = ($hydra_config_file && -f $hydra_config_file)
-        ? Hydra::Config::loadConfig($hydra_config_file) : {};
-    my $dest_store_uri = $hydra_config->{store_uri} // "";
-    my $use_substitutes = $hydra_config->{'use-substitutes'} // "";
-
-    # Write the TOML config for the queue runner.
-    {
-        my $db_url = $ctx->{central}{hydra_database_url};
-        open(my $fh, '>', $config_file) or die "Cannot write $config_file: $!\n";
-        print $fh "dbUrl = \"$db_url\"\n";
-        print $fh "hydraDataDir = \"$config_dir/data\"\n";
-        print $fh "remoteStoreAddr = [\"$dest_store_uri\"]\n" if $dest_store_uri ne "";
-        print $fh "useSubstitutes = true\n" if $use_substitutes eq "1";
-        close($fh);
-    }
-
-    my ($qr_in, $qr_out, $qr_err) = ("", "", "");
     my ($bl_in, $bl_out, $bl_err) = ("", "", "");
-
-    # Start the queue runner with central env applied.
-    my $qr_harness;
-    {
-        local @ENV{keys %{$ctx->{central_env}}} = values %{$ctx->{central_env}};
-        local $ENV{RUST_LOG} = "queue_runner=debug,info";
-        local $ENV{NO_COLOR} = "1";
-        $qr_harness = IPC::Run::start(
-            ["hydra-queue-runner",
-                "--config-path", $config_file,
-                "--rest-bind", "[::]:$http_port",
-                "--grpc-bind", "[::]:$grpc_port",
-                "--disable-queue-monitor-loop",
-            ],
-            \$qr_in, \$qr_out, \$qr_err,
-        );
-    }
-
-    my $base_url = "http://[::1]:$http_port";
     my $ua = LWP::UserAgent->new(timeout => 2);
     my $bl_harness;
 
@@ -124,7 +53,7 @@ sub runBuilds {
         local $SIG{ALRM} = sub { die "timeout\n" };
         alarm $timeout;
         # Wait for the REST server to become available.
-        _wait_for($ua, "$base_url/status")
+        wait_for_url($ua, "$base_url/status")
             or die "Timed out waiting for queue-runner REST server\n";
 
         # Start the builder with its own store settings.
@@ -146,7 +75,7 @@ sub runBuilds {
         }
 
         # Wait for the builder to register as a machine.
-        _wait_for($ua, "$base_url/status/machines", sub {
+        wait_for_url($ua, "$base_url/status/machines", sub {
             shift->decoded_content =~ /"hostname"/;
         }) or die "Timed out waiting for builder to register\n";
 
@@ -167,7 +96,7 @@ sub runBuilds {
             $qr_harness->pump_nb;
             $bl_harness->pump_nb;
             # Flush accumulated output so logs are visible while waiting.
-            _flush_harness("Queue runner", \$qr_out, \$qr_err);
+            _flush_harness("Queue runner", $qr_out_ref, $qr_err_ref);
             _flush_harness("Builder", \$bl_out, \$bl_err);
             if (!$bl_harness->pumpable) {
                 $bl_harness->finish;
@@ -201,7 +130,7 @@ sub runBuilds {
         _flush_harness("Builder", \$bl_out, \$bl_err, 1);
     }
     $qr_harness->kill_kill;
-    _flush_harness("Queue runner", \$qr_out, \$qr_err, 1);
+    _flush_harness("Queue runner", $qr_out_ref, $qr_err_ref, 1);
 
     if (!$ok) {
         print STDERR "runBuilds failed: $err" if $err;

--- a/subprojects/hydra-tests/lib/QueueRunnerContext.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerContext.pm
@@ -1,0 +1,101 @@
+use warnings;
+use strict;
+
+package QueueRunnerContext;
+use IO::Socket::IP;
+use IPC::Run;
+use LWP::UserAgent;
+use Hydra::Config;
+our @ISA = qw(Exporter);
+our @EXPORT = qw(
+    get_random_port
+    start_queue_runner
+    wait_for_url
+);
+
+sub get_random_port {
+    my ($min, $max) = @_;
+    while (1) {
+        my $port = $min + int(rand($max - $min + 1));
+        my $sock = IO::Socket::IP->new(
+            LocalAddr => '::',
+            LocalPort => $port,
+            Proto     => 'tcp',
+            ReuseAddr => 0,
+        );
+        if ($sock) {
+            close($sock);
+            return $port;
+        }
+    }
+}
+
+sub wait_for_url {
+    my ($ua, $url, $check) = @_;
+    for my $i (1..30) {
+        my $resp = $ua->get($url);
+        if ($resp->is_success) {
+            return 1 if !$check || $check->($resp);
+        }
+        select(undef, undef, undef, 0.5);
+    }
+    return 0;
+}
+
+# Start a queue runner process.
+# Returns ($harness, $http_url, $grpc_port, \$stdout_buf, \$stderr_buf).
+# Caller is responsible for calling $harness->kill_kill when done.
+sub start_queue_runner {
+    my ($ctx, %opts) = @_;
+    ref $ctx eq 'HydraTestContext' or die "start_queue_runner requires a HydraTestContext\n";
+
+    my $grpc_port = get_random_port(5000, 9999);
+    my $http_port = get_random_port(10000, 19999);
+
+    my $config_dir = $ENV{T2_HARNESS_TEMP_DIR}
+        // $ctx->{central}{hydra_data};
+    my $config_file = "$config_dir/qr-config.toml";
+
+    # Read store settings from the Hydra config file.
+    my $hydra_config_file = $ctx->{central}{hydra_config_file};
+    my $hydra_config = ($hydra_config_file && -f $hydra_config_file)
+        ? Hydra::Config::loadConfig($hydra_config_file) : {};
+    my $dest_store_uri = $hydra_config->{store_uri} // "";
+    my $use_substitutes = $hydra_config->{'use-substitutes'} // "";
+
+    # Write the TOML config for the queue runner.
+    {
+        my $db_url = $ctx->{central}{hydra_database_url};
+        open(my $fh, '>', $config_file) or die "Cannot write $config_file: $!\n";
+        print $fh "dbUrl = \"$db_url\"\n";
+        print $fh "hydraDataDir = \"$config_dir/data\"\n";
+        print $fh "remoteStoreAddr = [\"$dest_store_uri\"]\n" if $dest_store_uri ne "";
+        print $fh "useSubstitutes = true\n" if $use_substitutes eq "1";
+        close($fh);
+    }
+
+    my ($qr_in, $qr_out, $qr_err) = ("", "", "");
+
+    # Start the queue runner with central env applied.
+    my $qr_harness;
+    {
+        local @ENV{keys %{$ctx->{central_env}}} = values %{$ctx->{central_env}};
+        local $ENV{RUST_LOG} = $opts{rust_log} // "error";
+        local $ENV{NO_COLOR} = "1";
+        $qr_harness = IPC::Run::start(
+            ["hydra-queue-runner",
+                "--config-path", $config_file,
+                "--rest-bind", "[::]:$http_port",
+                "--grpc-bind", "[::]:$grpc_port",
+                "--disable-queue-monitor-loop",
+            ],
+            \$qr_in, \$qr_out, \$qr_err,
+        );
+    }
+
+    my $base_url = "http://[::1]:$http_port";
+
+    return ($qr_harness, $base_url, $grpc_port, \$qr_out, \$qr_err);
+}
+
+1;


### PR DESCRIPTION
Move the queue runner startup helpers (`_get_random_port`, `_wait_for`, and the config-writing + process-spawning logic) into a shared `QueueRunnerContext.pm` module so they can be reused by other tests.

No behavior change — `runBuilds` produces identical results.