### PR TITLE
Allow `dyn-drv-non-trivial` test to retry up to 5 times

### DIFF
--- a/subprojects/hydra-tests/content-addressed/dyn-drv-non-trivial.t
+++ b/subprojects/hydra-tests/content-addressed/dyn-drv-non-trivial.t
@@ -1,6 +1,10 @@
 use feature 'unicode_strings';
 use strict;
 use warnings;
+# There is something wrong with recursive nix that causes this to fail
+# wiht some regularity in CI. Allowing this test to be restarted as a
+# stop-gap for now.
+# HARNESS-RETRY 5
 use Setup;
 use Test2::V0;
 


### PR DESCRIPTION
There is an upstream recursive-nix issue that causes this test to fail intermittently in CI. Use `HARNESS-RETRY 5` so yath retries it rather than failing the whole suite.