### PR TITLE
Add systemd socket activation for `hydra-server` (Starman)

### DIFF
--- a/nixos-modules/web-app.nix
+++ b/nixos-modules/web-app.nix
@@ -254,8 +254,14 @@ in
 
     systemd.services.hydra-server = {
       wantedBy = [ "multi-user.target" ];
-      requires = [ "hydra-init.service" ];
-      after = [ "hydra-init.service" ];
+      requires = [
+        "hydra-init.service"
+        "hydra-server.socket"
+      ];
+      after = [
+        "hydra-init.service"
+        "hydra-server.socket"
+      ];
       environment = serverEnv // {
         HYDRA_DBI = "${serverEnv.HYDRA_DBI};application_name=hydra-server";
       };
@@ -266,10 +272,6 @@ in
             "@${cfg.package}/bin/hydra-server"
             "hydra-server"
             "-f"
-            "-h"
-            cfg.listenHost
-            "-p"
-            (toString cfg.port)
             "--max_spare_servers"
             "5"
             "--max_servers"
@@ -282,6 +284,16 @@ in
         User = "hydra-www";
         PermissionsStartOnly = true;
         Restart = "always";
+      };
+    };
+
+    systemd.sockets.hydra-server = {
+      description = "Hydra web server socket";
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream =
+          if cfg.listenHost == "*" then toString cfg.port else "${cfg.listenHost}:${toString cfg.port}";
+        Service = "hydra-server.service";
       };
     };
 

--- a/nixos-tests.nix
+++ b/nixos-tests.nix
@@ -76,6 +76,7 @@ in
       nodes.builder = builderConfig;
       testScript = ''
         server.wait_for_unit("hydra-init.service")
+        server.succeed("systemctl status hydra-server.socket")
         server.wait_for_unit("hydra-server.service")
         server.wait_for_unit("hydra-evaluator.service")
         server.wait_for_unit("hydra-queue-runner-dev.service")

--- a/subprojects/hydra/lib/Hydra/Script/Server.pm
+++ b/subprojects/hydra/lib/Hydra/Script/Server.pm
@@ -4,4 +4,15 @@ use namespace::autoclean;
 
 extends 'CatalystX::Script::Server::Starman';
 
+# When systemd socket activation is in use, swap Starman's Net::Server
+# personality to one that adopts the passed-in file descriptors.
+# This is equivalent to https://github.com/miyagawa/Starman/pull/156;
+# once that is merged and released, this block can be removed.
+before 'run' => sub {
+    if ($ENV{LISTEN_FDS}) {
+        require Net::Server::Systemd::PreFork;
+        @Starman::Server::ISA = qw(Net::Server::Systemd::PreFork);
+    }
+};
+
 1;

--- a/subprojects/hydra/lib/Net/Server/Systemd/PreFork.pm
+++ b/subprojects/hydra/lib/Net/Server/Systemd/PreFork.pm
@@ -1,0 +1,110 @@
+# This module is from https://github.com/miyagawa/Starman/pull/156. Once
+# that PR is merged, this should be removed.
+package Net::Server::Systemd::PreFork;
+
+use strict;
+use warnings;
+
+use Net::Server::PreFork;
+use Net::Server::Proto;
+use Net::Server::Proto::TCP;
+use Net::Server::Proto::UNIX;
+use Socket qw(AF_INET6);
+
+use base qw(Net::Server::PreFork);
+
+use constant SD_LISTEN_FDS_START => 3;
+
+sub pre_bind {
+    my $self = shift;
+    my $prop = $self->{server};
+
+    # Net::Server::Proto::TCP starts life inheriting from IO::Socket::INET (IPv4
+    # only). Normally its constructor (::object) swaps @ISA to an IPv6-capable
+    # class (IO::Socket::IP) at runtime. Since we bypass that constructor — we
+    # already have bound fds from systemd — we trigger the same swap here. This
+    # is a global, idempotent mutation; it's safe because all TCP sockets in
+    # this process need IPv6 support regardless.
+    @Net::Server::Proto::TCP::ISA = (Net::Server::Proto->ipv6_package($self))
+        if $Net::Server::Proto::TCP::ISA[0] eq 'IO::Socket::INET';
+
+    my $count = $ENV{LISTEN_FDS}
+        or $self->fatal("LISTEN_FDS not set");
+
+    # Validate LISTEN_PID if set and non-empty.
+    if (my $pid = $ENV{LISTEN_PID}) {
+        $pid == $$
+            or $self->fatal("LISTEN_PID ($pid) does not match our PID ($$)");
+    }
+
+    my $first_fd = $ENV{LISTEN_FDS_FIRST_FD} || SD_LISTEN_FDS_START;
+
+    for my $i (0 .. $count - 1) {
+        my $fd = $first_fd + $i;
+
+        # We use fdopen (not new_from_fd) because we need the socket to be a
+        # Net::Server::Proto::TCP object — it already has the NS_* accessor
+        # methods that Net::Server's event loop expects, and after the @ISA swap
+        # above it inherits from IO::Socket::IP which handles both IPv4 and IPv6
+        # accept/address parsing correctly.
+        my $sock = Net::Server::Proto::TCP->new();
+        $sock->fdopen($fd, 'r')
+            or $self->fatal("failed to fdopen listening socket fd $fd: $!");
+
+        # Detect the actual socket family so Net::Server knows how to format
+        # addresses in log messages, etc.
+        my $sockname = getsockname($sock)
+            or $self->fatal("getsockname failed on fd $fd: $!");
+        my $family = Socket::sockaddr_family($sockname);
+
+        if ($family == AF_INET6) {
+            $sock->NS_ipv('6');
+        } elsif ($family == Socket::AF_INET) {
+            $sock->NS_ipv('4');
+        } else {
+            # Not an IP socket — assume Unix domain. Re-fdopen into the correct
+            # Proto class since Proto::TCP can't handle Unix accept.
+            $sock = Net::Server::Proto::UNIX->new();
+            $sock->fdopen($fd, 'r')
+                or $self->fatal("failed to fdopen listening socket fd $fd: $!");
+        }
+
+        push @{$prop->{sock}}, $sock;
+    }
+
+    $prop->{multi_port} = 1 if @{$prop->{sock}} > 1;
+}
+
+# Override bind to skip actually binding (already done by systemd) and just set
+# up IO::Select if there are multiple listening sockets.
+sub bind {
+    my $self = shift;
+    my $prop = $self->{server};
+
+    if (@{$prop->{sock}} > 1) {
+        $prop->{multi_port} = 1;
+        $prop->{select} = IO::Select->new();
+        for (@{$prop->{sock}}) {
+            $prop->{select}->add($_);
+        }
+    } else {
+        $prop->{multi_port} = undef;
+        $prop->{select}     = undef;
+    }
+}
+
+# Use close(2) rather than shutdown(2). See Net::Server::SS::PreFork for
+# rationale — shutdown on a shared fd closes it for all forked workers.
+sub shutdown_sockets {
+    my $self = shift;
+    my $prop = $self->{server};
+
+    for my $sock (@{$prop->{sock}}) {
+        $sock->close;
+    }
+
+    $prop->{sock} = [];
+    return 1;
+}
+
+1;


### PR DESCRIPTION
Instead of forking Starman to add socket activation support, carry a `Net::Server::Systemd::PreFork` personality inside hydra's own Perl libs and monkey-patch `@Starman::Server::ISA` in `Hydra::Script::Server` when `LISTEN_FDS` is set. This avoids a forked dependency while the upstream PR (https://github.com/miyagawa/Starman/pull/156) is pending.

I am working on a forked foreman for optional local testing, but for now, the VM test tests that that the socket activation works correctly.