### PR TITLE
Remove legacy build machine discovery and `SystemStatus`-based status…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Running Hydra is currently only supported on NixOS. The [hydra module](https://g
     enable = true;
     hydraURL = "http://localhost:3000";
     notificationSender = "hydra@localhost";
-    buildMachinesFiles = [];
     useSubstitutes = true;
   };
 }

--- a/nixos-modules/web-app.nix
+++ b/nixos-modules/web-app.nix
@@ -24,7 +24,6 @@ let
   env = {
     NIX_REMOTE = "daemon";
     PGPASSFILE = "${baseDir}/pgpass";
-    NIX_REMOTE_SYSTEMS = concatStringsSep ":" cfg.buildMachinesFiles;
   }
   // optionalAttrs (cfg.smtpHost != null) {
     EMAIL_SENDER_TRANSPORT = "SMTP";
@@ -49,7 +48,12 @@ let
 in
 
 {
-  imports = [ ./postgresql.nix ];
+  imports = [
+    ./postgresql.nix
+    (mkRemovedOptionModule [ "services" "hydra-dev" "buildMachinesFiles" ]
+      "The queue runner no longer reads Nix build machines files. Builders now connect to the queue runner via gRPC."
+    )
+  ];
   ###### interface
   options = {
 
@@ -168,17 +172,6 @@ in
         type = types.path;
         default = "/nix/var/nix/gcroots/hydra";
         description = "Directory that holds Hydra garbage collector roots.";
-      };
-
-      buildMachinesFiles = mkOption {
-        type = types.listOf types.path;
-        default = optional (config.nix.buildMachines != [ ]) "/etc/nix/machines";
-        defaultText = literalExpression ''optional (config.nix.buildMachines != []) "/etc/nix/machines"'';
-        example = [
-          "/etc/nix/machines"
-          "/var/lib/hydra/provisioner/machines"
-        ];
-        description = "List of files containing build machines.";
       };
 
       useSubstitutes = mkOption {

--- a/subprojects/crates/db/src/connection.rs
+++ b/subprojects/crates/db/src/connection.rs
@@ -429,16 +429,6 @@ impl Connection {
         })
         .transpose()
     }
-
-    #[tracing::instrument(skip(self), err)]
-    pub async fn get_status(&mut self) -> sqlx::Result<Option<serde_json::Value>> {
-        Ok(
-            sqlx::query!("SELECT status FROM systemstatus WHERE what = 'queue-runner';",)
-                .fetch_optional(&mut *self.conn)
-                .await?
-                .map(|v| v.status),
-        )
-    }
 }
 
 impl Transaction<'_> {
@@ -1188,21 +1178,6 @@ impl Transaction<'_> {
         }
         Ok(())
     }
-
-    #[tracing::instrument(skip(self, status), err)]
-    pub async fn upsert_status(&mut self, status: &serde_json::Value) -> sqlx::Result<()> {
-        sqlx::query!(
-            r#"INSERT INTO systemstatus (
-              what, status
-            ) VALUES (
-              'queue-runner', $1
-            ) ON CONFLICT (what) DO UPDATE SET status = EXCLUDED.status;"#,
-            Some(status),
-        )
-        .execute(&mut *self.tx)
-        .await?;
-        Ok(())
-    }
 }
 
 impl Transaction<'_> {
@@ -1263,18 +1238,6 @@ impl Transaction<'_> {
             &format!("{build_id}\t{step_nr}\t{log_file}"),
         )
         .await?;
-        Ok(())
-    }
-
-    #[tracing::instrument(skip(self), err)]
-    pub async fn notify_dump_status(&mut self) -> sqlx::Result<()> {
-        self.notify_any("dump_status", "").await?;
-        Ok(())
-    }
-
-    #[tracing::instrument(skip(self), err)]
-    pub async fn notify_status_dumped(&mut self) -> sqlx::Result<()> {
-        self.notify_any("status_dumped", "").await?;
         Ok(())
     }
 }

--- a/subprojects/hydra-queue-runner/src/config.rs
+++ b/subprojects/hydra-queue-runner/src/config.rs
@@ -27,10 +27,6 @@ impl std::str::FromStr for BindSocket {
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub struct Cli {
-    /// Query the queue runner status
-    #[clap(long)]
-    pub status: bool,
-
     /// REST server bind, either a `SocketAddr` or `-` to use `ListenFD` (systemd socket activation)
     #[clap(short, long, default_value = "[::1]:8080")]
     pub rest_bind: BindSocket,

--- a/subprojects/hydra-queue-runner/src/main.rs
+++ b/subprojects/hydra-queue-runner/src/main.rs
@@ -37,7 +37,6 @@ fn start_task_loops(state: &std::sync::Arc<State>) -> Vec<tokio::task::AbortHand
     let mut service_list = vec![
         spawn_config_reloader(state.clone(), state.config.clone(), &state.cli.config_path),
         state.clone().start_dispatch_loop(),
-        state.clone().start_dump_status_loop(),
         state.clone().start_uploader_queue(),
     ];
     if !state.cli.disable_queue_monitor_loop {
@@ -77,7 +76,7 @@ fn spawn_config_reloader(
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let tracing_guard = hydra_tracing::init()?;
+    let _tracing_guard = hydra_tracing::init()?;
 
     #[cfg(debug_assertions)]
     {
@@ -91,11 +90,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     nix_utils::init_nix();
-    let state = State::new(&tracing_guard).await?;
-    if state.cli.status {
-        state.get_status_from_main_process().await?;
-        return Ok(());
-    }
+    let state = State::new().await?;
 
     let lockfile_path = state.config.get_lockfile();
     let _lock = lock_file::LockFile::acquire(&lockfile_path)

--- a/subprojects/hydra-queue-runner/src/server/http.rs
+++ b/subprojects/hydra-queue-runner/src/server/http.rs
@@ -162,9 +162,6 @@ async fn router(
                     .ok_or(Error::NotFound)?;
                 handler::status::active(id_str, state).await
             }
-            (&hyper::Method::POST, "/dump_status" | "/dump_status/") => {
-                handler::dump_status::post(state).await
-            }
             (&hyper::Method::PUT, "/build" | "/build/") => handler::build::put(req, state).await,
             (&hyper::Method::POST, "/build_one" | "/build_one/") => {
                 handler::build_one::post(req, state).await
@@ -338,20 +335,6 @@ mod handler {
 
             let response = io::BuildActiveResponse { active: is_active };
             construct_json_ok_response(&response)
-        }
-    }
-
-    pub(super) mod dump_status {
-        use super::super::{Error, Response, construct_json_ok_response};
-        use crate::{io, state::State};
-
-        #[tracing::instrument(skip(state), err)]
-        pub(crate) async fn post(state: std::sync::Arc<State>) -> Result<Response, Error> {
-            let mut db = state.db.get().await?;
-            let mut tx = db.begin_transaction().await?;
-            tx.notify_dump_status().await?;
-            tx.commit().await?;
-            construct_json_ok_response(&io::Empty {})
         }
     }
 

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -98,16 +98,13 @@ pub struct State {
 }
 
 impl State {
-    #[tracing::instrument(skip(tracing_guard), err)]
-    pub async fn new(tracing_guard: &hydra_tracing::TracingGuard) -> anyhow::Result<Arc<Self>> {
+    #[tracing::instrument(err)]
+    pub async fn new() -> anyhow::Result<Arc<Self>> {
         let store = nix_utils::LocalStore::init();
         nix_utils::set_verbosity(1);
         tracing::info!("LocalStore dir={}", nix_utils::get_store_dir());
 
         let cli = Cli::new();
-        if cli.status {
-            tracing_guard.change_log_level(hydra_tracing::EnvFilter::new("error"));
-        }
 
         let config = App::init(&cli.config_path)?;
         let log_dir = config.get_hydra_log_dir();
@@ -968,95 +965,6 @@ impl State {
         task.abort_handle()
     }
 
-    #[tracing::instrument(skip(self), err)]
-    async fn dump_status_loop(self: Arc<Self>) -> anyhow::Result<()> {
-        let mut listener = self.db.listener(vec!["dump_status"]).await?;
-
-        let state = self.clone();
-        loop {
-            let _ = match listener.try_next().await {
-                Ok(Some(v)) => v,
-                Ok(None) => continue,
-                Err(e) => {
-                    tracing::warn!("PgListener failed with e={e}");
-                    continue;
-                }
-            };
-
-            let state = state.clone();
-            let queue_stats = crate::io::QueueRunnerStats::new(state.clone()).await;
-            let sort_fn = state.config.get_machine_sort_fn();
-            let free_fn = state.config.get_machine_free_fn();
-            let machines = state
-                .machines
-                .get_all_machines()
-                .into_iter()
-                .map(|m| {
-                    (
-                        m.hostname.clone(),
-                        crate::io::Machine::from_state(&m, sort_fn, free_fn),
-                    )
-                })
-                .collect();
-            let jobsets = self.jobsets.clone_as_io();
-            let s3_stores: Vec<binary_cache::S3BinaryCacheClient> = {
-                let stores = state.remote_stores.read();
-                stores
-                    .iter()
-                    .filter_map(|s| match s {
-                        RemoteStoreBackend::S3(s) => Some(s.clone()),
-                        _ => None,
-                    })
-                    .collect()
-            };
-            let dump_status = crate::io::DumpResponse::new(
-                queue_stats,
-                machines,
-                jobsets,
-                &state.store,
-                &s3_stores,
-            );
-            {
-                let Ok(mut db) = self.db.get().await else {
-                    continue;
-                };
-                let Ok(mut tx) = db.begin_transaction().await else {
-                    continue;
-                };
-                let dump_status = match serde_json::to_value(dump_status) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        tracing::error!("Failed to update status in database: {e}");
-                        continue;
-                    }
-                };
-                if let Err(e) = tx.upsert_status(&dump_status).await {
-                    tracing::error!("Failed to update status in database: {e}");
-                    continue;
-                }
-                if let Err(e) = tx.notify_status_dumped().await {
-                    tracing::error!("Failed to update status in database: {e}");
-                    continue;
-                }
-                if let Err(e) = tx.commit().await {
-                    tracing::error!("Failed to update status in database: {e}");
-                }
-            }
-        }
-    }
-
-    #[tracing::instrument(skip(self))]
-    pub fn start_dump_status_loop(self: Arc<Self>) -> tokio::task::AbortHandle {
-        let task = tokio::task::spawn({
-            async move {
-                if let Err(e) = self.dump_status_loop().await {
-                    tracing::error!("Failed to spawn queue monitor loop. e={e}");
-                }
-            }
-        });
-        task.abort_handle()
-    }
-
     #[tracing::instrument(skip(self))]
     pub fn start_uploader_queue(self: Arc<Self>) -> tokio::task::AbortHandle {
         let task = tokio::task::spawn({
@@ -1084,42 +992,6 @@ impl State {
             }
         });
         task.abort_handle()
-    }
-
-    #[tracing::instrument(skip(self))]
-    pub async fn get_status_from_main_process(self: Arc<Self>) -> anyhow::Result<()> {
-        let mut db = self.db.get().await?;
-
-        let mut listener = self.db.listener(vec!["status_dumped"]).await?;
-        {
-            let mut tx = db.begin_transaction().await?;
-            tx.notify_dump_status().await?;
-            tx.commit().await?;
-        }
-
-        let notification =
-            tokio::time::timeout(tokio::time::Duration::from_secs(5), listener.try_next()).await;
-
-        match notification {
-            Ok(Ok(Some(_))) => {}
-            Ok(Ok(None)) => return Ok(()),
-            Ok(Err(e)) => {
-                tracing::warn!("PgListener failed with e={e}");
-                return Ok(());
-            }
-            Err(_) => {
-                // No response from queue-runner daemon — print a down status.
-                println!(r#"{{"status":"down"}}"#);
-                return Ok(());
-            }
-        }
-
-        if let Some(status) = db.get_status().await? {
-            // we want a println! here so it can be consumed by other tools
-            println!("{}", serde_json::to_string_pretty(&status)?);
-        }
-
-        Ok(())
     }
 
     #[tracing::instrument(skip(self))]

--- a/subprojects/hydra-tests/Hydra/Helper/Nix.t
+++ b/subprojects/hydra-tests/Hydra/Helper/Nix.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 use Setup;
-use File::Temp;
 
 my $ctx = test_context();
 my $db = $ctx->db();
@@ -9,63 +8,6 @@ my $db = $ctx->db();
 require Hydra::Helper::Nix;
 
 use Test2::V0;
-
-my $dir = File::Temp->newdir();
-my $machines = "$dir/machines";
-
-open(my $fh, '>', $machines) or die "Could not open file '$machines' $!";
-print $fh q|
-# foobar
-root@ip x86_64-darwin /sshkey 15 15 big-parallel,kvm,nixos-test - base64key
-
-# Macs
-# root@bar x86_64-darwin /sshkey 6 1 big-parallel
-root@baz aarch64-darwin /sshkey 4 1 big-parallel
-
-root@bux i686-linux,x86_64-linux /var/sshkey 1 1 kvm,nixos-test benchmark
-root@lotsofspace    i686-linux,x86_64-linux    /var/sshkey   1   1  kvm,nixos-test   benchmark
-
-|;
-close $fh;
-
-# getMachines -> getHydraConfig -> getHydraPath needs HYDRA_CONFIG
-my $got_machines = do {
-    local $ENV{HYDRA_CONFIG} = $ctx->{central}{hydra_config_file};
-    local $ENV{NIX_REMOTE_SYSTEMS} = $machines;
-    Hydra::Helper::Nix::getMachines();
-};
-
-is($got_machines, {
-    'root@ip' => {
-        'systemTypes' => ["x86_64-darwin"],
-        'maxJobs' => 15,
-        'speedFactor' => 15,
-        'supportedFeatures' => ["big-parallel", "kvm", "nixos-test" ],
-        'mandatoryFeatures' => [ ],
-    },
-    'root@baz' => {
-        'systemTypes' => [ "aarch64-darwin" ],
-        'maxJobs' => 4,
-        'speedFactor' => 1,
-        'supportedFeatures' => ["big-parallel"],
-        'mandatoryFeatures' => [],
-    },
-    'root@bux' => {
-        'systemTypes' => [ "i686-linux", "x86_64-linux" ],
-        'maxJobs' => 1,
-        'speedFactor' => 1,
-        'supportedFeatures' => [ "kvm", "nixos-test", "benchmark" ],
-        'mandatoryFeatures' => [ "benchmark" ],
-    },
-    'root@lotsofspace' => {
-        'systemTypes' => [ "i686-linux", "x86_64-linux" ],
-        'maxJobs' => 1,
-        'speedFactor' => 1,
-        'supportedFeatures' => [ "kvm", "nixos-test", "benchmark" ],
-        'mandatoryFeatures' => [ "benchmark" ],
-    },
-
-}, ":)");
 
 subtest "constructRunCommandLogPath" => sub {
     my $builds = $ctx->makeAndEvaluateJobset(

--- a/subprojects/hydra-tests/lib/HydraTestContext.pm
+++ b/subprojects/hydra-tests/lib/HydraTestContext.pm
@@ -129,7 +129,6 @@ sub new {
             'HYDRA_DBI'          => $central->{hydra_dbi},
             'HYDRA_DATABASE_URL' => $central->{hydra_database_url},
             'NIX_CONF_DIR'       => $central->{nix_conf_dir},
-            'NIX_REMOTE_SYSTEMS' => '',
             'NIX_REMOTE'         => $central->{nix_store_uri},
             'NIX_STATE_DIR'      => $central->{nix_state_dir}, # FIXME: remove
             'NIX_STORE_DIR'      => $central->{nix_store_dir}, # FIXME: remove

--- a/subprojects/hydra-tests/scripts/hydra-send-stats.t
+++ b/subprojects/hydra-tests/scripts/hydra-send-stats.t
@@ -2,6 +2,9 @@ use feature 'unicode_strings';
 use strict;
 use warnings;
 use Setup;
+use QueueRunnerContext;
+use LWP::UserAgent;
+use File::Slurper qw(write_text);
 
 my %ctx = test_init();
 
@@ -11,9 +14,50 @@ use Test2::V0;
 
 my $db = $ctx{context}->db();
 
-my ($res, $stdout, $stderr) = $ctx{context}->capture_cmd(60, ("hydra-send-stats", "--once"));
-is($stdout, "", "hydra-send-stats stdout should be empty");
-is($stderr, "", "hydra-send-stats stderr should be empty");
-is($res, 0, "hydra-send-stats --once should exit zero");
+subtest "without queue_runner_endpoint" => sub {
+    my ($res, $stdout, $stderr) = $ctx{context}->capture_cmd(60, ("hydra-send-stats", "--once"));
+    is($stdout, "", "stdout should be empty");
+    like($stderr, qr/queue_runner_endpoint not configured/, "warns about missing endpoint");
+    is($res, 0, "exits zero (error is non-fatal)");
+};
+
+subtest "with queue_runner_endpoint" => sub {
+    my ($qr_harness, $base_url, undef, undef, undef, $daemon_harness) = start_queue_runner($ctx{context});
+
+    my $ok = eval {
+        local $SIG{ALRM} = sub { die "timeout\n" };
+        alarm 30;
+
+        # Wait for the REST server to come up.
+        my $ua = LWP::UserAgent->new(timeout => 2);
+        wait_for_url($ua, "$base_url/status")
+            or die "Timed out waiting for queue-runner REST server\n";
+
+        # Write a hydra.conf pointing at our queue runner.
+        my $config_dir = $ENV{T2_HARNESS_TEMP_DIR}
+            // $ctx{context}->{central}{hydra_data};
+        my $hydra_conf = "$config_dir/hydra-send-stats-test.conf";
+        write_text($hydra_conf, "queue_runner_endpoint = $base_url\n");
+
+        # Run hydra-send-stats with the test config.
+        local $ctx{context}->{central_env}{HYDRA_CONFIG} = $hydra_conf;
+        my ($res, $stdout, $stderr) = $ctx{context}->capture_cmd(
+            60, ("hydra-send-stats", "--once"),
+        );
+        is($stdout, "", "stdout should be empty");
+        is($stderr, "", "stderr should be empty");
+        is($res, 0, "exits zero");
+
+        alarm 0;
+        1;
+    };
+    my $err = $@;
+    alarm 0;
+
+    $qr_harness->kill_kill;
+    $daemon_harness->kill_kill;
+
+    die "with queue_runner_endpoint failed: $err" if !$ok && $err;
+};
 
 done_testing;

--- a/subprojects/hydra/lib/Hydra/Controller/Root.pm
+++ b/subprojects/hydra/lib/Hydra/Controller/Root.pm
@@ -14,7 +14,7 @@ use Encode;
 use File::Basename;
 use JSON::MaybeXS;
 use HTML::Entities;
-use IPC::Run3;
+use LWP::UserAgent;
 use List::Util qw[min max];
 use List::SomeUtils qw{any};
 use Net::Prometheus;
@@ -177,14 +177,18 @@ sub queue_runner_status :Local :Path('queue-runner-status') :Args(0) :ActionClas
 sub queue_runner_status_GET {
     my ($self, $c) = @_;
 
-    #my $status = from_json($c->model('DB::SystemStatus')->find('queue-runner')->status);
-    my ($stdout, $stderr);
-    run3(['hydra-queue-runner', '--status'], \undef, \$stdout, \$stderr);
+    my $endpoint = $c->config->{'queue_runner_endpoint'};
     my $status;
-    if ($? != 0) {
+    if (!$endpoint) {
         $status = { status => "unknown" };
     } else {
-        $status = decode_json($stdout);
+        my $ua = LWP::UserAgent->new();
+        my $resp = $ua->get($endpoint . "/status");
+        if ($resp->is_success) {
+            $status = decode_json($resp->decoded_content);
+        } else {
+            $status = { status => "unreachable" };
+        }
     }
     my $json = JSON->new->pretty()->canonical();
 
@@ -197,25 +201,6 @@ sub queue_runner_status_GET {
 sub machines :Local Args(0) {
     my ($self, $c) = @_;
     my $machines = getMachines;
-
-    # Add entry for localhost. The implicit addition is not needed with queue runner v2
-    if (not $c->config->{'queue_runner_endpoint'}) {
-        $machines->{''} //= {};
-    }
-    delete $machines->{'localhost'};
-
-    my $status = $c->model('DB::SystemStatus')->find("queue-runner");
-    if ($status) {
-        my $ms = decode_json($status->status)->{"machines"};
-        foreach my $name (keys %{$ms}) {
-            $name = "" if $name eq "localhost";
-            my $outName = $name;
-            $outName = "" if $name eq "ssh://localhost";
-            $machines->{$outName} //= {disabled => 1};
-            $machines->{$outName}->{nrStepsDone} = $ms->{$name}->{nrStepsDone};
-            $machines->{$outName}->{avgStepBuildTime} = $ms->{$name}->{avgStepBuildTime} // 0;
-        }
-    }
 
     $c->stash->{machines} = $machines;
     $c->stash->{steps} = dbh($c)->selectall_arrayref(

--- a/subprojects/hydra/lib/Hydra/Helper/Nix.pm
+++ b/subprojects/hydra/lib/Hydra/Helper/Nix.pm
@@ -356,66 +356,39 @@ sub getMachines {
     my %machines = ();
     my $config = getHydraConfig();
 
-    if ($config->{'queue_runner_endpoint'}) {
-        my $ua = LWP::UserAgent->new();
-        my $resp = $ua->get($config->{'queue_runner_endpoint'} . "/status/machines");
-        if (not $resp->is_success) {
-            print STDERR "Unable to ask queue runner for machines\n";
-            return \%machines;
-        }
+    my $endpoint = $config->{'queue_runner_endpoint'};
+    if (!$endpoint) {
+        print STDERR "warning: queue_runner_endpoint not configured in hydra.conf\n";
+        return \%machines;
+    }
 
-        my $data = decode_json($resp->decoded_content) or return \%machines;
-        my $machinesData = $data->{machines};
+    my $ua = LWP::UserAgent->new();
+    my $resp = $ua->get($endpoint . "/status/machines");
+    if (not $resp->is_success) {
+        print STDERR "Unable to ask queue runner for machines\n";
+        return \%machines;
+    }
 
-        foreach my $machineName (keys %$machinesData) {
-            my $machine = %$machinesData{$machineName};
-            $machines{$machineName} =
-                { systemTypes => $machine->{systems}
-                , maxJobs => $machine->{maxJobs}
-                , speedFactor => $machine->{speedFactor}
-                , supportedFeatures => [ @{$machine->{supportedFeatures}}, @{$machine->{mandatoryFeatures}} ]
-                , mandatoryFeatures => [ @{$machine->{mandatoryFeatures}} ]
-                # New fields for the machine status
-                , primarySystemType => $machine->{systems}[0]
-                , hasCapacity => $machine->{hasCapacity}
-                , hasDynamicCapacity => $machine->{hasDynamicCapacity}
-                , hasStaticCapacity => $machine->{hasStaticCapacity}
-                , score => $machine->{score}
-                , stats => $machine->{stats}
-                , memTotal => $machine->{totalMem}
-                };
-        }
-    } else {
-        my @machinesFiles = split /:/, ($ENV{"NIX_REMOTE_SYSTEMS"} || "/etc/nix/machines");
+    my $data = decode_json($resp->decoded_content) or return \%machines;
+    my $machinesData = $data->{machines};
 
-        for my $machinesFile (@machinesFiles) {
-            next unless -e $machinesFile;
-            open(my $conf, "<", $machinesFile) or die;
-            while (my $line = <$conf>) {
-                chomp($line);
-                $line =~ s/\#.*$//g;
-                next if $line =~ /^\s*$/;
-                my @tokens = split /\s+/, $line;
-
-                if (!defined($tokens[5]) || $tokens[5] eq "-") {
-                    $tokens[5] = "";
-                }
-                my @supportedFeatures = split(/,/, $tokens[5] || "");
-
-                if (!defined($tokens[6]) || $tokens[6] eq "-") {
-                    $tokens[6] = "";
-                }
-                my @mandatoryFeatures = split(/,/, $tokens[6] || "");
-                $machines{$tokens[0]} =
-                    { systemTypes => [ split(/,/, $tokens[1]) ]
-                    , maxJobs => int($tokens[3])
-                    , speedFactor => 1.0 * (defined $tokens[4] ? int($tokens[4]) : 1)
-                    , supportedFeatures => [ @supportedFeatures, @mandatoryFeatures ]
-                    , mandatoryFeatures => [ @mandatoryFeatures ]
-                    };
-            }
-            close $conf;
-        }
+    foreach my $machineName (keys %$machinesData) {
+        my $machine = %$machinesData{$machineName};
+        $machines{$machineName} =
+            { systemTypes => $machine->{systems}
+            , maxJobs => $machine->{maxJobs}
+            , speedFactor => $machine->{speedFactor}
+            , supportedFeatures => [ @{$machine->{supportedFeatures}}, @{$machine->{mandatoryFeatures}} ]
+            , mandatoryFeatures => [ @{$machine->{mandatoryFeatures}} ]
+            # New fields for the machine status
+            , primarySystemType => $machine->{systems}[0]
+            , hasCapacity => $machine->{hasCapacity}
+            , hasDynamicCapacity => $machine->{hasDynamicCapacity}
+            , hasStaticCapacity => $machine->{hasStaticCapacity}
+            , score => $machine->{score}
+            , stats => $machine->{stats}
+            , memTotal => $machine->{totalMem}
+            };
     }
 
     return \%machines;

--- a/subprojects/hydra/root/machine-status.tt
+++ b/subprojects/hydra/root/machine-status.tt
@@ -60,9 +60,9 @@
               </span>
             [% END %]
           [% END %]
-          [% IF m.value.nrStepsDone %]
+          [% IF m.value.stats.nrStepsDone %]
             <span class="muted" style="font-weight: normal;">
-              ([% m.value.nrStepsDone %] steps done, [% f = format("%.1f"); f(m.value.avgStepBuildTime) %] s/step)
+              ([% m.value.stats.nrStepsDone %] steps done, [% f = format("%.1f"); f(m.value.stats.avgStepBuildTimeMs / 1000) %] s/step)
             </span>
           [% END %]
         </th>

--- a/subprojects/hydra/script/hydra-send-stats
+++ b/subprojects/hydra/script/hydra-send-stats
@@ -9,7 +9,7 @@ use Net::Statsd;
 use File::Slurper qw(read_text);
 use JSON::MaybeXS;
 use Getopt::Long qw(:config gnu_getopt);
-use IPC::Run3;
+use LWP::UserAgent;
 
 STDERR->autoflush(1);
 binmode STDERR, ":encoding(utf8)";
@@ -26,48 +26,48 @@ sub gauge {
 }
 
 sub sendQueueRunnerStats {
-    my ($stdout, $stderr);
-    run3(['hydra-queue-runner', '--status'], \undef, \$stdout, \$stderr);
-    die "cannot get queue runner stats: $stderr\n" if $? != 0;
+    my $endpoint = $config->{'queue_runner_endpoint'}
+        or die "queue_runner_endpoint not configured in hydra.conf\n";
 
-    my $json = decode_json($stdout) or die "cannot decode queue runner status";
+    my $ua = LWP::UserAgent->new();
+    my $resp = $ua->get($endpoint . "/status");
+    die "cannot get queue runner stats: " . $resp->status_line . "\n"
+        unless $resp->is_success;
 
-    gauge("hydra.queue.up", $json->{status} eq "up" ? 1 : 0);
+    my $json = decode_json($resp->decoded_content)
+        or die "cannot decode queue runner status";
 
-    return if $json->{status} ne "up";
+    my $qr = $json->{queueRunner};
 
-    gauge("hydra.queue.steps.active", $json->{nrActiveSteps});
-    gauge("hydra.queue.steps.building", $json->{nrStepsBuilding});
-    gauge("hydra.queue.steps.copying_to", $json->{nrStepsCopyingTo});
-    gauge("hydra.queue.steps.copying_from", $json->{nrStepsCopyingFrom});
-    gauge("hydra.queue.steps.waiting", $json->{nrStepsWaiting});
-    gauge("hydra.queue.steps.runnable", $json->{nrRunnableSteps});
-    gauge("hydra.queue.steps.unfinished", $json->{nrUnfinishedSteps});
-    gauge("hydra.queue.steps.finished", $json->{nrStepsDone});
-    gauge("hydra.queue.steps.retries", $json->{nrRetries});
-    gauge("hydra.queue.steps.unsupported", $json->{nrUnsupportedSteps});
-    gauge("hydra.queue.steps.max_retries", $json->{maxNrRetries});
-    if ($json->{nrStepsDone}) {
-        gauge("hydra.queue.steps.avg_total_time", $json->{avgStepTime});
-        gauge("hydra.queue.steps.avg_build_time", $json->{avgStepBuildTime});
+    gauge("hydra.queue.up", $qr->{status} eq "up" ? 1 : 0);
+
+    return if $qr->{status} ne "up";
+
+    gauge("hydra.queue.steps.building", $qr->{nrStepsBuilding});
+    gauge("hydra.queue.steps.runnable", $qr->{nrStepsRunnable});
+    gauge("hydra.queue.steps.unfinished", $qr->{nrStepsUnfinished});
+    gauge("hydra.queue.steps.finished", $qr->{nrStepsDone});
+    gauge("hydra.queue.steps.retries", $qr->{nrRetries});
+    gauge("hydra.queue.steps.unsupported", $qr->{nrUnsupportedSteps});
+    gauge("hydra.queue.steps.max_retries", $qr->{maxNrRetries});
+    if ($qr->{nrStepsDone}) {
+        gauge("hydra.queue.steps.avg_total_time", $qr->{avgStepTimeMs} / 1000);
+        gauge("hydra.queue.steps.avg_build_time", $qr->{avgStepBuildTimeMs} / 1000);
     }
-    foreach my $machine (keys %{$json->{machineTypes}}) {
-        my $machineType = $machine  =~ s/:|,/_/r;
-        gauge("hydra.queue.$machineType.runnable", $json->{machineTypes}->{$machine}->{runnable});
-        gauge("hydra.queue.$machineType.running", $json->{machineTypes}->{$machine}->{running});
+    foreach my $system (keys %{$qr->{queueStats}}) {
+        my $systemKey = $system =~ s/:|,/_/gr;
+        gauge("hydra.queue.$systemKey.runnable", $qr->{queueStats}->{$system}->{totalRunnable});
+        gauge("hydra.queue.$systemKey.active_runnable", $qr->{queueStats}->{$system}->{activeRunnable});
     }
 
-    gauge("hydra.queue.builds.read", $json->{nrBuildsRead});
-    gauge("hydra.queue.builds.unfinished", $json->{nrQueuedBuilds});
-    gauge("hydra.queue.builds.finished", $json->{nrBuildsDone});
+    gauge("hydra.queue.builds.read", $qr->{nrBuildsRead});
+    gauge("hydra.queue.builds.unfinished", $qr->{nrBuildsUnfinished});
+    gauge("hydra.queue.builds.finished", $qr->{nrBuildsDone});
 
-    gauge("hydra.queue.checks", $json->{nrQueueWakeups});
+    gauge("hydra.queue.checks", $qr->{nrQueueWakeups});
 
-    gauge("hydra.queue.bytes_sent", $json->{bytesSent});
-    gauge("hydra.queue.bytes_received", $json->{bytesReceived});
-
-    gauge("hydra.queue.machines.total", scalar(grep { $_->{enabled} } (values %{$json->{machines}})));
-    gauge("hydra.queue.machines.in_use", scalar(grep { $_->{currentJobs} > 0 } (values %{$json->{machines}})));
+    gauge("hydra.queue.machines.total", $qr->{machinesTotal});
+    gauge("hydra.queue.machines.in_use", $qr->{machinesInUse});
 }
 
 

--- a/subprojects/hydra/sql/hydra.sql
+++ b/subprojects/hydra/sql/hydra.sql
@@ -628,6 +628,8 @@ create rule IdempotentInsert as on insert to FailedPaths
 
 
 
+-- TODO: Drop this table in a future migration. The queue runner no longer
+-- writes status here; all status is served via its REST API instead.
 create table SystemStatus (
     what text primary key not null,
     status json not null


### PR DESCRIPTION
… reporting

The Perl web controllers were falling back to reading `/etc/nix/machines` (the old Nix remote systems file) when `queue_runner_endpoint` wasn't configured. But this doesn't really make sense because Hydra won't actually fall back to using those machines — the Rust queue runner uses a completely different gRPC self-registration mechanism.

`getMachines()` now always queries the queue runner's `/status/machines` HTTP endpoint, and warns if `queue_runner_endpoint` is missing.

Additionally, the `SystemStatus` DB table was being used as an intermediary for status reporting: the queue runner would write a JSON dump there, and `hydra-queue-runner --status` would read it back. This is no longer needed since the queue runner has a REST API that serves the same data directly. All consumers (`queue-runner-status` page, `hydra-send-stats`) now query the HTTP endpoint instead.

Removed:

- Legacy `/etc/nix/machines` file parsing from `getMachines()`

- `SystemStatus` DB reads from `Root.pm` (the Perl controller)

- The `--status` CLI flag and `dump_status_loop` from the Rust queue runner (no more writing status to the database)

- `upsert_status`, `get_status`, `notify_dump_status`, `notify_status_dumped` from the DB crate

- The `POST /dump_status` HTTP endpoint

- The `buildMachinesFiles` NixOS option (with `mkRemovedOptionModule` deprecation message) and `NIX_REMOTE_SYSTEMS` env var

- The machines file parsing test and related test scaffolding

`hydra-send-stats` and the `queue-runner-status` page now query the queue runner's REST API directly. The `SystemStatus` table is marked for removal in a future migration. The `hydra-send-stats` test now exercises both the no-endpoint and with-endpoint code paths.