### PR TITLE
Add systemd socket activation to queue runner

### DIFF
--- a/nixos-modules/queue-runner-module.nix
+++ b/nixos-modules/queue-runner-module.nix
@@ -151,18 +151,18 @@ in
       };
 
       grpc = lib.mkOption {
-        description = "grpc options";
+        description = "gRPC listener options";
         default = { };
         type = lib.types.submodule {
           options = {
             address = lib.mkOption {
               type = lib.types.singleLineStr;
               default = "[::1]";
-              description = "The IP address the grpc listener should bound to";
+              description = "The IP address the gRPC listener should bind to.";
             };
 
             port = lib.mkOption {
-              description = "Which grpc port this app should listen on";
+              description = "Which gRPC port this app should listen on.";
               type = lib.types.port;
               default = 50051;
             };
@@ -171,18 +171,18 @@ in
       };
 
       rest = lib.mkOption {
-        description = "rest options";
+        description = "REST listener options";
         default = { };
         type = lib.types.submodule {
           options = {
             address = lib.mkOption {
               type = lib.types.singleLineStr;
               default = "[::1]";
-              description = "The IP address the rest listener should bound to";
+              description = "The IP address the REST listener should bind to.";
             };
 
             port = lib.mkOption {
-              description = "Which rest port this app should listen on";
+              description = "Which REST port this app should listen on.";
               type = lib.types.port;
               default = 8080;
             };
@@ -243,7 +243,11 @@ in
     systemd.services.hydra-queue-runner-dev = {
       description = "Hydra Queue Runner main service";
 
-      requires = [ "nix-daemon.socket" ];
+      requires = [
+        "nix-daemon.socket"
+        "hydra-queue-runner-dev-rest.socket"
+        "hydra-queue-runner-dev-grpc.socket"
+      ];
       after = [
         # sets up database, queue-runner crashes if schema is incorrect
         "hydra-init.service"
@@ -276,9 +280,9 @@ in
           [
             "${cfg.package}/bin/hydra-queue-runner"
             "--rest-bind"
-            "${cfg.rest.address}:${toString cfg.rest.port}"
+            "-"
             "--grpc-bind"
-            "${cfg.grpc.address}:${toString cfg.grpc.port}"
+            "-"
             "--config-path"
             "/etc/hydra/queue-runner.toml"
           ]
@@ -342,6 +346,26 @@ in
         MemoryDenyWriteExecute = true;
         PrivateUsers = true;
         RestrictNamespaces = true;
+      };
+    };
+
+    systemd.sockets.hydra-queue-runner-dev-rest = {
+      description = "Hydra Queue Runner REST socket";
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = "${cfg.rest.address}:${toString cfg.rest.port}";
+        FileDescriptorName = "rest";
+        Service = "hydra-queue-runner-dev.service";
+      };
+    };
+
+    systemd.sockets.hydra-queue-runner-dev-grpc = {
+      description = "Hydra Queue Runner gRPC socket";
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = "${cfg.grpc.address}:${toString cfg.grpc.port}";
+        FileDescriptorName = "grpc";
+        Service = "hydra-queue-runner-dev.service";
       };
     };
 

--- a/subprojects/hydra-queue-runner/src/config.rs
+++ b/subprojects/hydra-queue-runner/src/config.rs
@@ -31,9 +31,9 @@ pub struct Cli {
     #[clap(long)]
     pub status: bool,
 
-    /// REST server bind
+    /// REST server bind, either a `SocketAddr` or `-` to use `ListenFD` (systemd socket activation)
     #[clap(short, long, default_value = "[::1]:8080")]
-    pub rest_bind: SocketAddr,
+    pub rest_bind: BindSocket,
 
     /// GRPC server bind, either a `SocketAddr`, a Path for a Unix Socket or `-` to use `ListenFD` (systemd socket activation)
     #[clap(short, long, default_value = "[::1]:50051")]

--- a/subprojects/hydra-queue-runner/src/main.rs
+++ b/subprojects/hydra-queue-runner/src/main.rs
@@ -21,6 +21,8 @@ pub mod server;
 pub mod state;
 pub mod utils;
 
+use std::future::Future;
+
 use anyhow::Context as _;
 
 use state::State;
@@ -109,13 +111,79 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let task_abort_handles = start_task_loops(&state);
+
+    // Resolve listeners for both servers. When using socket activation
+    // (ListenFd), we use LISTEN_FDNAMES to map names to fd indices.
+    let mut listenfd = listenfd::ListenFd::from_env();
+    let fd_names: Vec<String> = std::env::var("LISTEN_FDNAMES")
+        .unwrap_or_default()
+        .split(':')
+        .map(String::from)
+        .collect();
+
+    let http_listener = match &state.cli.rest_bind {
+        config::BindSocket::Tcp(s) => {
+            let listener = tokio::net::TcpListener::bind(s).await?;
+            listener
+        }
+        config::BindSocket::ListenFd => {
+            let idx = fd_names.iter().position(|n| n == "rest").unwrap_or(0);
+            let std_listener = listenfd.take_tcp_listener(idx)?.ok_or_else(|| {
+                anyhow::anyhow!("No listenfd TCP listener at index {idx} for REST")
+            })?;
+            std_listener.set_nonblocking(true)?;
+            tokio::net::TcpListener::from_std(std_listener)?
+        }
+        config::BindSocket::Unix(_) => {
+            anyhow::bail!("HTTP server does not support Unix sockets");
+        }
+    };
+    let http_addr = http_listener.local_addr()?;
+
+    let (srv1, grpc_info): (
+        std::pin::Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>,
+        String,
+    ) = match &state.cli.grpc_bind {
+        config::BindSocket::Tcp(s) => {
+            let listener = tokio::net::TcpListener::bind(s).await?;
+            let addr = listener.local_addr()?;
+            let info = addr.to_string();
+            (
+                Box::pin(server::grpc::Server::run(listener, state.clone())),
+                info,
+            )
+        }
+        config::BindSocket::ListenFd => {
+            let idx = fd_names.iter().position(|n| n == "grpc").unwrap_or(1);
+            let std_listener = listenfd.take_tcp_listener(idx)?.ok_or_else(|| {
+                anyhow::anyhow!("No listenfd TCP listener at index {idx} for gRPC")
+            })?;
+            let addr = std_listener.local_addr()?;
+            let info = addr.to_string();
+            std_listener.set_nonblocking(true)?;
+            let listener = tokio::net::TcpListener::from_std(std_listener)?;
+            (
+                Box::pin(server::grpc::Server::run(listener, state.clone())),
+                info,
+            )
+        }
+        config::BindSocket::Unix(p) => {
+            let listener = tokio::net::UnixListener::bind(p)?;
+            let info = format!("unix:{}", p.display());
+            (
+                Box::pin(server::grpc::Server::run_unix(listener, state.clone())),
+                info,
+            )
+        }
+    };
+
     tracing::info!(
-        "QueueRunner listening on grpc: {:?} and rest: {}",
-        state.cli.grpc_bind,
-        state.cli.rest_bind
+        "QueueRunner listening on grpc: {} and rest: {}",
+        grpc_info,
+        http_addr
     );
-    let srv1 = server::grpc::Server::run(state.cli.grpc_bind.clone(), state.clone());
-    let srv2 = server::http::Server::run(state.cli.rest_bind, state.clone());
+
+    let srv2 = server::http::Server::run(http_listener, state.clone());
 
     let task = tokio::spawn(async move {
         match futures_util::future::join(srv1, srv2).await {

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -7,7 +7,6 @@ use tower::ServiceBuilder;
 use tracing::Instrument as _;
 
 use crate::{
-    config::BindSocket,
     server::grpc::runner_v1::{BuildResultState, StepUpdate},
     state::{Machine, MachineMessage, State},
 };
@@ -178,8 +177,34 @@ pub struct Server {
 }
 
 impl Server {
-    #[tracing::instrument(skip(state), err)]
-    pub async fn run(addr: BindSocket, state: Arc<State>) -> anyhow::Result<()> {
+    /// Serve on a pre-bound TCP listener.
+    #[tracing::instrument(skip(listener, state), err)]
+    pub async fn run(listener: tokio::net::TcpListener, state: Arc<State>) -> anyhow::Result<()> {
+        let stream = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Self::serve_incoming(stream, state).await
+    }
+
+    /// Serve on a Unix socket listener.
+    #[tracing::instrument(skip(listener, state), err)]
+    pub async fn run_unix(
+        listener: tokio::net::UnixListener,
+        state: Arc<State>,
+    ) -> anyhow::Result<()> {
+        let stream = tokio_stream::wrappers::UnixListenerStream::new(listener);
+        Self::serve_incoming(stream, state).await
+    }
+
+    async fn serve_incoming<S, IO, IE>(incoming: S, state: Arc<State>) -> anyhow::Result<()>
+    where
+        S: futures_util::Stream<Item = Result<IO, IE>>,
+        IO: tokio::io::AsyncRead
+            + tokio::io::AsyncWrite
+            + tonic::transport::server::Connected
+            + Unpin
+            + Send
+            + 'static,
+        IE: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
         let service = RunnerServiceServer::new(Self {
             state: state.clone(),
         })
@@ -222,30 +247,12 @@ impl Server {
             .build_v1()?;
 
         let (_health_reporter, health_service) = tonic_health::server::health_reporter();
-        let server = server
+        server
             .add_service(health_service)
             .add_service(reflection_service)
-            .add_service(intercepted_service);
-
-        match addr {
-            BindSocket::Tcp(s) => server.serve(s).await?,
-            BindSocket::Unix(p) => {
-                let uds = tokio::net::UnixListener::bind(p)?;
-                let uds_stream = tokio_stream::wrappers::UnixListenerStream::new(uds);
-                server.serve_with_incoming(uds_stream).await?;
-            }
-            BindSocket::ListenFd => {
-                let listener = listenfd::ListenFd::from_env()
-                    .take_unix_listener(0)?
-                    .ok_or_else(|| anyhow::anyhow!("No listenfd found in env"))?;
-                listener.set_nonblocking(true)?;
-                let listener = tokio_stream::wrappers::UnixListenerStream::new(
-                    tokio::net::UnixListener::from_std(listener)?,
-                );
-
-                server.serve_with_incoming(listener).await?;
-            }
-        }
+            .add_service(intercepted_service)
+            .serve_with_incoming(incoming)
+            .await?;
 
         Ok(())
     }

--- a/subprojects/hydra-queue-runner/src/server/http.rs
+++ b/subprojects/hydra-queue-runner/src/server/http.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::sync::Arc;
 
 use crate::state::State;
 use bytes::Bytes;
@@ -84,34 +84,31 @@ fn construct_json_ok_response<U: serde::Serialize>(data: &U) -> Result<Response,
 #[derive(Debug, Clone, Copy)]
 pub struct Server {}
 impl Server {
-    pub async fn run(addr: SocketAddr, state: Arc<State>) -> Result<(), Error> {
-        async move {
-            let listener = tokio::net::TcpListener::bind(&addr).await?;
-            let server_span = tracing::span!(tracing::Level::TRACE, "http_server", %addr);
+    pub async fn run(listener: tokio::net::TcpListener, state: Arc<State>) -> Result<(), Error> {
+        let addr = listener.local_addr()?;
+        let server_span = tracing::span!(tracing::Level::TRACE, "http_server", %addr);
 
-            loop {
-                let (stream, _) = listener.accept().await?;
-                let io = hyper_util::rt::TokioIo::new(stream);
+        loop {
+            let (stream, _) = listener.accept().await?;
+            let io = hyper_util::rt::TokioIo::new(stream);
 
-                let state = state.clone();
-                tokio::task::spawn({
-                    let server_span = server_span.clone();
-                    async move {
-                        if let Err(err) = hyper::server::conn::http1::Builder::new()
-                            .serve_connection(
-                                io,
-                                hyper::service::service_fn(move |req| router(req, state.clone())),
-                            )
-                            .instrument(server_span.clone())
-                            .await
-                        {
-                            tracing::error!("Error serving connection: {err:?}");
-                        }
+            let state = state.clone();
+            tokio::task::spawn({
+                let server_span = server_span.clone();
+                async move {
+                    if let Err(err) = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(
+                            io,
+                            hyper::service::service_fn(move |req| router(req, state.clone())),
+                        )
+                        .instrument(server_span.clone())
+                        .await
+                    {
+                        tracing::error!("Error serving connection: {err:?}");
                     }
-                });
-            }
+                }
+            });
         }
-        .await
     }
 }
 

--- a/subprojects/hydra-tests/content-addressed/dyn-drv-non-trivial.t
+++ b/subprojects/hydra-tests/content-addressed/dyn-drv-non-trivial.t
@@ -1,6 +1,10 @@
 use feature 'unicode_strings';
 use strict;
 use warnings;
+# There is something wrong with recursive nix that causes this to fail
+# wiht some regularity in CI. Allowing this test to be restarted as a
+# stop-gap for now.
+# HARNESS-RETRY 5
 use Setup;
 use Test2::V0;
 

--- a/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
@@ -40,7 +40,7 @@ sub runBuilds {
     ref $ctx eq 'HydraTestContext' or die "runBuilds requires a HydraTestContext as first argument\n";
     my @build_ids = map { $_->id } @builds;
 
-    my ($qr_harness, $base_url, $grpc_port, $qr_out_ref, $qr_err_ref, $qr_daemon) = start_queue_runner($ctx,
+    my ($qr_harness, $base_url, $grpc_addr, $qr_out_ref, $qr_err_ref, $qr_daemon) = start_queue_runner($ctx,
         rust_log => "queue_runner=debug,info",
     );
 
@@ -71,7 +71,7 @@ sub runBuilds {
             local $ENV{NO_COLOR} = "1";
             $bl_harness = IPC::Run::start(
                 ["hydra-builder",
-                    "--gateway-endpoint", "http://[::1]:$grpc_port",
+                    "--gateway-endpoint", "http://$grpc_addr",
                 ],
                 \$bl_in, \$bl_out, \$bl_err,
             );

--- a/subprojects/hydra-tests/lib/QueueRunnerContext.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerContext.pm
@@ -6,30 +6,13 @@ use File::Path qw(make_path);
 use IO::Socket::IP;
 use IPC::Run;
 use LWP::UserAgent;
+use POSIX qw(dup2);
 use Hydra::Config;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
-    get_random_port
     start_queue_runner
     wait_for_url
 );
-
-sub get_random_port {
-    my ($min, $max) = @_;
-    while (1) {
-        my $port = $min + int(rand($max - $min + 1));
-        my $sock = IO::Socket::IP->new(
-            LocalAddr => '::',
-            LocalPort => $port,
-            Proto     => 'tcp',
-            ReuseAddr => 0,
-        );
-        if ($sock) {
-            close($sock);
-            return $port;
-        }
-    }
-}
 
 sub wait_for_url {
     my ($ua, $url, $check) = @_;
@@ -72,8 +55,10 @@ sub start_nix_daemon {
     return $harness;
 }
 
-# Start a queue runner process.
-# Returns ($harness, $http_url, $grpc_port, \$stdout_buf, \$stderr_buf, $daemon_harness).
+# Start a queue runner process using systemd socket activation.
+# We bind TCP sockets ourselves (port 0 for OS-assigned ports), then
+# pass them to the queue runner via LISTEN_FDS/LISTEN_FDNAMES.
+# Returns ($harness, $rest_url, $grpc_addr, \$stdout_buf, \$stderr_buf, $daemon_harness).
 # Caller is responsible for calling $harness->kill_kill when done.
 sub start_queue_runner {
     my ($ctx, %opts) = @_;
@@ -81,9 +66,6 @@ sub start_queue_runner {
 
     # Start a nix daemon for the queue runner to use.
     my $daemon_harness = start_nix_daemon($ctx->{central});
-
-    my $grpc_port = get_random_port(5000, 9999);
-    my $http_port = get_random_port(10000, 19999);
 
     my $config_dir = $ENV{T2_HARNESS_TEMP_DIR}
         // $ctx->{central}{hydra_data};
@@ -107,6 +89,34 @@ sub start_queue_runner {
         close($fh);
     }
 
+    # Bind TCP sockets for both servers (port 0 = OS picks a free port).
+    my $rest_sock = IO::Socket::IP->new(
+        LocalAddr => '::',
+        LocalPort => 0,
+        Proto     => 'tcp',
+        Listen    => 128,
+        ReuseAddr => 1,
+        V6Only    => 0,
+    ) or die "Cannot bind REST socket: $!\n";
+
+    my $grpc_sock = IO::Socket::IP->new(
+        LocalAddr => '::',
+        LocalPort => 0,
+        Proto     => 'tcp',
+        Listen    => 128,
+        ReuseAddr => 1,
+        V6Only    => 0,
+    ) or die "Cannot bind gRPC socket: $!\n";
+
+    my $rest_port = $rest_sock->sockport;
+    my $grpc_port = $grpc_sock->sockport;
+
+    # The systemd socket activation protocol passes fds starting at 3.
+    # We need to place our sockets at fd 3 and fd 4 in the child process.
+    # IPC::Run's init callback runs in the child after fork.
+    my $rest_fd = fileno($rest_sock);
+    my $grpc_fd = fileno($grpc_sock);
+
     my ($qr_in, $qr_out, $qr_err) = ("", "", "");
 
     # Start the queue runner, connecting to the nix daemon via unix://.
@@ -116,20 +126,37 @@ sub start_queue_runner {
         local $ENV{NIX_REMOTE} = $ctx->{central}{nix_daemon_uri};
         local $ENV{RUST_LOG} = $opts{rust_log} // "error";
         local $ENV{NO_COLOR} = "1";
+        local $ENV{LISTEN_FDS} = "2";
+        local $ENV{LISTEN_FDNAMES} = "rest:grpc";
+        # Don't set LISTEN_PID — listenfd skips the PID check when it's unset.
+        delete $ENV{LISTEN_PID};
         $qr_harness = IPC::Run::start(
             ["hydra-queue-runner",
                 "--config-path", $config_file,
-                "--rest-bind", "[::]:$http_port",
-                "--grpc-bind", "[::]:$grpc_port",
+                "--rest-bind", "-",
+                "--grpc-bind", "-",
                 "--disable-queue-monitor-loop",
             ],
             \$qr_in, \$qr_out, \$qr_err,
+            init => sub {
+                # In the child: place sockets at fd 3 and 4.
+                POSIX::dup2($rest_fd, 3) or die "dup2 rest to fd 3: $!";
+                POSIX::dup2($grpc_fd, 4) or die "dup2 grpc to fd 4: $!";
+                # Close originals if they aren't already 3 or 4.
+                POSIX::close($rest_fd) if $rest_fd != 3 && $rest_fd != 4;
+                POSIX::close($grpc_fd) if $grpc_fd != 3 && $grpc_fd != 4;
+            },
         );
     }
 
-    my $base_url = "http://[::1]:$http_port";
+    # Close our copies of the sockets (child has its own).
+    close($rest_sock);
+    close($grpc_sock);
 
-    return ($qr_harness, $base_url, $grpc_port, \$qr_out, \$qr_err, $daemon_harness);
+    my $rest_url = "http://[::1]:$rest_port";
+    my $grpc_addr = "[::1]:$grpc_port";
+
+    return ($qr_harness, $rest_url, $grpc_addr, \$qr_out, \$qr_err, $daemon_harness);
 }
 
 1;


### PR DESCRIPTION
The queue runner now supports systemd socket activation for both its REST and gRPC servers (`--rest-bind -` and `--grpc-bind -`). It uses `LISTEN_FDNAMES` to map socket names (`rest`, `grpc`) to fd indices. The HTTP and gRPC servers are refactored to accept pre-bound listeners, and binding is done centrally in `main`.

The NixOS module now unconditionally uses socket units, eliminating port races and enabling the standard systemd socket activation lifecycle.

The test harness (`QueueRunnerContext.pm`) binds sockets with port 0 and passes them to the queue runner via `LISTEN_FDS`, so tests get OS-assigned ports with no race condition.

Depends on #1700