### PR TITLE
Make the test suite's queue runner and builder go through a nix daemon

### DIFF
--- a/subprojects/hydra-tests/lib/HydraTestContext.pm
+++ b/subprojects/hydra-tests/lib/HydraTestContext.pm
@@ -53,11 +53,13 @@ sub new {
     # use sandboxed builds.
     my $builder = { root => "$dir/builder" };
     make_path($builder->{root});
+    $builder->{nix_conf_dir} = "$dir/nix/etc/nix";
     $builder->{nix_store_dir} = "$builder->{root}/nix/store";
     $builder->{nix_state_dir} = "$builder->{root}/nix/var/nix";
     $builder->{nix_log_dir} = "$builder->{root}/nix/var/log/nix";
     $builder->{nix_store_uri} = "local?root=$builder->{root}&store=$builder->{nix_store_dir}";
-    $builder->{nix_conf_dir} = "$dir/nix/etc/nix";
+    $builder->{nix_daemon_socket_path} = "$builder->{nix_state_dir}/daemon-socket/socket";
+    $builder->{nix_daemon_uri} = "unix://$builder->{nix_daemon_socket_path}?root=$builder->{root}&store=$builder->{nix_store_dir}";
 
     # Physical dirs for centralized services (queue runner, main web app, etc.)
     my $central = { root => "$dir/central" };
@@ -70,6 +72,8 @@ sub new {
     $central->{nix_state_dir} = "$central->{root}/nix/var/nix";
     $central->{nix_log_dir} = "$central->{root}/nix/var/log/nix";
     $central->{nix_store_uri} = "local?root=$central->{root}&store=$central->{nix_store_dir}";
+    $central->{nix_daemon_socket_path} = "$central->{nix_state_dir}/daemon-socket/socket";
+    $central->{nix_daemon_uri} = "unix://$central->{nix_daemon_socket_path}?root=$central->{root}&store=$central->{nix_store_dir}";
 
     {
         mkdir $central->{hydra_data};

--- a/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
@@ -40,9 +40,12 @@ sub runBuilds {
     ref $ctx eq 'HydraTestContext' or die "runBuilds requires a HydraTestContext as first argument\n";
     my @build_ids = map { $_->id } @builds;
 
-    my ($qr_harness, $base_url, $grpc_port, $qr_out_ref, $qr_err_ref) = start_queue_runner($ctx,
+    my ($qr_harness, $base_url, $grpc_port, $qr_out_ref, $qr_err_ref, $qr_daemon) = start_queue_runner($ctx,
         rust_log => "queue_runner=debug,info",
     );
+
+    # Start a nix daemon for the builder.
+    my $bl_daemon = QueueRunnerContext::start_nix_daemon($ctx->{builder});
 
     my ($bl_in, $bl_out, $bl_err) = ("", "", "");
     my $ua = LWP::UserAgent->new(timeout => 2);
@@ -56,9 +59,9 @@ sub runBuilds {
         wait_for_url($ua, "$base_url/status")
             or die "Timed out waiting for queue-runner REST server\n";
 
-        # Start the builder with its own store settings.
+        # Start the builder, connecting to the nix daemon via unix://.
         {
-            local $ENV{NIX_REMOTE} = $ctx->{builder}{nix_store_uri};
+            local $ENV{NIX_REMOTE} = $ctx->{builder}{nix_daemon_uri};
             local $ENV{NIX_CONF_DIR} = $ctx->{builder}{nix_conf_dir};
             local $ENV{NIX_STATE_DIR} = $ctx->{builder}{nix_state_dir};
             # TODO: hydra-builder reads NIX_STORE_DIR to report its
@@ -129,8 +132,10 @@ sub runBuilds {
         $bl_harness->kill_kill;
         _flush_harness("Builder", \$bl_out, \$bl_err, 1);
     }
+    $bl_daemon->kill_kill(grace => 2);
     $qr_harness->kill_kill;
     _flush_harness("Queue runner", $qr_out_ref, $qr_err_ref, 1);
+    $qr_daemon->kill_kill(grace => 2);
 
     if (!$ok) {
         print STDERR "runBuilds failed: $err" if $err;

--- a/subprojects/hydra-tests/lib/QueueRunnerContext.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerContext.pm
@@ -2,6 +2,7 @@ use warnings;
 use strict;
 
 package QueueRunnerContext;
+use File::Path qw(make_path);
 use IO::Socket::IP;
 use IPC::Run;
 use LWP::UserAgent;
@@ -42,12 +43,44 @@ sub wait_for_url {
     return 0;
 }
 
+# Start a nix daemon for the given store config.
+# Returns the daemon harness.  Caller must kill_kill it when done.
+sub start_nix_daemon {
+    my ($store) = @_;
+    make_path($store->{nix_state_dir});
+
+    my ($in, $out, $err) = ("", "", "");
+    my $harness;
+    {
+        local $ENV{NIX_REMOTE} = $store->{nix_store_uri};
+        local $ENV{NIX_STORE_DIR} = $store->{nix_store_dir};
+        local $ENV{NIX_STATE_DIR} = $store->{nix_state_dir};
+        local $ENV{NIX_CONF_DIR} = $store->{nix_conf_dir};
+        local $ENV{NIX_DAEMON_SOCKET_PATH} = $store->{nix_daemon_socket_path};
+        local $ENV{NIX_CONFIG} = "trusted-users = *";
+        $harness = IPC::Run::start(
+            ["nix-daemon"],
+            \$in, \$out, \$err,
+        );
+    }
+    my $socket = $store->{nix_daemon_socket_path};
+    for (1..50) {
+        last if -S $socket;
+        select(undef, undef, undef, 0.1);
+    }
+    -S $socket or die "nix-daemon did not start: $socket\n";
+    return $harness;
+}
+
 # Start a queue runner process.
-# Returns ($harness, $http_url, $grpc_port, \$stdout_buf, \$stderr_buf).
+# Returns ($harness, $http_url, $grpc_port, \$stdout_buf, \$stderr_buf, $daemon_harness).
 # Caller is responsible for calling $harness->kill_kill when done.
 sub start_queue_runner {
     my ($ctx, %opts) = @_;
     ref $ctx eq 'HydraTestContext' or die "start_queue_runner requires a HydraTestContext\n";
+
+    # Start a nix daemon for the queue runner to use.
+    my $daemon_harness = start_nix_daemon($ctx->{central});
 
     my $grpc_port = get_random_port(5000, 9999);
     my $http_port = get_random_port(10000, 19999);
@@ -76,10 +109,11 @@ sub start_queue_runner {
 
     my ($qr_in, $qr_out, $qr_err) = ("", "", "");
 
-    # Start the queue runner with central env applied.
+    # Start the queue runner, connecting to the nix daemon via unix://.
     my $qr_harness;
     {
         local @ENV{keys %{$ctx->{central_env}}} = values %{$ctx->{central_env}};
+        local $ENV{NIX_REMOTE} = $ctx->{central}{nix_daemon_uri};
         local $ENV{RUST_LOG} = $opts{rust_log} // "error";
         local $ENV{NO_COLOR} = "1";
         $qr_harness = IPC::Run::start(
@@ -95,7 +129,7 @@ sub start_queue_runner {
 
     my $base_url = "http://[::1]:$http_port";
 
-    return ($qr_harness, $base_url, $grpc_port, \$qr_out, \$qr_err);
+    return ($qr_harness, $base_url, $grpc_port, \$qr_out, \$qr_err, $daemon_harness);
 }
 
 1;


### PR DESCRIPTION
We were seeing the builder crash due to SQLite WAL issues via the FFI. While we investigate that, we can side-step the issue by making the FFI use a nix daemon rather than directly opening the SQLite database.

Each test that runs builds now starts a fresh `nix-daemon` process for both the queue runner (central store) and the builder, managed 1:1 with their respective processes in `QueueRunnerContext` and`QueueRunnerBuildOne`. The daemon opens the same `local?root=...&store=...` store URI via `NIX_REMOTE`, and clients connect through `unix://...?root=...&store=...` URIs. `NIX_STORE_DIR` is set for the daemon so that substituters see the correct store prefix (note: it is unclear why the `store=....` query param was not good enough for this). The daemon also gets `trusted-users = *` via `NIX_CONFIG` so it accepts unsigned paths from the builder, which is equivalent to how the local store worked (direct local store is always trusted).

The evaluator and other central services continue to open the store directly — only the queue runner and builder are routed through daemons.

Long term, we want Hydra to be pure Rust anyways, so this isn't so bad; the FFI is just a stop-gap, the daemon protocol can also be a stop-gap.