### PR TITLE
queue-runner: include actual error in `build_log` failure messages

### DIFF
--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -449,7 +449,7 @@ impl RunnerService for Server {
                     .into(),
             )
             .await
-            .map_err(|_| tonic::Status::internal("Failed to create log file."))?;
+            .map_err(|e| tonic::Status::internal(format!("Failed to create log file: {e}")))?;
 
         let first = tokio_stream::iter(vec![Ok::<_, std::io::Error>(first_data)]);
         let rest = mapped.map(|r| r.map(|(_, data)| data));
@@ -461,7 +461,7 @@ impl RunnerService for Server {
 
         tokio::io::copy(&mut decoder, &mut file)
             .await
-            .map_err(|_| tonic::Status::internal("Failed to write log file."))?;
+            .map_err(|e| tonic::Status::internal(format!("Failed to write log file: {e}")))?;
 
         Ok(tonic::Response::new(runner_v1::Empty {}))
     }


### PR DESCRIPTION
The `build_log` gRPC handler discarded the `io::Error` with `|_|`, reporting only `"Failed to write log file."` regardless of whether the cause was a disk issue, a broken stream from a crashed builder, or something else. This made intermittent CI failures impossible to diagnose.

Include the error in the gRPC status message so the builder logs show the real cause (e.g. `"broken pipe"`, `"No space left on device"`).