### PR TITLE
hydra-tests: Extract `ProcessGroup` and shared test helpers

### DIFF
--- a/subprojects/hydra-tests/lib/ProcessGroup.pm
+++ b/subprojects/hydra-tests/lib/ProcessGroup.pm
@@ -1,0 +1,123 @@
+use warnings;
+use strict;
+
+package ProcessGroup;
+
+# A lightweight wrapper around a set of IPC::Run harnesses with
+# labelled log flushing, pump, and ordered teardown.
+#
+# Usage:
+#   my $pg = ProcessGroup->new;
+#   $pg->spawn("queue-runner", ["hydra-queue-runner", ...], env => { ... });
+#   $pg->pump_logs;
+#   $pg->stop;   # or let DESTROY handle it
+
+use IPC::Run;
+
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw();
+
+sub new {
+    my ($class, %opts) = @_;
+    bless {
+        procs => {},
+        order => [],
+        env   => $opts{env} // {},
+    }, $class;
+}
+
+# Spawn a labelled child process and register it.
+#
+# Options:
+#   env => { KEY => VAL, ... }  extra env vars merged with the group default
+#   init => sub { ... }         passed to IPC::Run::start as init callback
+sub spawn {
+    my ($self, $key, $cmd, %opts) = @_;
+    my %env = (%{$self->{env}}, %{$opts{env} // {}});
+    my ($in, $out, $err) = ("", "", "");
+    my $harness;
+    {
+        local @ENV{keys %env} = values %env;
+        local $ENV{NO_COLOR} = "1";
+        my @extra;
+        push @extra, (init => $opts{init}) if $opts{init};
+        $harness = IPC::Run::start($cmd, \$in, \$out, \$err, @extra);
+    }
+    $self->{procs}{$key} = {
+        label   => $key,
+        harness => $harness,
+        out     => \$out,
+        err     => \$err,
+    };
+    push @{$self->{order}}, $key;
+    return $harness;
+}
+
+# Pump all harnesses and flush any complete log lines to stderr.
+sub pump_logs {
+    my ($self) = @_;
+    for my $key (@{$self->{order}}) {
+        my $p = $self->{procs}{$key} or next;
+        eval { $p->{harness}->pump_nb };
+        _flush_proc($p);
+    }
+}
+
+# Return the harness for a given key, or undef.
+sub harness {
+    my ($self, $key) = @_;
+    my $p = $self->{procs}{$key} or return undef;
+    return $p->{harness};
+}
+
+# Return the stdout buffer ref for a given key.
+sub stdout_ref {
+    my ($self, $key) = @_;
+    return $self->{procs}{$key}{out};
+}
+
+# Return the stderr buffer ref for a given key.
+sub stderr_ref {
+    my ($self, $key) = @_;
+    return $self->{procs}{$key}{err};
+}
+
+# Kill all processes in reverse spawn order and flush final output.
+sub stop {
+    my ($self) = @_;
+    return if $self->{stopped};
+    $self->{stopped} = 1;
+    for my $key (reverse @{$self->{order}}) {
+        my $p = $self->{procs}{$key} or next;
+        eval { $p->{harness}->kill_kill };
+        _flush_proc($p, 1);
+    }
+}
+
+sub DESTROY {
+    my ($self) = @_;
+    $self->stop;
+}
+
+# --- Internal helpers ---
+
+sub _flush_stream {
+    my ($label, $stream, $buf_ref, $final) = @_;
+    return if $$buf_ref eq "";
+    utf8::decode($$buf_ref) or warn "Invalid unicode in $label $stream.";
+    while ($$buf_ref =~ s/^([^\n]*)\n//) {
+        print STDERR "[$label $stream] $1\n";
+    }
+    if ($final && $$buf_ref ne "") {
+        print STDERR "[$label $stream] $$buf_ref\n";
+        $$buf_ref = "";
+    }
+}
+
+sub _flush_proc {
+    my ($p, $final) = @_;
+    _flush_stream($p->{label}, "stdout", $p->{out}, $final);
+    _flush_stream($p->{label}, "stderr", $p->{err}, $final);
+}
+
+1;

--- a/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
@@ -2,10 +2,10 @@ use warnings;
 use strict;
 
 package QueueRunnerBuildOne;
-use IPC::Run;
 use JSON::PP;
 use LWP::UserAgent;
 use HTTP::Request;
+use ProcessGroup;
 use QueueRunnerContext;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
@@ -13,76 +13,48 @@ our @EXPORT = qw(
     runBuilds
 );
 
-sub _flush_stream {
-    my ($label, $stream, $buf_ref, $final) = @_;
-    return if $$buf_ref eq "";
-    utf8::decode($$buf_ref) or warn "Invalid unicode in $label $stream.";
-    # Print each complete line with a label prefix. Leave any trailing
-    # partial line in the buffer so it can be flushed together with the
-    # rest of its line on a subsequent call.
-    while ($$buf_ref =~ s/^([^\n]*)\n//) {
-        print STDERR "[$label $stream] $1\n";
-    }
-    if ($final && $$buf_ref ne "") {
-        print STDERR "[$label $stream] $$buf_ref\n";
-        $$buf_ref = "";
-    }
-}
-
-sub _flush_harness {
-    my ($label, $out_ref, $err_ref, $final) = @_;
-    _flush_stream($label, "stdout", $out_ref, $final);
-    _flush_stream($label, "stderr", $err_ref, $final);
-}
-
 sub runBuilds {
     my ($ctx, @builds) = @_;
     ref $ctx eq 'HydraTestContext' or die "runBuilds requires a HydraTestContext as first argument\n";
     my @build_ids = map { $_->id } @builds;
 
-    my ($qr_harness, $base_url, $grpc_addr, $qr_out_ref, $qr_err_ref, $qr_daemon) = start_queue_runner($ctx,
+    my $pg = ProcessGroup->new;
+
+    my ($qr_harness, $base_url, $grpc_addr, $qr_out, $qr_err, $qr_daemon) = start_queue_runner($ctx,
         rust_log => "queue_runner=debug,info",
     );
+    $pg->{procs}{"queue-runner"} = {
+        label => "queue-runner", harness => $qr_harness, out => $qr_out, err => $qr_err,
+    };
+    push @{$pg->{order}}, "queue-runner";
 
-    # Start a nix daemon for the builder.
     my $bl_daemon = QueueRunnerContext::start_nix_daemon($ctx->{builder});
 
-    my ($bl_in, $bl_out, $bl_err) = ("", "", "");
-    my $ua = LWP::UserAgent->new(timeout => 2);
-    my $bl_harness;
+    $pg->spawn("builder",
+        ["hydra-builder", "--gateway-endpoint", "http://$grpc_addr"],
+        env => {
+            NIX_REMOTE    => $ctx->{builder}{nix_daemon_uri},
+            NIX_CONF_DIR  => $ctx->{builder}{nix_conf_dir},
+            NIX_STATE_DIR => $ctx->{builder}{nix_state_dir},
+            NIX_STORE_DIR => $ctx->{builder}{nix_store_dir},
+            RUST_LOG      => "hydra_builder=debug,info",
+        },
+    );
 
+    my $ua = LWP::UserAgent->new(timeout => 2);
     my $timeout = 60 * scalar(@build_ids);
+
     my $ok = eval {
         local $SIG{ALRM} = sub { die "timeout\n" };
         alarm $timeout;
-        # Wait for the REST server to become available.
+
         wait_for_url($ua, "$base_url/status")
             or die "Timed out waiting for queue-runner REST server\n";
 
-        # Start the builder, connecting to the nix daemon via unix://.
-        {
-            local $ENV{NIX_REMOTE} = $ctx->{builder}{nix_daemon_uri};
-            local $ENV{NIX_CONF_DIR} = $ctx->{builder}{nix_conf_dir};
-            local $ENV{NIX_STATE_DIR} = $ctx->{builder}{nix_state_dir};
-            # TODO: hydra-builder reads NIX_STORE_DIR to report its
-            # store dir to the queue runner; should use the store URI instead.
-            local $ENV{NIX_STORE_DIR} = $ctx->{builder}{nix_store_dir};
-            local $ENV{RUST_LOG} = "hydra_builder=debug,info";
-            local $ENV{NO_COLOR} = "1";
-            $bl_harness = IPC::Run::start(
-                ["hydra-builder",
-                    "--gateway-endpoint", "http://$grpc_addr",
-                ],
-                \$bl_in, \$bl_out, \$bl_err,
-            );
-        }
-
-        # Wait for the builder to register as a machine.
         wait_for_url($ua, "$base_url/status/machines", sub {
             shift->decoded_content =~ /"hostname"/;
         }) or die "Timed out waiting for builder to register\n";
 
-        # Submit all builds. Returns 200 even if a build is already finished.
         for my $bid (@build_ids) {
             my $req = HTTP::Request->new(POST => "$base_url/build_one");
             $req->header('Content-Type' => 'application/json');
@@ -92,33 +64,7 @@ sub runBuilds {
                 unless $resp->is_success;
         }
 
-        # Poll until every build is no longer active.
-        while (1) {
-            # If the builder crashed, fail fast instead of waiting for the
-            # queue-runner to time out the orphaned builds.
-            $qr_harness->pump_nb;
-            $bl_harness->pump_nb;
-            # Flush accumulated output so logs are visible while waiting.
-            _flush_harness("Queue runner", $qr_out_ref, $qr_err_ref);
-            _flush_harness("Builder", \$bl_out, \$bl_err);
-            if (!$bl_harness->pumpable) {
-                $bl_harness->finish;
-                my $rc = $bl_harness->result;
-                print STDERR "builder exited unexpectedly (exit code $rc)\n";
-                die "builder exited unexpectedly\n";
-            }
-
-            my $all_done = 1;
-            for my $bid (@build_ids) {
-                my $resp = $ua->get("$base_url/status/build/$bid/active");
-                if ($resp->decoded_content =~ /true/) {
-                    $all_done = 0;
-                    last;
-                }
-            }
-            last if $all_done;
-            sleep 2;
-        }
+        wait_for_builds($ua, $base_url, $pg, @build_ids);
 
         alarm 0;
         1;
@@ -126,15 +72,8 @@ sub runBuilds {
     my $err = $@;
     alarm 0;
 
-    # Always clean up child processes, then flush any trailing stderr
-    # that arrived after the last poll iteration.
-    if ($bl_harness) {
-        $bl_harness->kill_kill;
-        _flush_harness("Builder", \$bl_out, \$bl_err, 1);
-    }
+    $pg->stop;
     $bl_daemon->kill_kill(grace => 2);
-    $qr_harness->kill_kill;
-    _flush_harness("Queue runner", $qr_out_ref, $qr_err_ref, 1);
     $qr_daemon->kill_kill(grace => 2);
 
     if (!$ok) {

--- a/subprojects/hydra-tests/lib/QueueRunnerContext.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerContext.pm
@@ -11,6 +11,7 @@ use Hydra::Config;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
     start_queue_runner
+    wait_for_builds
     wait_for_url
 );
 
@@ -157,6 +158,39 @@ sub start_queue_runner {
     my $grpc_addr = "[::1]:$grpc_port";
 
     return ($qr_harness, $rest_url, $grpc_addr, \$qr_out, \$qr_err, $daemon_harness);
+}
+
+# Poll the queue runner REST API until all given build IDs are no longer
+# active. Calls $pg->pump_logs each iteration so test output stays visible.
+#
+# Args: ($ua, $base_url, $process_group, @build_ids)
+# Dies on timeout or if the builder process exits unexpectedly.
+sub wait_for_builds {
+    my ($ua, $base_url, $pg, @build_ids) = @_;
+    my $timeout = 60 * scalar(@build_ids);
+    $timeout = 60 if $timeout < 60;
+    my $deadline = time() + $timeout;
+    while (time() < $deadline) {
+        $pg->pump_logs;
+        my $bl = $pg->harness("builder");
+        if ($bl && !$bl->pumpable) {
+            $bl->finish;
+            my $rc = $bl->result;
+            die "builder exited unexpectedly (exit code $rc)\n";
+        }
+
+        my $all_done = 1;
+        for my $bid (@build_ids) {
+            my $resp = $ua->get("$base_url/status/build/$bid/active");
+            if ($resp->decoded_content =~ /true/) {
+                $all_done = 0;
+                last;
+            }
+        }
+        return 1 if $all_done;
+        sleep 2;
+    }
+    die "timed out waiting for builds to finish\n";
 }
 
 1;


### PR DESCRIPTION
Prepare for reuse by pulling process-management and polling logic out of `QueueRunnerBuildOne` into standalone modules:

- `ProcessGroup.pm`: reusable labelled process group with `spawn`, `pump_logs`, and ordered teardown.
- `wait_for_builds` in `QueueRunnerContext`: polling loop that checks the queue runner REST API until all build IDs are inactive.
- `start_queue_runner` and `start_nix_daemon` in `QueueRunnerContext`: extracted from `QueueRunnerBuildOne` so future test helpers can start queue infrastructure without duplicating the setup.

`QueueRunnerBuildOne` is rewritten to use these shared helpers. The queue-runner harness is still registered manually because `start_queue_runner` returns pre-bound sockets and a separate daemon harness that don't fit `ProcessGroup::spawn`'s simple model.