### PR TITLE
Replace local `NarInfo` with `harmonia-store-nar-info`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,8 @@ dependencies = [
  "fs-err",
  "futures",
  "harmonia-store-core",
+ "harmonia-store-nar-info",
+ "harmonia-store-path-info",
  "harmonia-utils-hash",
  "hashbrown 0.16.1",
  "hydra-tracing",
@@ -1334,6 +1336,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "harmonia-store-nar-info"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#cc307ffd78901217062ccfd5c9415999aa43485c"
+dependencies = [
+ "harmonia-store-core",
+ "harmonia-store-path-info",
+ "harmonia-utils-hash",
+ "serde",
+]
+
+[[package]]
+name = "harmonia-store-path-info"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#cc307ffd78901217062ccfd5c9415999aa43485c"
+dependencies = [
+ "harmonia-store-core",
+ "harmonia-utils-hash",
+ "serde",
+]
+
+[[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
 source = "git+https://github.com/nix-community/harmonia.git#cc307ffd78901217062ccfd5c9415999aa43485c"
@@ -1562,6 +1585,9 @@ dependencies = [
  "db",
  "fs-err",
  "harmonia-store-core",
+ "harmonia-store-nar-info",
+ "harmonia-store-path-info",
+ "harmonia-utils-hash",
  "prost",
  "sha2 0.10.9",
  "store-path-utils",
@@ -1589,6 +1615,8 @@ dependencies = [
  "futures-util",
  "h2",
  "harmonia-store-core",
+ "harmonia-store-nar-info",
+ "harmonia-store-path-info",
  "hashbrown 0.16.1",
  "http-body-util",
  "hydra-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -131,9 +131,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -214,9 +214,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -491,7 +491,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -565,9 +565,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "bzip2",
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
@@ -1264,7 +1264,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1283,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#523a9033c4bdc0aa954d4ec789ba12e57d3883c7"
+source = "git+https://github.com/nix-community/harmonia.git#cc307ffd78901217062ccfd5c9415999aa43485c"
 dependencies = [
  "harmonia-store-core",
  "harmonia-utils-hash",
@@ -1315,7 +1315,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-core"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#523a9033c4bdc0aa954d4ec789ba12e57d3883c7"
+source = "git+https://github.com/nix-community/harmonia.git#cc307ffd78901217062ccfd5c9415999aa43485c"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -1336,7 +1336,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#523a9033c4bdc0aa954d4ec789ba12e57d3883c7"
+source = "git+https://github.com/nix-community/harmonia.git#cc307ffd78901217062ccfd5c9415999aa43485c"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1346,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#523a9033c4bdc0aa954d4ec789ba12e57d3883c7"
+source = "git+https://github.com/nix-community/harmonia.git#cc307ffd78901217062ccfd5c9415999aa43485c"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1391,6 +1391,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1499,9 +1505,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1639,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1654,7 +1660,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1662,20 +1667,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1742,12 +1746,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1755,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1768,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1782,15 +1787,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1802,15 +1807,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1840,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1850,12 +1855,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1865,16 +1870,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1899,9 +1894,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -1914,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1950,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1977,15 +1972,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "liblzma"
@@ -1999,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "liblzma-sys"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2db66f3268487b5033077f266da6777d057949b8f93c8ad82e441df25e6186"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
 dependencies = [
  "cc",
  "libc",
@@ -2016,14 +2011,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2070,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2252,7 +2247,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2339,7 +2334,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest",
  "ring",
  "serde",
@@ -2448,7 +2443,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2511,18 +2506,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2534,12 +2529,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -2564,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2582,18 +2571,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2792,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -2829,7 +2818,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2852,7 +2841,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2884,9 +2873,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2895,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2905,13 +2894,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2954,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -2969,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -3077,7 +3066,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3145,15 +3134,15 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -3185,7 +3174,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3203,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -3230,9 +3219,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3353,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3402,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3685,7 +3674,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1 0.10.6",
@@ -3723,7 +3712,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3891,7 +3880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -3965,9 +3954,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3990,9 +3979,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4007,9 +3996,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4053,9 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4068,18 +4057,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4089,24 +4078,24 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -4130,14 +4119,14 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4147,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
 dependencies = [
  "prost",
  "tokio",
@@ -4160,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -4171,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4187,9 +4176,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-reflection"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf0685a51e6d02b502ba0764002e766b7f3042aed13d9234925b6ffbfa3fca7"
+checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
 dependencies = [
  "prost",
  "prost-types",
@@ -4220,21 +4209,21 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4335,9 +4324,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -4428,9 +4417,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4483,11 +4472,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4496,7 +4485,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4507,9 +4496,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4520,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4530,9 +4519,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4540,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4553,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4609,9 +4598,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4633,14 +4622,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4677,7 +4666,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4818,6 +4807,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4849,11 +4856,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4878,6 +4902,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4888,6 +4918,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4902,10 +4938,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4920,6 +4968,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,6 +4984,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4944,6 +5004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4956,10 +5022,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "1.0.1"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -4972,6 +5044,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5054,9 +5132,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -5069,9 +5147,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5080,9 +5158,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5112,18 +5190,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5139,9 +5217,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5150,9 +5228,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5161,9 +5239,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ gethostname = "1"
 h2 = "0.4"
 harmonia-store-aterm = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-store-core = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-nar-info = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-path-info = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-hash = { git = "https://github.com/nix-community/harmonia.git" }
 hashbrown = "0.16"
@@ -106,5 +108,7 @@ test-utils       = { path = "subprojects/crates/test-utils" }
 [patch.crates-io]
 harmonia-store-aterm         = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-store-core          = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-nar-info      = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-path-info     = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-hash          = { git = "https://github.com/nix-community/harmonia.git" }

--- a/cargo-output-hashes.nix
+++ b/cargo-output-hashes.nix
@@ -1,5 +1,5 @@
 # Shared outputHashes for cargoLock across all Rust crates.
 # Update this file when the harmonia dependency changes.
 {
-  "harmonia-store-core-0.0.0-alpha.0" = "sha256-zx1fIAQ7S3OI/uo198s0HlMaidnNvc/3ydGwEiyGiKQ=";
+  "harmonia-store-core-0.0.0-alpha.0" = "sha256-jpa6kwJh/+TwfVFioWHC5R1zwVR1XdiFqbZdfKoK6f8=";
 }

--- a/packaging/dev-shell.nix
+++ b/packaging/dev-shell.nix
@@ -47,6 +47,7 @@ hydra.overrideAttrs (
 
     nativeBuildInputs = collectInputs "nativeBuildInputs" ++ [
       foreman
+      pkgs.cargo-nextest
       pkgs.clippy
       pkgs.nixfmt
       pkgs.rustfmt

--- a/subprojects/crates/binary-cache/Cargo.toml
+++ b/subprojects/crates/binary-cache/Cargo.toml
@@ -37,9 +37,11 @@ tokio = { workspace = true, features = [ "full" ] }
 tokio-stream = { workspace = true, features = [ "io-util" ] }
 tokio-util = { workspace = true, features = [ "io", "io-util" ] }
 
-harmonia-store-core.workspace = true
-harmonia-utils-hash.workspace = true
-nix-utils.workspace           = true
+harmonia-store-core.workspace      = true
+harmonia-store-nar-info.workspace  = true
+harmonia-store-path-info.workspace = true
+harmonia-utils-hash.workspace      = true
+nix-utils.workspace                = true
 
 [dev-dependencies]
 hydra-tracing.workspace = true

--- a/subprojects/crates/binary-cache/examples/download_file.rs
+++ b/subprojects/crates/binary-cache/examples/download_file.rs
@@ -23,7 +23,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     tracing::info!("narinfo:\n{narinfo:?}");
 
-    let nardata = client.download_nar(&narinfo.unwrap().url).await?;
+    let nardata = client
+        .download_nar(narinfo.unwrap().info.url.as_deref().unwrap_or(""))
+        .await?;
     tracing::info!("nardata len: {}", nardata.unwrap().len());
 
     let stats = client.s3_stats();

--- a/subprojects/crates/binary-cache/examples/simple_presigned.rs
+++ b/subprojects/crates/binary-cache/examples/simple_presigned.rs
@@ -40,8 +40,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let presigned_request = client
                     .generate_nar_upload_presigned_url(
-                        &narinfo.store_path,
-                        &format!("{}", narinfo.nar_hash.as_base32()),
+                        &narinfo.path,
+                        &format!("{}", narinfo.info.info.nar_hash.as_base32()),
                         binary_cache::get_debug_info_build_ids(&store, &p).await?,
                     )
                     .await?;

--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -38,7 +38,10 @@ pub use crate::cfg::{S3CacheConfig, S3ClientConfig, S3CredentialsConfig, S3Schem
 pub use crate::compression::Compression;
 pub use crate::debug_info::get_debug_info_build_ids;
 use crate::narinfo::NarInfoError;
-pub use crate::narinfo::{NarInfo, parse_hash};
+pub use crate::narinfo::{
+    NarInfo, clear_sigs_and_sign, format_narinfo_txt, get_ls_path, narinfo_from_path_info,
+    narinfo_simple, parse_hash, parse_nar_hash, parse_narinfo, render_narinfo,
+};
 pub use crate::presigned::{
     PresignedUpload, PresignedUploadClient, PresignedUploadMetrics, PresignedUploadResponse,
     PresignedUploadResult,
@@ -55,16 +58,13 @@ pub async fn path_to_narinfo(
             path: path.to_string(),
         });
     };
-    let narinfo = NarInfo::simple(path, path_info, Compression::None);
+    let narinfo = narinfo_simple(path, path_info, Compression::None, store.get_store_dir());
     let queried_references = store
-        .query_path_infos(&narinfo.references.iter().collect::<Vec<_>>())
+        .query_path_infos(&narinfo.info.info.references.iter().collect::<Vec<_>>())
         .await;
-    for r in &narinfo.references {
+    for r in &narinfo.info.info.references {
         if !queried_references.contains_key(r) {
-            return Err(CacheError::ReferenceVerifyError(
-                narinfo.store_path,
-                r.to_owned(),
-            ));
+            return Err(CacheError::ReferenceVerifyError(narinfo.path, r.to_owned()));
         }
     }
     Ok(narinfo)
@@ -529,10 +529,14 @@ impl S3BinaryCacheClient {
         store_dir: &nix_utils::StoreDir,
         narinfo: NarInfo,
     ) -> Result<String, CacheError> {
-        let base = narinfo.store_path.hash().to_string();
+        let base = narinfo.path.hash().to_string();
         let info_key = format!("{base}.narinfo");
-        self.upsert_file(&info_key, narinfo.render(store_dir)?, "text/x-nix-narinfo")
-            .await?;
+        self.upsert_file(
+            &info_key,
+            render_narinfo(store_dir, &narinfo),
+            "text/x-nix-narinfo",
+        )
+        .await?;
         Ok(info_key)
     }
 
@@ -547,7 +551,7 @@ impl S3BinaryCacheClient {
                 path: path.to_string(),
             });
         };
-        let narinfo = NarInfo::new(
+        let narinfo = narinfo_from_path_info(
             path,
             path_info,
             self.cfg.compression,
@@ -555,14 +559,11 @@ impl S3BinaryCacheClient {
             &self.signing_keys,
         );
         let queried_references = store
-            .query_path_infos(&narinfo.references.iter().collect::<Vec<_>>())
+            .query_path_infos(&narinfo.info.info.references.iter().collect::<Vec<_>>())
             .await;
-        for r in &narinfo.references {
+        for r in &narinfo.info.info.references {
             if !queried_references.contains_key(r) {
-                return Err(CacheError::ReferenceVerifyError(
-                    narinfo.store_path,
-                    r.to_owned(),
-                ));
+                return Err(CacheError::ReferenceVerifyError(narinfo.path, r.to_owned()));
             }
         }
         Ok(narinfo)
@@ -582,13 +583,15 @@ impl S3BinaryCacheClient {
         tracing::debug!("start copying path: {path}");
         let mut narinfo = self.path_to_narinfo(store, path).await?;
         if self.cfg.write_nar_listing {
-            let ls = store.list_nar_deep(&narinfo.store_path).await?;
-            self.upload_listing(&narinfo.get_ls_path(), ls).await?;
+            let ls = store.list_nar_deep(&narinfo.path).await?;
+            self.upload_listing(&get_ls_path(&narinfo), ls).await?;
         }
 
+        let nar_url = narinfo.info.url.clone().unwrap_or_default();
+        let compression = self.cfg.compression;
+
         if self.cfg.write_debug_info {
-            debug_info::process_debug_info(&narinfo.url, store, &narinfo.store_path, self.clone())
-                .await?;
+            debug_info::process_debug_info(&nar_url, store, &narinfo.path, self.clone()).await?;
         }
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();
@@ -598,7 +601,7 @@ impl S3BinaryCacheClient {
         };
 
         tokio::task::spawn({
-            let path = narinfo.store_path.clone();
+            let path = narinfo.path.clone();
             let store = store.clone();
             async move {
                 let _ = store.nar_from_path(&path, closure);
@@ -607,17 +610,17 @@ impl S3BinaryCacheClient {
         let stream = tokio_util::io::StreamReader::new(
             tokio_stream::wrappers::UnboundedReceiverStream::new(rx),
         );
-        let compressor = narinfo.compression.get_compression_fn(
+        let compressor = compression.get_compression_fn(
             self.cfg.get_compression_level(),
             self.cfg.parallel_compression,
         );
         let compressed_stream = compressor(stream);
         let (mut hashing_reader, _) = streaming_hash::HashingReader::new(compressed_stream);
         self.upload_file(
-            &narinfo.url,
+            &nar_url,
             &mut hashing_reader,
-            narinfo.compression.content_type(),
-            narinfo.compression.content_encoding(),
+            compression.content_type(),
+            compression.content_encoding(),
         )
         .await?;
 
@@ -626,8 +629,8 @@ impl S3BinaryCacheClient {
         if let Ok(file_hash) =
             Hash::from_slice(harmonia_utils_hash::Algorithm::SHA256, file_hash.as_slice())
         {
-            narinfo.file_hash = Some(file_hash);
-            narinfo.file_size = Some(file_size as u64);
+            narinfo.info.download_hash = Some(file_hash);
+            narinfo.info.download_size = Some(file_size as u64);
         }
 
         // Realisation writing for CA derivations is handled by the caller
@@ -698,7 +701,7 @@ impl S3BinaryCacheClient {
             .await?
         {
             Some(v) => {
-                let narinfo: NarInfo = String::from_utf8_lossy(&v).parse()?;
+                let narinfo = parse_narinfo(&String::from_utf8_lossy(&v))?;
                 self.narinfo_cache
                     .insert(store_path.to_owned(), narinfo.clone())
                     .await;
@@ -884,21 +887,19 @@ impl S3BinaryCacheClient {
         narinfo: NarInfo,
     ) -> Result<String, CacheError> {
         if self.cfg.write_nar_listing {
-            self.head_object(&narinfo.get_ls_path())
+            let ls_path = get_ls_path(&narinfo);
+            self.head_object(&ls_path)
                 .await?
                 .then_some(())
-                .ok_or(CacheError::PathNotFound {
-                    path: narinfo.get_ls_path(),
-                })?;
+                .ok_or(CacheError::PathNotFound { path: ls_path })?;
         }
-        self.head_object(&narinfo.url)
+        let nar_url = narinfo.info.url.clone().unwrap_or_default();
+        self.head_object(&nar_url)
             .await?
             .then_some(())
-            .ok_or(CacheError::PathNotFound {
-                path: narinfo.url.clone(),
-            })?;
+            .ok_or(CacheError::PathNotFound { path: nar_url })?;
 
-        let narinfo = narinfo.clear_sigs_and_sign(store.get_store_dir(), &self.signing_keys);
+        let narinfo = clear_sigs_and_sign(narinfo, store.get_store_dir(), &self.signing_keys);
         // TODO: we also need to integarte realisation into this!
         self.upload_narinfo(store.get_store_dir(), narinfo).await
     }

--- a/subprojects/crates/binary-cache/src/narinfo.rs
+++ b/subprojects/crates/binary-cache/src/narinfo.rs
@@ -1,179 +1,180 @@
-use std::fmt::Write as _;
+use std::collections::BTreeSet;
 
-use harmonia_store_core::signature::{SecretKey, fingerprint_path};
+use harmonia_store_core::signature::{SecretKey, Signature, fingerprint_path};
 use harmonia_store_core::store_path::StoreDir;
+use harmonia_store_nar_info::{UnkeyedNarInfo, format_narinfo_txt as harmonia_format_narinfo_txt};
+use harmonia_store_path_info::{NarHash, UnkeyedValidPathInfo};
 use harmonia_utils_hash::Hash;
 use harmonia_utils_hash::fmt::CommonHash as _;
 use secrecy::ExposeSecret as _;
 
 use crate::Compression;
 
-#[derive(Debug, Clone)]
-pub struct NarInfo {
-    pub store_path: nix_utils::StorePath,
-    pub url: String,
-    pub compression: Compression,
-    pub file_hash: Option<Hash>,
-    pub file_size: Option<u64>,
-    pub nar_hash: Hash,
-    pub nar_size: u64,
-    pub references: Vec<nix_utils::StorePath>,
-    pub deriver: Option<nix_utils::StorePath>,
-    pub ca: Option<String>,
-    pub sigs: Vec<String>,
-}
+pub use harmonia_store_nar_info::NarInfo;
 
-impl NarInfo {
-    #[must_use]
-    pub fn new(
-        path: &nix_utils::StorePath,
-        path_info: nix_utils::PathInfo,
-        compression: Compression,
-        store_dir: &StoreDir,
-        signing_keys: &[secrecy::SecretString],
-    ) -> Self {
-        let nar_hash = parse_hash(&path_info.nar_hash);
-        let nar_hash_url = nar_hash.as_ref().map_or_else(
-            || path.hash().to_string(),
-            |h| format!("{:#}", h.as_base32()),
-        );
-
-        let narinfo = Self {
-            store_path: path.clone(),
-            url: format!("nar/{}.{}", nar_hash_url, compression.ext()),
-            compression,
-            file_hash: None,
-            file_size: None,
-            nar_hash: nar_hash.unwrap_or_else(|| {
-                Hash::from_slice(harmonia_utils_hash::Algorithm::SHA256, &[0; 32])
-                    .expect("sha256 zero hash")
-            }),
-            nar_size: path_info.nar_size,
-            references: path_info.refs,
-            deriver: path_info.deriver,
-            ca: path_info.ca.clone(),
-            sigs: vec![],
-        };
-
-        let mut narinfo = narinfo.clear_sigs_and_sign(store_dir, signing_keys);
-        if narinfo.sigs.is_empty() && !path_info.sigs.is_empty() {
-            narinfo.sigs = path_info.sigs;
-        }
-
-        narinfo
-    }
-
-    #[must_use]
-    pub fn simple(
-        path: &nix_utils::StorePath,
-        path_info: nix_utils::PathInfo,
-        compression: Compression,
-    ) -> Self {
-        let nar_hash = parse_hash(&path_info.nar_hash);
-        let nar_hash_url = nar_hash.as_ref().map_or_else(
-            || path.hash().to_string(),
-            |h| format!("{:#}", h.as_base32()),
-        );
-
-        Self {
-            store_path: path.clone(),
-            url: format!("nar/{}.{}", nar_hash_url, compression.ext()),
-            compression,
-            file_hash: None,
-            file_size: None,
-            nar_hash: nar_hash.unwrap_or_else(|| {
-                Hash::from_slice(harmonia_utils_hash::Algorithm::SHA256, &[0; 32])
-                    .expect("sha256 zero hash")
-            }),
-            nar_size: path_info.nar_size,
-            references: path_info.refs,
-            deriver: path_info.deriver,
-            ca: path_info.ca,
-            sigs: vec![],
-        }
-    }
-
-    #[must_use]
-    pub fn clear_sigs_and_sign(
-        mut self,
-        store_dir: &StoreDir,
-        signing_keys: &[secrecy::SecretString],
-    ) -> Self {
-        self.sigs.clear();
-        if !signing_keys.is_empty()
-            && let Some(fp) = self.fingerprint(store_dir)
-        {
-            for s in signing_keys {
-                if let Ok(sk) = s.expose_secret().parse::<SecretKey>() {
-                    self.sigs.push(sk.sign(&fp).to_string());
-                }
-            }
-        }
-        self
-    }
-
-    #[must_use]
-    fn fingerprint(&self, store_dir: &StoreDir) -> Option<Vec<u8>> {
-        let refs = self.references.iter().cloned().collect();
-        let nar_hash_str = format!("{}", self.nar_hash.as_base32());
-        fingerprint_path(
-            store_dir,
-            &self.store_path,
-            nar_hash_str.as_bytes(),
-            self.nar_size,
-            &refs,
-        )
-        .ok()
-    }
-
-    #[must_use]
-    pub fn get_ls_path(&self) -> String {
-        format!("{}.ls", self.store_path.hash())
-    }
-
-    pub fn render(&self, store_dir: &StoreDir) -> Result<String, std::fmt::Error> {
-        let mut o = String::with_capacity(200);
-        writeln!(o, "StorePath: {}", store_dir.display(&self.store_path))?;
-        writeln!(o, "URL: {}", self.url)?;
-        writeln!(o, "Compression: {}", self.compression.as_str())?;
-        if let Some(h) = &self.file_hash {
-            writeln!(o, "FileHash: {}", h.as_base32())?;
-        }
-        if let Some(s) = self.file_size {
-            writeln!(o, "FileSize: {s}")?;
-        }
-        writeln!(o, "NarHash: {}", self.nar_hash.as_base32())?;
-        writeln!(o, "NarSize: {}", self.nar_size)?;
-
-        writeln!(
-            o,
-            "References: {}",
-            self.references
-                .iter()
-                .map(nix_utils::StorePath::to_string)
-                .collect::<Vec<_>>()
-                .join(" ")
-        )?;
-
-        if let Some(d) = &self.deriver {
-            writeln!(o, "Deriver: {d}")?;
-        }
-        if let Some(ca) = &self.ca {
-            writeln!(o, "CA: {ca}")?;
-        }
-
-        for sig in &self.sigs {
-            writeln!(o, "Sig: {sig}")?;
-        }
-        Ok(o)
-    }
-}
+/// Re-export the harmonia narinfo formatter.
+pub use harmonia_store_nar_info::format_narinfo_txt;
 
 /// Parse a hash string (in any format: hex, nix32, sri) into a typed `Hash`.
 pub fn parse_hash(raw: &str) -> Option<Hash> {
     raw.parse::<harmonia_utils_hash::fmt::Any<Hash>>()
         .map(harmonia_utils_hash::fmt::Any::into_hash)
         .ok()
+}
+
+/// Parse a hash string into a `NarHash` (SHA256 only).
+pub fn parse_nar_hash(raw: &str) -> Option<NarHash> {
+    parse_hash(raw).and_then(|h| NarHash::try_from(h).ok())
+}
+
+/// Build a `NarInfo` from a `nix_utils::PathInfo`, optionally signing it.
+pub fn narinfo_from_path_info(
+    path: &nix_utils::StorePath,
+    path_info: nix_utils::PathInfo,
+    compression: Compression,
+    store_dir: &StoreDir,
+    signing_keys: &[secrecy::SecretString],
+) -> NarInfo {
+    let nar_hash = parse_nar_hash(&path_info.nar_hash)
+        .unwrap_or_else(|| NarHash::from_slice(&[0; 32]).expect("sha256 zero hash"));
+
+    let nar_hash_url = {
+        let h: Hash = nar_hash.into();
+        format!("{:#}", h.as_base32())
+    };
+
+    let references: BTreeSet<nix_utils::StorePath> = path_info.refs.into_iter().collect();
+    let signatures: BTreeSet<Signature> = path_info
+        .sigs
+        .iter()
+        .filter_map(|s| s.parse().ok())
+        .collect();
+
+    let ca = path_info.ca.as_deref().and_then(|s| s.parse().ok());
+
+    let unkeyed = UnkeyedValidPathInfo {
+        deriver: path_info.deriver,
+        nar_hash,
+        references: references.clone(),
+        registration_time: std::num::NonZero::new(path_info.registration_time),
+        nar_size: path_info.nar_size,
+        ultimate: false,
+        signatures: signatures.clone(),
+        ca,
+        store_dir: store_dir.clone(),
+    };
+
+    let url = format!("nar/{}.{}", nar_hash_url, compression.ext());
+
+    let mut narinfo = NarInfo {
+        path: path.clone(),
+        info: UnkeyedNarInfo {
+            info: unkeyed,
+            url: Some(url),
+            compression: Some(compression.as_str().to_owned()),
+            download_hash: None,
+            download_size: None,
+        },
+    };
+
+    // Sign with the provided signing keys (clears existing sigs first)
+    narinfo = clear_sigs_and_sign(narinfo, store_dir, signing_keys);
+
+    // If signing produced no sigs but path_info had sigs, restore them
+    if narinfo.info.info.signatures.is_empty() && !signatures.is_empty() {
+        narinfo.info.info.signatures = signatures;
+    }
+
+    narinfo
+}
+
+/// Build a simple `NarInfo` without signing.
+pub fn narinfo_simple(
+    path: &nix_utils::StorePath,
+    path_info: nix_utils::PathInfo,
+    compression: Compression,
+    store_dir: &StoreDir,
+) -> NarInfo {
+    let nar_hash = parse_nar_hash(&path_info.nar_hash)
+        .unwrap_or_else(|| NarHash::from_slice(&[0; 32]).expect("sha256 zero hash"));
+
+    let nar_hash_url = {
+        let h: Hash = nar_hash.into();
+        format!("{:#}", h.as_base32())
+    };
+
+    let references: BTreeSet<nix_utils::StorePath> = path_info.refs.into_iter().collect();
+    let signatures: BTreeSet<Signature> = path_info
+        .sigs
+        .iter()
+        .filter_map(|s| s.parse().ok())
+        .collect();
+    let ca = path_info.ca.as_deref().and_then(|s| s.parse().ok());
+
+    NarInfo {
+        path: path.clone(),
+        info: UnkeyedNarInfo {
+            info: UnkeyedValidPathInfo {
+                deriver: path_info.deriver,
+                nar_hash,
+                references,
+                registration_time: std::num::NonZero::new(path_info.registration_time),
+                nar_size: path_info.nar_size,
+                ultimate: false,
+                signatures,
+                ca,
+                store_dir: store_dir.clone(),
+            },
+            url: Some(format!("nar/{}.{}", nar_hash_url, compression.ext())),
+            compression: Some(compression.as_str().to_owned()),
+            download_hash: None,
+            download_size: None,
+        },
+    }
+}
+
+/// Clear signatures and re-sign with the provided signing keys.
+pub fn clear_sigs_and_sign(
+    mut narinfo: NarInfo,
+    store_dir: &StoreDir,
+    signing_keys: &[secrecy::SecretString],
+) -> NarInfo {
+    narinfo.info.info.signatures.clear();
+    if !signing_keys.is_empty()
+        && let Some(fp) = narinfo_fingerprint(&narinfo, store_dir)
+    {
+        for s in signing_keys {
+            if let Ok(sk) = s.expose_secret().parse::<SecretKey>() {
+                narinfo.info.info.signatures.insert(sk.sign(&fp));
+            }
+        }
+    }
+    narinfo
+}
+
+fn narinfo_fingerprint(narinfo: &NarInfo, store_dir: &StoreDir) -> Option<Vec<u8>> {
+    let nar_hash_str = {
+        let h: Hash = narinfo.info.info.nar_hash.into();
+        format!("{}", h.as_base32())
+    };
+    fingerprint_path(
+        store_dir,
+        &narinfo.path,
+        nar_hash_str.as_bytes(),
+        narinfo.info.info.nar_size,
+        &narinfo.info.info.references,
+    )
+    .ok()
+}
+
+/// Return the `.ls` listing key for this narinfo.
+pub fn get_ls_path(narinfo: &NarInfo) -> String {
+    format!("{}.ls", narinfo.path.hash())
+}
+
+/// Render the narinfo as a text string (for upload).
+pub fn render_narinfo(store_dir: &StoreDir, narinfo: &NarInfo) -> String {
+    String::from_utf8_lossy(&harmonia_format_narinfo_txt(store_dir, narinfo)).into_owned()
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -191,139 +192,135 @@ pub enum NarInfoError {
     },
 }
 
-impl std::str::FromStr for NarInfo {
-    type Err = NarInfoError;
+/// Parse a narinfo text into a [`NarInfo`].
+///
+/// `FromStr` cannot be implemented directly on the re-exported type due to
+/// Rust's orphan rules, so this free function is provided instead.
+// TODO: harmonia should grow its own narinfo parser so we can use that instead
+#[tracing::instrument(skip(input), err)]
+#[allow(clippy::too_many_lines)]
+pub fn parse_narinfo(input: &str) -> Result<NarInfo, NarInfoError> {
+    let mut store_path_opt: Option<nix_utils::StorePath> = None;
+    let mut url_opt: Option<String> = None;
+    let mut compression_opt: Option<String> = None;
+    let mut file_hash: Option<Hash> = None;
+    let mut file_size: Option<u64> = None;
+    let mut nar_hash_opt: Option<NarHash> = None;
+    let mut nar_size: u64 = 0;
+    let mut have_nar_size = false;
+    let mut references: BTreeSet<nix_utils::StorePath> = BTreeSet::new();
+    let mut deriver: Option<nix_utils::StorePath> = None;
+    let mut ca_str: Option<String> = None;
+    let mut sigs: BTreeSet<Signature> = BTreeSet::new();
 
-    #[tracing::instrument(skip(input), err)]
-    #[allow(clippy::too_many_lines)]
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let mut out = Self {
-            store_path: nix_utils::parse_store_path("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bla"),
-            url: String::new(),
-            compression: Compression::None,
-            file_hash: None,
-            file_size: None,
-            nar_hash: Hash::from_slice(harmonia_utils_hash::Algorithm::SHA256, &[0; 32])
-                .expect("sha256 zero hash"),
-            nar_size: 0,
-            references: vec![],
-            deriver: None,
-            ca: None,
-            sigs: vec![],
+    for (idx, raw_line) in input.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let Some((k, v)) = line.split_once(':') else {
+            return Err(NarInfoError::Line {
+                line: line_no,
+                reason: "expected `Key: value`".into(),
+            });
         };
+        let key = k.trim();
+        let val = v
+            .strip_prefix(' ')
+            .map_or(v, |stripped| stripped)
+            .trim_end();
 
-        // Temporaries to know what was present
-        let mut have_store_path = false;
-        let mut have_url = false;
-        let mut have_compression = false;
-        let mut have_nar_hash = false;
-        let mut have_nar_size = false;
-
-        for (idx, raw_line) in input.lines().enumerate() {
-            let line_no = idx + 1;
-            let line = raw_line.trim();
-            if line.is_empty() || line.starts_with('#') {
-                continue;
+        match key {
+            "StorePath" => {
+                store_path_opt = Some(nix_utils::parse_store_path(val));
             }
-
-            let Some((k, v)) = line.split_once(':') else {
-                return Err(NarInfoError::Line {
-                    line: line_no,
-                    reason: "expected `Key: value`".into(),
-                });
-            };
-            let key = k.trim();
-            let val = v
-                .strip_prefix(' ')
-                .map_or(v, |stripped| stripped)
-                .trim_end();
-
-            match key {
-                "StorePath" => {
-                    out.store_path = nix_utils::parse_store_path(val);
-                    have_store_path = true;
-                }
-                "URL" => {
-                    out.url = val.to_string();
-                    have_url = true;
-                }
-                "Compression" => {
-                    out.compression = val.parse().map_err(|e| NarInfoError::InvalidField {
-                        field: "Compression".into(),
-                        value: e,
-                    })?;
-                    have_compression = true;
-                }
-                "FileHash" => {
-                    out.file_hash = parse_hash(val);
-                }
-                "FileSize" => {
-                    out.file_size = Some(val.parse::<u64>().map_err(|e| NarInfoError::Int {
-                        field: "FileSize",
-                        err: e,
-                    })?);
-                }
-                "NarHash" => {
-                    if let Some(h) = parse_hash(val) {
-                        out.nar_hash = h;
-                        have_nar_hash = true;
+            "URL" => {
+                url_opt = Some(val.to_string());
+            }
+            "Compression" => {
+                compression_opt = Some(val.to_string());
+            }
+            "FileHash" => {
+                file_hash = parse_hash(val);
+            }
+            "FileSize" => {
+                file_size = Some(val.parse::<u64>().map_err(|e| NarInfoError::Int {
+                    field: "FileSize",
+                    err: e,
+                })?);
+            }
+            "NarHash" => {
+                nar_hash_opt = parse_nar_hash(val);
+            }
+            "NarSize" => {
+                nar_size = val.parse::<u64>().map_err(|e| NarInfoError::Int {
+                    field: "NarSize",
+                    err: e,
+                })?;
+                have_nar_size = true;
+            }
+            "References" => {
+                references = val
+                    .split_whitespace()
+                    .filter(|s| !s.is_empty())
+                    .map(nix_utils::parse_store_path)
+                    .collect();
+            }
+            "Deriver" => {
+                deriver = if val.is_empty() {
+                    None
+                } else {
+                    Some(nix_utils::parse_store_path(val))
+                };
+            }
+            "CA" => {
+                ca_str = if val.is_empty() {
+                    None
+                } else {
+                    Some(val.to_string())
+                };
+            }
+            "Sig" => {
+                if !val.is_empty() {
+                    if let Ok(sig) = val.parse() {
+                        sigs.insert(sig);
                     }
                 }
-                "NarSize" => {
-                    out.nar_size = val.parse::<u64>().map_err(|e| NarInfoError::Int {
-                        field: "NarSize",
-                        err: e,
-                    })?;
-                    have_nar_size = true;
-                }
-                "References" => {
-                    let refs = val
-                        .split_whitespace()
-                        .filter(|s| !s.is_empty())
-                        .map(nix_utils::parse_store_path)
-                        .collect::<Vec<_>>();
-                    out.references = refs;
-                }
-                "Deriver" => {
-                    out.deriver = if val.is_empty() {
-                        None
-                    } else {
-                        Some(nix_utils::parse_store_path(val))
-                    };
-                }
-                "CA" => {
-                    out.ca = if val.is_empty() {
-                        None
-                    } else {
-                        Some(val.to_string())
-                    };
-                }
-                "Sig" => {
-                    if !val.is_empty() {
-                        out.sigs.push(val.to_string());
-                    }
-                }
-                _ => {}
             }
+            _ => {}
         }
-
-        // Validate requireds
-        if !have_store_path {
-            return Err(NarInfoError::MissingField("StorePath"));
-        }
-        if !have_url {
-            return Err(NarInfoError::MissingField("URL"));
-        }
-        if !have_compression {
-            return Err(NarInfoError::MissingField("Compression"));
-        }
-        if !have_nar_hash {
-            return Err(NarInfoError::MissingField("NarHash"));
-        }
-        if !have_nar_size {
-            return Err(NarInfoError::MissingField("NarSize"));
-        }
-
-        Ok(out)
     }
+
+    let store_path = store_path_opt.ok_or(NarInfoError::MissingField("StorePath"))?;
+    let url = url_opt.ok_or(NarInfoError::MissingField("URL"))?;
+    let compression = compression_opt.ok_or(NarInfoError::MissingField("Compression"))?;
+    let nar_hash = nar_hash_opt.ok_or(NarInfoError::MissingField("NarHash"))?;
+    if !have_nar_size {
+        return Err(NarInfoError::MissingField("NarSize"));
+    }
+
+    let ca = ca_str.as_deref().and_then(|s| s.parse().ok());
+
+    Ok(NarInfo {
+        path: store_path,
+        info: UnkeyedNarInfo {
+            info: UnkeyedValidPathInfo {
+                deriver,
+                nar_hash,
+                references,
+                registration_time: None,
+                nar_size,
+                ultimate: false,
+                signatures: sigs,
+                ca,
+                store_dir: StoreDir::default(),
+            },
+            url: Some(url),
+            compression: Some(compression),
+            download_hash: file_hash,
+            download_size: file_size,
+        },
+    })
 }

--- a/subprojects/crates/binary-cache/src/presigned.rs
+++ b/subprojects/crates/binary-cache/src/presigned.rs
@@ -112,13 +112,11 @@ impl PresignedUploadClient {
         mut narinfo: crate::NarInfo,
         req: PresignedUploadResponse,
     ) -> Result<crate::NarInfo, CacheError> {
-        narinfo.url = req.nar_url;
-        narinfo.compression = req.nar_upload.compression;
+        narinfo.info.url = Some(req.nar_url.clone());
+        narinfo.info.compression = Some(req.nar_upload.compression.as_str().to_owned());
 
         if let Some(ls_upload) = req.ls_upload {
-            let _ = self
-                .upload_ls(store, &narinfo.store_path, &ls_upload)
-                .await?;
+            let _ = self.upload_ls(store, &narinfo.path, &ls_upload).await?;
         }
 
         if !req.debug_info_upload.is_empty() {
@@ -127,19 +125,19 @@ impl PresignedUploadClient {
                 debug_info_urls: std::sync::Arc::new(req.debug_info_upload),
             };
             crate::debug_info::process_debug_info(
-                &narinfo.url,
+                &req.nar_url,
                 store,
-                &narinfo.store_path,
+                &narinfo.path,
                 debug_info_client.clone(),
             )
             .await?;
         }
 
         let upload_res = self
-            .upload_nar(store, &narinfo.store_path, &req.nar_upload)
+            .upload_nar(store, &narinfo.path, &req.nar_upload)
             .await?;
-        narinfo.file_hash = Some(upload_res.file_hash);
-        narinfo.file_size = Some(upload_res.file_size);
+        narinfo.info.download_hash = Some(upload_res.file_hash);
+        narinfo.info.download_size = Some(upload_res.file_size);
 
         Ok(narinfo)
     }

--- a/subprojects/crates/proto/Cargo.toml
+++ b/subprojects/crates/proto/Cargo.toml
@@ -6,10 +6,13 @@ license                = "GPL-3.0"
 rust-version.workspace = true
 
 [dependencies]
-harmonia-store-core.workspace = true
-prost.workspace               = true
-tonic.workspace               = true
-tonic-prost.workspace         = true
+harmonia-store-core.workspace      = true
+harmonia-store-nar-info.workspace  = true
+harmonia-store-path-info.workspace = true
+harmonia-utils-hash.workspace      = true
+prost.workspace                    = true
+tonic.workspace                    = true
+tonic-prost.workspace              = true
 
 db                         = { workspace = true, optional = true }
 store-path-utils.workspace = true

--- a/subprojects/crates/proto/src/lib.rs
+++ b/subprojects/crates/proto/src/lib.rs
@@ -13,7 +13,9 @@ pub mod nix {
     }
 }
 
-pub use nix::store::v1::{NarInfo, RelativeStorePath, StorePaths, ValidPathInfo};
+pub use nix::store::v1::{
+    NarInfo, RelativeStorePath, StorePaths, UnkeyedNarInfo, UnkeyedValidPathInfo, ValidPathInfo,
+};
 
 tonic::include_proto!("runner.v1");
 
@@ -41,6 +43,137 @@ impl TryFrom<RelativeStorePath> for store_path_utils::RelativeStorePath {
         })
     }
 }
+
+// -- NarInfo / ValidPathInfo conversions --
+
+use harmonia_utils_hash::Hash;
+use harmonia_utils_hash::fmt::CommonHash as _;
+
+fn parse_hash(raw: &str) -> Option<Hash> {
+    raw.parse::<harmonia_utils_hash::fmt::Any<Hash>>()
+        .map(harmonia_utils_hash::fmt::Any::into_hash)
+        .ok()
+}
+
+impl From<harmonia_store_path_info::UnkeyedValidPathInfo> for UnkeyedValidPathInfo {
+    fn from(v: harmonia_store_path_info::UnkeyedValidPathInfo) -> Self {
+        let nar_hash_obj: Hash = v.nar_hash.into();
+        Self {
+            deriver: v.deriver.map(ProtoStorePath::from),
+            nar_hash: format!("{}", nar_hash_obj.as_base32()),
+            references: v.references.into_iter().map(ProtoStorePath::from).collect(),
+            registration_time: v.registration_time.map(|t| t.get()),
+            nar_size: v.nar_size,
+            ultimate: v.ultimate,
+            signatures: v.signatures.iter().map(|s| s.to_string()).collect(),
+            ca: v.ca.map(|ca| ca.to_string()),
+            store_dir: v.store_dir.to_string(),
+        }
+    }
+}
+
+impl From<harmonia_store_nar_info::UnkeyedNarInfo> for UnkeyedNarInfo {
+    fn from(n: harmonia_store_nar_info::UnkeyedNarInfo) -> Self {
+        Self {
+            info: Some(n.info.into()),
+            url: n.url.unwrap_or_default(),
+            compression: n.compression.unwrap_or_default(),
+            file_hash: n
+                .download_hash
+                .map(|h| format!("{}", h.as_base32()))
+                .unwrap_or_default(),
+            file_size: n.download_size.unwrap_or(0),
+        }
+    }
+}
+
+impl From<harmonia_store_nar_info::NarInfo> for NarInfo {
+    fn from(n: harmonia_store_nar_info::NarInfo) -> Self {
+        Self {
+            path: Some(ProtoStorePath::from(n.path)),
+            info: Some(n.info.into()),
+        }
+    }
+}
+
+/// Error type for converting proto `NarInfo` to harmonia `NarInfo`.
+#[derive(Debug, Clone)]
+pub struct NarInfoConvertError(pub &'static str);
+
+impl std::fmt::Display for NarInfoConvertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+impl TryFrom<UnkeyedValidPathInfo> for harmonia_store_path_info::UnkeyedValidPathInfo {
+    type Error = NarInfoConvertError;
+
+    fn try_from(v: UnkeyedValidPathInfo) -> Result<Self, Self::Error> {
+        let raw_hash = parse_hash(&v.nar_hash).ok_or(NarInfoConvertError("invalid nar_hash"))?;
+        let nar_hash = harmonia_store_path_info::NarHash::try_from(raw_hash)
+            .map_err(|_| NarInfoConvertError("nar_hash is not sha256"))?;
+
+        Ok(Self {
+            deriver: v.deriver.map(|p| p.0),
+            nar_hash,
+            references: v.references.into_iter().map(|p| p.0).collect(),
+            registration_time: std::num::NonZero::new(v.registration_time.unwrap_or(0)),
+            nar_size: v.nar_size,
+            ultimate: v.ultimate,
+            signatures: v
+                .signatures
+                .into_iter()
+                .filter_map(|s| s.parse().ok())
+                .collect(),
+            ca: v.ca.as_deref().and_then(|s| s.parse().ok()),
+            store_dir: harmonia_store_core::store_path::StoreDir::new(&v.store_dir)
+                .unwrap_or_default(),
+        })
+    }
+}
+
+impl TryFrom<UnkeyedNarInfo> for harmonia_store_nar_info::UnkeyedNarInfo {
+    type Error = NarInfoConvertError;
+
+    fn try_from(n: UnkeyedNarInfo) -> Result<Self, Self::Error> {
+        let info = n
+            .info
+            .ok_or(NarInfoConvertError("missing info"))?
+            .try_into()?;
+        Ok(Self {
+            info,
+            url: if n.url.is_empty() { None } else { Some(n.url) },
+            compression: if n.compression.is_empty() {
+                None
+            } else {
+                Some(n.compression)
+            },
+            download_hash: parse_hash(&n.file_hash),
+            download_size: if n.file_size == 0 {
+                None
+            } else {
+                Some(n.file_size)
+            },
+        })
+    }
+}
+
+impl TryFrom<NarInfo> for harmonia_store_nar_info::NarInfo {
+    type Error = NarInfoConvertError;
+
+    fn try_from(n: NarInfo) -> Result<Self, Self::Error> {
+        let path = n.path.ok_or(NarInfoConvertError("missing path"))?.0;
+        let info = n
+            .info
+            .ok_or(NarInfoConvertError("missing info"))?
+            .try_into()?;
+        Ok(Self { path, info })
+    }
+}
+
+#[cfg(test)]
+mod tests;
 
 #[cfg(feature = "db")]
 impl From<StepStatus> for db::models::StepStatus {

--- a/subprojects/crates/proto/src/tests.rs
+++ b/subprojects/crates/proto/src/tests.rs
@@ -1,0 +1,92 @@
+use super::*;
+use std::collections::BTreeSet;
+
+use harmonia_store_core::store_path::StoreDir;
+use harmonia_store_path_info::NarHash;
+
+fn roundtrip(original: &harmonia_store_nar_info::NarInfo) -> harmonia_store_nar_info::NarInfo {
+    let proto: NarInfo = original.clone().into();
+    proto.try_into().unwrap()
+}
+
+#[test]
+fn narinfo_roundtrip_minimal() {
+    let ni = harmonia_store_nar_info::NarInfo {
+        path: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello".parse().unwrap(),
+        info: harmonia_store_nar_info::UnkeyedNarInfo {
+            info: harmonia_store_path_info::UnkeyedValidPathInfo {
+                deriver: None,
+                nar_hash: NarHash::from_slice(&[0xab; 32]).unwrap(),
+                references: BTreeSet::from(["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-dep"
+                    .parse()
+                    .unwrap()]),
+                registration_time: None,
+                nar_size: 12345,
+                ultimate: false,
+                signatures: BTreeSet::new(),
+                ca: None,
+                store_dir: StoreDir::new("/nix/store").unwrap(),
+            },
+            url: Some("nar/abc.nar".to_owned()),
+            compression: Some("zstd".to_owned()),
+            download_hash: None,
+            download_size: None,
+        },
+    };
+    assert_eq!(roundtrip(&ni), ni);
+}
+
+#[test]
+fn narinfo_roundtrip_with_download_info() {
+    let ni = harmonia_store_nar_info::NarInfo {
+        path: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello".parse().unwrap(),
+        info: harmonia_store_nar_info::UnkeyedNarInfo {
+            info: harmonia_store_path_info::UnkeyedValidPathInfo {
+                deriver: Some("cccccccccccccccccccccccccccccccc-drv.drv".parse().unwrap()),
+                nar_hash: NarHash::from_slice(&[0xcd; 32]).unwrap(),
+                references: BTreeSet::new(),
+                registration_time: None,
+                nar_size: 99999,
+                ultimate: false,
+                signatures: BTreeSet::new(),
+                ca: None,
+                store_dir: StoreDir::new("/nix/store").unwrap(),
+            },
+            url: Some("nar/xyz.nar.zst".to_owned()),
+            compression: Some("zstd".to_owned()),
+            download_hash: parse_hash("sha256:1b2m2y8asgthdy6knt0d3k5z6s8p7nd0df8sm3k"),
+            download_size: Some(9999),
+        },
+    };
+    assert_eq!(roundtrip(&ni), ni);
+}
+
+#[test]
+fn narinfo_missing_path_fails() {
+    let proto = NarInfo {
+        path: None,
+        info: Some(nix::store::v1::UnkeyedNarInfo {
+            info: None,
+            url: String::new(),
+            compression: String::new(),
+            file_hash: String::new(),
+            file_size: 0,
+        }),
+    };
+    let result: Result<harmonia_store_nar_info::NarInfo, _> = proto.try_into();
+    assert!(result.is_err());
+}
+
+#[test]
+fn narinfo_missing_info_fails() {
+    let proto = NarInfo {
+        path: Some(ProtoStorePath::from(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x"
+                .parse::<harmonia_store_core::store_path::StorePath>()
+                .unwrap(),
+        )),
+        info: None,
+    };
+    let result: Result<harmonia_store_nar_info::NarInfo, _> = proto.try_into();
+    assert!(result.is_err());
+}

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -5,7 +5,6 @@ use std::time::Instant;
 
 use anyhow::Context as _;
 use backon::RetryableWithContext as _;
-use binary_cache::harmonia_utils_hash::fmt::CommonHash as _;
 use futures::TryFutureExt as _;
 use hashbrown::HashMap;
 use tonic::Request;
@@ -1094,34 +1093,15 @@ async fn upload_single_nar_presigned(
     tracing::debug!(
         "Successfully uploaded presigned NAR for {} to {}",
         nar_path,
-        updated_narinfo.url
+        updated_narinfo.info.url.as_deref().unwrap_or("")
     );
 
-    if let (Some(file_hash), Some(file_size)) = (
-        updated_narinfo.file_hash.as_ref(),
-        updated_narinfo.file_size,
-    ) {
+    if updated_narinfo.info.download_hash.is_some() && updated_narinfo.info.download_size.is_some()
+    {
         let completion_msg = hydra_proto::PresignedUploadComplete {
             build_id: build_id.to_owned(),
             machine_id: machine_id.to_owned(),
-            nar_info: Some(hydra_proto::nix::store::v1::NarInfo {
-                path_info: Some(hydra_proto::nix::store::v1::ValidPathInfo {
-                    path: Some(ProtoStorePath::from(nar_path.clone())),
-                    nar_hash: format!("{}", updated_narinfo.nar_hash.as_base32()),
-                    nar_size: updated_narinfo.nar_size,
-                    references: updated_narinfo
-                        .references
-                        .iter()
-                        .map(|p| ProtoStorePath::from(p.clone()))
-                        .collect(),
-                    deriver: updated_narinfo.deriver.map(ProtoStorePath::from),
-                    ca: updated_narinfo.ca,
-                }),
-                url: updated_narinfo.url.clone(),
-                compression: updated_narinfo.compression.as_str().to_owned(),
-                file_hash: format!("{}", file_hash.as_base32()),
-                file_size,
-            }),
+            nar_info: Some(updated_narinfo.into()),
         };
 
         client

--- a/subprojects/hydra-queue-runner/Cargo.toml
+++ b/subprojects/hydra-queue-runner/Cargo.toml
@@ -52,14 +52,16 @@ prometheus               = { workspace = true, features = [ "process" ] }
 tower                    = { workspace = true, features = [ "util" ] }
 tower-http               = { workspace = true, features = [ "trace" ] }
 
-binary-cache.workspace        = true
-db.workspace                  = true
-harmonia-store-core.workspace = true
-hydra-proto                   = { workspace = true, features = [ "db", "server" ] }
-hydra-tracing                 = { workspace = true, features = [ "tonic" ] }
-nix-utils.workspace           = true
-shared.workspace              = true
-store-path-utils.workspace    = true
+binary-cache.workspace             = true
+db.workspace                       = true
+harmonia-store-core.workspace      = true
+harmonia-store-nar-info.workspace  = true
+harmonia-store-path-info.workspace = true
+hydra-proto                        = { workspace = true, features = [ "db", "server" ] }
+hydra-tracing                      = { workspace = true, features = [ "tonic" ] }
+nix-utils.workspace                = true
+shared.workspace                   = true
+store-path-utils.workspace         = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator.workspace = true

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -782,32 +782,29 @@ impl RunnerService for Server {
                 .ok_or_else(|| tonic::Status::failed_precondition("No remote store configured"))?
         };
 
-        let nar_info = req
+        let proto_nar_info = req
             .nar_info
             .ok_or_else(|| tonic::Status::invalid_argument("missing nar_info"))?;
-        let path_info = nar_info
-            .path_info
-            .ok_or_else(|| tonic::Status::invalid_argument("missing path_info"))?;
-        let store_path = path_info
-            .path
-            .ok_or_else(|| tonic::Status::invalid_argument("missing store_path"))?
-            .0;
 
-        let narinfo = binary_cache::NarInfo {
-            store_path: store_path.clone(),
-            url: nar_info.url.clone(),
-            compression: remote_store.cfg.compression,
-            file_hash: binary_cache::parse_hash(&nar_info.file_hash),
-            file_size: Some(nar_info.file_size),
-            nar_hash: binary_cache::parse_hash(&path_info.nar_hash).ok_or_else(|| {
-                tonic::Status::invalid_argument(format!("invalid nar hash: {}", path_info.nar_hash))
-            })?,
-            nar_size: path_info.nar_size,
-            references: path_info.references.into_iter().map(|p| p.0).collect(),
-            deriver: path_info.deriver.map(|p| p.0),
-            ca: path_info.ca,
-            sigs: vec![],
-        };
+        let mut narinfo: binary_cache::NarInfo = proto_nar_info
+            .try_into()
+            .map_err(|e: hydra_proto::NarInfoConvertError| tonic::Status::invalid_argument(e.0))?;
+
+        if &narinfo.info.info.store_dir != self.state.store.get_store_dir() {
+            return Err(tonic::Status::invalid_argument(format!(
+                "store_dir mismatch: expected {}, got {}",
+                self.state.store.get_store_dir(),
+                narinfo.info.info.store_dir
+            )));
+        }
+
+        let store_path = narinfo.path.clone();
+
+        // Override compression from server config
+        narinfo.info.compression = Some(remote_store.cfg.compression.as_str().to_owned());
+
+        let url = narinfo.info.url.clone();
+        let size = narinfo.info.download_size;
 
         let narinfo_url = remote_store
             .upload_narinfo_after_presigned_upload(&self.state.store, narinfo)
@@ -818,10 +815,10 @@ impl RunnerService for Server {
             })?;
 
         tracing::debug!(
-            "Presigned upload completed and narinfo uploaded for path: {}, url: {}, size: {} bytes, narinfo: {}",
+            "Presigned upload completed and narinfo uploaded for path: {}, url: {:?}, size: {:?} bytes, narinfo: {}",
             store_path,
-            nar_info.url,
-            nar_info.file_size,
+            url,
+            size,
             narinfo_url
         );
 

--- a/subprojects/proto/v1/store.proto
+++ b/subprojects/proto/v1/store.proto
@@ -15,19 +15,32 @@ message RelativeStorePath {
   string sub_path = 2;
 }
 
-message ValidPathInfo {
-  StorePath path = 1;
+message UnkeyedValidPathInfo {
+  optional StorePath deriver = 1;
   string nar_hash = 2;
-  uint64 nar_size = 3;
-  repeated StorePath references = 4;
-  optional StorePath deriver = 5;
-  optional string ca = 6;
+  repeated StorePath references = 3;
+  optional int64 registration_time = 4;
+  uint64 nar_size = 5;
+  bool ultimate = 6;
+  repeated string signatures = 7;
+  optional string ca = 8;
+  string store_dir = 9;
 }
 
-message NarInfo {
-  ValidPathInfo path_info = 1;
+message ValidPathInfo {
+  StorePath path = 1;
+  UnkeyedValidPathInfo info = 2;
+}
+
+message UnkeyedNarInfo {
+  UnkeyedValidPathInfo info = 1;
   string url = 2;
   string compression = 3;
   string file_hash = 4;
   uint64 file_size = 5;
+}
+
+message NarInfo {
+  StorePath path = 1;
+  UnkeyedNarInfo info = 2;
 }


### PR DESCRIPTION
The `binary-cache` crate had its own `NarInfo` struct that duplicated what harmonia now provides as `harmonia_store_nar_info::NarInfo`. This replaces it with the upstream type, which also brings in `harmonia-store-path-info` for `ValidPathInfo`/`UnkeyedValidPathInfo`.

The local struct was flat; the harmonia type is nested: `NarInfo { path, info: UnkeyedNarInfo { info: UnkeyedValidPathInfo, url, compression, ... } }`. All construction and field access sites are updated accordingly.

`From<harmonia_store_nar_info::NarInfo>` and `TryFrom<proto::NarInfo>` conversions are added in the proto crate so both components can convert between native and wire representations without manual field-by-field marshalling. Round-trip unit tests verify the conversion is lossless.

Also adds `store_dir` field to proto `ValidPathInfo` to match the harmonia type. The queue-runner now asserts the store dir matches rather than silently overriding it.