### PR TITLE
Split `.proto` into generic Nix store types and Hydra-specific types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#5eabb8d7307572e48556fa559570c999683d0779"
+source = "git+https://github.com/nix-community/harmonia.git#523a9033c4bdc0aa954d4ec789ba12e57d3883c7"
 dependencies = [
  "harmonia-store-core",
  "harmonia-utils-hash",
@@ -1315,7 +1315,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-core"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#5eabb8d7307572e48556fa559570c999683d0779"
+source = "git+https://github.com/nix-community/harmonia.git#523a9033c4bdc0aa954d4ec789ba12e57d3883c7"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -1336,7 +1336,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#5eabb8d7307572e48556fa559570c999683d0779"
+source = "git+https://github.com/nix-community/harmonia.git#523a9033c4bdc0aa954d4ec789ba12e57d3883c7"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1346,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#5eabb8d7307572e48556fa559570c999683d0779"
+source = "git+https://github.com/nix-community/harmonia.git#523a9033c4bdc0aa954d4ec789ba12e57d3883c7"
 dependencies = [
  "data-encoding",
  "derive_more",

--- a/cargo-output-hashes.nix
+++ b/cargo-output-hashes.nix
@@ -1,5 +1,5 @@
 # Shared outputHashes for cargoLock across all Rust crates.
 # Update this file when the harmonia dependency changes.
 {
-  "harmonia-store-core-0.0.0-alpha.0" = "sha256-qrMHC9+zQQ3vt8LZxGXqpKRHQvrqL+od6OBUExNsv6A=";
+  "harmonia-store-core-0.0.0-alpha.0" = "sha256-zx1fIAQ7S3OI/uo198s0HlMaidnNvc/3ydGwEiyGiKQ=";
 }

--- a/subprojects/crates/proto/build.rs
+++ b/subprojects/crates/proto/build.rs
@@ -22,8 +22,23 @@ pub const PROTO_API_VERSION: &str = "{version}";
         ),
     )?;
 
+    // First pass: generate nix.store.v1 types (except StorePath which is manual)
     tonic_prost_build::configure()
-        .extern_path(".runner.v1.StorePath", "crate::store_path::ProtoStorePath")
+        .extern_path(
+            ".nix.store.v1.StorePath",
+            "crate::store_path::ProtoStorePath",
+        )
+        .build_client(false)
+        .build_server(false)
+        .compile_protos(&["../../proto/v1/store.proto"], &["../../proto"])?;
+
+    // Second pass: generate runner.v1 (references nix.store.v1 via extern_path)
+    tonic_prost_build::configure()
+        .extern_path(
+            ".nix.store.v1.StorePath",
+            "crate::store_path::ProtoStorePath",
+        )
+        .extern_path(".nix.store.v1", "crate::nix::store::v1")
         .build_client(cfg!(feature = "client"))
         .build_server(cfg!(feature = "server"))
         .file_descriptor_set_path(out_dir.join("streaming_descriptor.bin"))

--- a/subprojects/crates/proto/src/lib.rs
+++ b/subprojects/crates/proto/src/lib.rs
@@ -5,6 +5,16 @@ pub mod store_path;
 
 pub use store_path::ProtoStorePath;
 
+pub mod nix {
+    pub mod store {
+        pub mod v1 {
+            tonic::include_proto!("nix.store.v1");
+        }
+    }
+}
+
+pub use nix::store::v1::{NarInfo, RelativeStorePath, StorePaths, ValidPathInfo};
+
 tonic::include_proto!("runner.v1");
 
 include!(concat!(env!("OUT_DIR"), "/proto_version.rs"));

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -1104,20 +1104,24 @@ async fn upload_single_nar_presigned(
         let completion_msg = hydra_proto::PresignedUploadComplete {
             build_id: build_id.to_owned(),
             machine_id: machine_id.to_owned(),
-            store_path: nar_path.to_string().clone(),
-            url: updated_narinfo.url.clone(),
-            compression: updated_narinfo.compression.as_str().to_owned(),
-            file_hash: format!("{}", file_hash.as_base32()),
-            file_size,
-            nar_hash: format!("{}", updated_narinfo.nar_hash.as_base32()),
-            nar_size: updated_narinfo.nar_size,
-            references: updated_narinfo
-                .references
-                .iter()
-                .map(|p| p.to_string().clone())
-                .collect(),
-            deriver: updated_narinfo.deriver.map(|p| p.to_string().clone()),
-            ca: updated_narinfo.ca,
+            nar_info: Some(hydra_proto::nix::store::v1::NarInfo {
+                path_info: Some(hydra_proto::nix::store::v1::ValidPathInfo {
+                    path: Some(ProtoStorePath::from(nar_path.clone())),
+                    nar_hash: format!("{}", updated_narinfo.nar_hash.as_base32()),
+                    nar_size: updated_narinfo.nar_size,
+                    references: updated_narinfo
+                        .references
+                        .iter()
+                        .map(|p| ProtoStorePath::from(p.clone()))
+                        .collect(),
+                    deriver: updated_narinfo.deriver.map(ProtoStorePath::from),
+                    ca: updated_narinfo.ca,
+                }),
+                url: updated_narinfo.url.clone(),
+                compression: updated_narinfo.compression.as_str().to_owned(),
+                file_hash: format!("{}", file_hash.as_base32()),
+                file_size,
+            }),
         };
 
         client

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -744,7 +744,6 @@ impl RunnerService for Server {
         fields(
             build_id=req.get_ref().build_id,
             machine_id=req.get_ref().machine_id,
-            store_path=req.get_ref().store_path
         ),
         err,
     )]
@@ -783,26 +782,32 @@ impl RunnerService for Server {
                 .ok_or_else(|| tonic::Status::failed_precondition("No remote store configured"))?
         };
 
+        let nar_info = req
+            .nar_info
+            .ok_or_else(|| tonic::Status::invalid_argument("missing nar_info"))?;
+        let path_info = nar_info
+            .path_info
+            .ok_or_else(|| tonic::Status::invalid_argument("missing path_info"))?;
+        let store_path = path_info
+            .path
+            .ok_or_else(|| tonic::Status::invalid_argument("missing store_path"))?
+            .0;
+
         let narinfo = binary_cache::NarInfo {
-            store_path: nix_utils::parse_store_path(&req.store_path),
-            url: req.url.clone(),
+            store_path: store_path.clone(),
+            url: nar_info.url.clone(),
             compression: remote_store.cfg.compression,
-            file_hash: binary_cache::parse_hash(&req.file_hash),
-            file_size: Some(req.file_size),
-            nar_hash: binary_cache::parse_hash(&req.nar_hash).ok_or_else(|| {
-                tonic::Status::invalid_argument(format!("invalid nar hash: {}", req.nar_hash))
+            file_hash: binary_cache::parse_hash(&nar_info.file_hash),
+            file_size: Some(nar_info.file_size),
+            nar_hash: binary_cache::parse_hash(&path_info.nar_hash).ok_or_else(|| {
+                tonic::Status::invalid_argument(format!("invalid nar hash: {}", path_info.nar_hash))
             })?,
-            nar_size: req.nar_size,
-            references: req
-                .references
-                .into_iter()
-                .map(|p| nix_utils::parse_store_path(&p))
-                .collect(),
-            deriver: req.deriver.map(|p| nix_utils::parse_store_path(&p)),
-            ca: req.ca,
+            nar_size: path_info.nar_size,
+            references: path_info.references.into_iter().map(|p| p.0).collect(),
+            deriver: path_info.deriver.map(|p| p.0),
+            ca: path_info.ca,
             sigs: vec![],
         };
-        let store_path = narinfo.store_path.clone();
 
         let narinfo_url = remote_store
             .upload_narinfo_after_presigned_upload(&self.state.store, narinfo)
@@ -815,8 +820,8 @@ impl RunnerService for Server {
         tracing::debug!(
             "Presigned upload completed and narinfo uploaded for path: {}, url: {}, size: {} bytes, narinfo: {}",
             store_path,
-            req.url,
-            req.file_size,
+            nar_info.url,
+            nar_info.file_size,
             narinfo_url
         );
 

--- a/subprojects/proto/v1/store.proto
+++ b/subprojects/proto/v1/store.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package nix.store.v1;
+
+message StorePath {
+  string path = 1;
+}
+
+message StorePaths {
+  repeated StorePath paths = 1;
+}
+
+message RelativeStorePath {
+  StorePath store_path = 1;
+  string sub_path = 2;
+}
+
+message ValidPathInfo {
+  StorePath path = 1;
+  string nar_hash = 2;
+  uint64 nar_size = 3;
+  repeated StorePath references = 4;
+  optional StorePath deriver = 5;
+  optional string ca = 6;
+}
+
+message NarInfo {
+  ValidPathInfo path_info = 1;
+  string url = 2;
+  string compression = 3;
+  string file_hash = 4;
+  uint64 file_size = 5;
+}

--- a/subprojects/proto/v1/streaming.proto
+++ b/subprojects/proto/v1/streaming.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package runner.v1;
 
+import "v1/store.proto";
+
 option java_multiple_files = true;
 option java_outer_classname = "RunnerProto";
 option java_package = "io.grpc.hydra.runner";
@@ -14,9 +16,9 @@ service RunnerService {
   rpc BuildStepUpdate(StepUpdate) returns (Empty) {}
   rpc CompleteBuild(BuildResultInfo) returns (Empty) {}
   rpc FetchDrvRequisites(FetchRequisitesRequest) returns (DrvRequisitesMessage) {}
-  rpc HasPath(StorePath) returns (HasPathResponse) {}
-  rpc StreamFile(StorePath) returns (stream NarData) {}
-  rpc StreamFiles(StorePaths) returns (stream NarData) {}
+  rpc HasPath(nix.store.v1.StorePath) returns (HasPathResponse) {}
+  rpc StreamFile(nix.store.v1.StorePath) returns (stream NarData) {}
+  rpc StreamFiles(nix.store.v1.StorePaths) returns (stream NarData) {}
   rpc RequestPresignedUrl(PresignedUrlRequest) returns (PresignedUrlResponse) {}
   rpc NotifyPresignedUploadComplete(PresignedUploadComplete) returns (Empty) {}
 }
@@ -124,7 +126,7 @@ message PresignedUploadOpts {
 
 message BuildMessage {
   string build_id = 1; // UUIDv4
-  StorePath drv = 2;
+  nix.store.v1.StorePath drv = 2;
   reserved 3;
   uint64 max_log_size = 4;
   int32 max_silent_time = 5;
@@ -135,7 +137,7 @@ message BuildMessage {
 }
 
 message DrvRequisitesMessage {
-  repeated StorePath requisites = 1;
+  repeated nix.store.v1.StorePath requisites = 1;
 }
 
 message AbortMessage {
@@ -143,21 +145,13 @@ message AbortMessage {
 }
 
 message LogChunk {
-  StorePath drv = 1;
+  nix.store.v1.StorePath drv = 1;
   bytes data = 2;
 }
 
 message FetchRequisitesRequest {
-  StorePath path = 1;
+  nix.store.v1.StorePath path = 1;
   bool include_outputs = 2;
-}
-
-message StorePath {
-  string path = 1;
-}
-
-message StorePaths {
-  repeated StorePath paths = 1;
 }
 
 message HasPathResponse {
@@ -174,7 +168,7 @@ message OutputNameOnly {
 
 message OutputWithPath {
   string name = 1;
-  StorePath path = 2;
+  nix.store.v1.StorePath path = 2;
   uint64 closure_size = 3;
   uint64 nar_size = 4;
   string nar_hash = 5;
@@ -194,13 +188,8 @@ message BuildMetric {
   double value = 4;
 }
 
-message RelativeStorePath {
-  StorePath store_path = 1;
-  string sub_path = 2;
-}
-
 message BuildProduct {
-  RelativeStorePath path = 1;
+  nix.store.v1.RelativeStorePath path = 1;
   string default_path = 2;
 
   string type = 3;
@@ -291,14 +280,5 @@ message PresignedUrlResponse {
 message PresignedUploadComplete {
   string build_id = 1; // UUIDv4
   string machine_id = 2; // UUIDv4
-  string store_path = 3;
-  string url = 4;
-  string compression = 5;
-  string file_hash = 6;
-  uint64 file_size = 7;
-  string nar_hash = 8;
-  uint64 nar_size = 9;
-  repeated string references = 10;
-  optional string deriver = 11;
-  optional string ca = 12;
+  nix.store.v1.NarInfo nar_info = 13;
 }


### PR DESCRIPTION
Introduces `store.proto` (`nix.store.v1` package) containing types that are generic to any Nix store, not specific to Hydra:

- `StorePath`, `StorePaths`, `RelativeStorePath`

- `ValidPathInfo` — store path with NAR hash/size, references, deriver, CA

- `NarInfo` — wraps `ValidPathInfo` with cache-specific fields (url, compression, file hash/size)

`streaming.proto` (`runner.v1`) imports these and uses them for `BuildMessage.drv`, `BuildProduct.path`, `PresignedUploadComplete`, etc.

`PresignedUploadComplete` is restructured to contain a `NarInfo` message instead of flattening all fields, making the layering explicit.