### PR TITLE
Remove harmonia re-exports from `nix-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fs-err",
+ "harmonia-store-core",
  "nix-utils",
  "regex",
  "sha2 0.10.9",

--- a/subprojects/crates/binary-cache/examples/upload_realisation.rs
+++ b/subprojects/crates/binary-cache/examples/upload_realisation.rs
@@ -1,4 +1,5 @@
 use binary_cache::S3BinaryCacheClient;
+use harmonia_store_core::realisation::DrvOutput;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
     tracing::info!("{:#?}", client.cfg);
 
-    let id = nix_utils::DrvOutput {
+    let id = DrvOutput {
         drv_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bash-5.2p37.drv"
             .parse()
             .unwrap(),

--- a/subprojects/crates/binary-cache/src/debug_info.rs
+++ b/subprojects/crates/binary-cache/src/debug_info.rs
@@ -4,6 +4,7 @@
 //! from NIX store paths that contain debug symbols in the standard
 //! `lib/debug/.build-id` directory structure.
 
+use harmonia_store_core::store_path::StorePath;
 use nix_utils::BaseStore as _;
 
 use crate::CacheError;
@@ -19,7 +20,7 @@ pub(crate) struct DebugInfoLink {
 pub(crate) async fn process_debug_info<C>(
     nar_url: &str,
     store: &nix_utils::LocalStore,
-    store_path: &nix_utils::StorePath,
+    store_path: &StorePath,
     client: C,
 ) -> Result<(), CacheError>
 where
@@ -54,7 +55,7 @@ where
 
 pub async fn get_debug_info_build_ids(
     store: &nix_utils::LocalStore,
-    store_path: &nix_utils::StorePath,
+    store_path: &StorePath,
 ) -> Result<Vec<String>, CacheError> {
     let full_path = store.print_store_path(store_path);
     let build_id_path = std::path::Path::new(&full_path).join("lib/debug/.build-id");
@@ -130,6 +131,8 @@ pub(crate) trait DebugInfoClient {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
+
+    use harmonia_store_core::store_path::StoreDir;
 
     use super::*;
 
@@ -236,7 +239,7 @@ mod tests {
             .unwrap();
 
         let mut local = nix_utils::LocalStore::init();
-        local.unsafe_set_store_dir(nix_utils::StoreDir::new(store_prefix.as_path()).unwrap());
+        local.unsafe_set_store_dir(StoreDir::new(store_prefix.as_path()).unwrap());
 
         process_debug_info("test.nar", &local, &store_path, mock_client.clone())
             .await
@@ -378,7 +381,7 @@ mod tests {
         fs_err::tokio::create_dir_all(&full_path).await.unwrap();
 
         let mut local = nix_utils::LocalStore::init();
-        local.unsafe_set_store_dir(nix_utils::StoreDir::new(store_prefix.as_path()).unwrap());
+        local.unsafe_set_store_dir(StoreDir::new(store_prefix.as_path()).unwrap());
 
         process_debug_info("test.nar", &local, &store_path, mock_client.clone())
             .await
@@ -405,7 +408,7 @@ mod tests {
         fs_err::tokio::create_dir_all(&build_id_dir).await.unwrap();
 
         let mut local = nix_utils::LocalStore::init();
-        local.unsafe_set_store_dir(nix_utils::StoreDir::new(store_prefix.as_path()).unwrap());
+        local.unsafe_set_store_dir(StoreDir::new(store_prefix.as_path()).unwrap());
 
         process_debug_info("test.nar", &local, &store_path, mock_client.clone())
             .await
@@ -446,7 +449,7 @@ mod tests {
         }
 
         let mut local = nix_utils::LocalStore::init();
-        local.unsafe_set_store_dir(nix_utils::StoreDir::new(store_prefix.as_path()).unwrap());
+        local.unsafe_set_store_dir(StoreDir::new(store_prefix.as_path()).unwrap());
 
         process_debug_info("multi.nar", &local, &store_path, mock_client.clone())
             .await

--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -24,6 +24,9 @@ use object_store::{ObjectStore as _, ObjectStoreExt as _, signer::Signer as _};
 use secrecy::ExposeSecret;
 use smallvec::SmallVec;
 
+use harmonia_store_core::derived_path::OutputName;
+use harmonia_store_core::realisation::{DrvOutput, Realisation};
+use harmonia_store_core::store_path::{StoreDir, StorePath};
 use nix_utils::BaseStore as _;
 // Realisation writing is now done by the caller, not via FFI query.
 
@@ -51,7 +54,7 @@ pub use harmonia_utils_hash::{self as harmonia_utils_hash, Hash};
 
 pub async fn path_to_narinfo(
     store: &nix_utils::LocalStore,
-    path: &nix_utils::StorePath,
+    path: &StorePath,
 ) -> Result<NarInfo, CacheError> {
     let Some(path_info) = store.query_path_info(path).await else {
         return Err(CacheError::PathNotFound {
@@ -139,7 +142,7 @@ pub enum CacheError {
     #[error(transparent)]
     NixStoreError(#[from] nix_utils::Error),
     #[error("cannot add '{0}' to the binary cache because the reference '{1}' is not valid")]
-    ReferenceVerifyError(nix_utils::StorePath, nix_utils::StorePath),
+    ReferenceVerifyError(StorePath, StorePath),
     #[error("Hash error: {0}")]
     HashingError(#[from] streaming_hash::Error),
     #[error("Render error: {0}")]
@@ -164,7 +167,7 @@ pub struct S3BinaryCacheClient {
     pub cfg: S3CacheConfig,
     s3_stats: Arc<AtomicS3Stats>,
     signing_keys: SmallVec<[secrecy::SecretString; 4]>,
-    narinfo_cache: Cache<nix_utils::StorePath, NarInfo, foldhash::fast::RandomState>,
+    narinfo_cache: Cache<StorePath, NarInfo, foldhash::fast::RandomState>,
 }
 
 #[tracing::instrument(skip(stream, chunk), err)]
@@ -526,7 +529,7 @@ impl S3BinaryCacheClient {
     #[tracing::instrument(skip(self, store_dir, narinfo), err)]
     async fn upload_narinfo(
         &self,
-        store_dir: &nix_utils::StoreDir,
+        store_dir: &StoreDir,
         narinfo: NarInfo,
     ) -> Result<String, CacheError> {
         let base = narinfo.path.hash().to_string();
@@ -544,7 +547,7 @@ impl S3BinaryCacheClient {
     async fn path_to_narinfo(
         &self,
         store: &nix_utils::LocalStore,
-        path: &nix_utils::StorePath,
+        path: &StorePath,
     ) -> Result<NarInfo, CacheError> {
         let Some(path_info) = store.query_path_info(path).await else {
             return Err(CacheError::PathNotFound {
@@ -573,7 +576,7 @@ impl S3BinaryCacheClient {
     pub async fn copy_path(
         &self,
         store: &nix_utils::LocalStore,
-        path: &nix_utils::StorePath,
+        path: &StorePath,
         repair: bool,
     ) -> Result<(), CacheError> {
         if !repair && self.has_narinfo(path).await? {
@@ -646,7 +649,7 @@ impl S3BinaryCacheClient {
     pub async fn copy_paths(
         &self,
         store: &nix_utils::LocalStore,
-        paths: Vec<nix_utils::StorePath>,
+        paths: Vec<StorePath>,
         repair: bool,
     ) -> Result<(), CacheError> {
         use futures::stream::StreamExt as _;
@@ -669,10 +672,7 @@ impl S3BinaryCacheClient {
     ///
     /// Signs the realisation with the cache's secret keys before uploading.
     #[tracing::instrument(skip(self, realisation), err)]
-    pub async fn write_realisation(
-        &self,
-        mut realisation: nix_utils::Realisation,
-    ) -> Result<(), CacheError> {
+    pub async fn write_realisation(&self, mut realisation: Realisation) -> Result<(), CacheError> {
         let keys = self
             .signing_keys
             .iter()
@@ -690,7 +690,7 @@ impl S3BinaryCacheClient {
     #[tracing::instrument(skip(self), err)]
     pub async fn download_narinfo(
         &self,
-        store_path: &nix_utils::StorePath,
+        store_path: &StorePath,
     ) -> Result<Option<NarInfo>, CacheError> {
         if let Some(narinfo) = self.narinfo_cache.get(store_path).await {
             return Ok(Some(narinfo));
@@ -717,7 +717,7 @@ impl S3BinaryCacheClient {
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn has_narinfo(&self, store_path: &nix_utils::StorePath) -> Result<bool, CacheError> {
+    pub async fn has_narinfo(&self, store_path: &StorePath) -> Result<bool, CacheError> {
         if self.narinfo_cache.contains_key(store_path) {
             return Ok(true);
         }
@@ -725,10 +725,7 @@ impl S3BinaryCacheClient {
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn download_realisation(
-        &self,
-        id: &nix_utils::DrvOutput,
-    ) -> Result<Option<String>, CacheError> {
+    pub async fn download_realisation(&self, id: &DrvOutput) -> Result<Option<String>, CacheError> {
         (self.get_object(&format!("realisations/{id}.doi")).await?).map_or_else(
             || Ok(None),
             |v| Ok(Some(String::from_utf8_lossy(&v).to_string())),
@@ -736,15 +733,12 @@ impl S3BinaryCacheClient {
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn has_realisation(&self, id: &nix_utils::DrvOutput) -> Result<bool, CacheError> {
+    pub async fn has_realisation(&self, id: &DrvOutput) -> Result<bool, CacheError> {
         Ok(self.download_realisation(id).await?.is_some())
     }
 
     #[tracing::instrument(skip(self, paths))]
-    pub async fn query_missing_paths(
-        &self,
-        paths: Vec<nix_utils::StorePath>,
-    ) -> Vec<nix_utils::StorePath> {
+    pub async fn query_missing_paths(&self, paths: Vec<StorePath>) -> Vec<StorePath> {
         use futures::stream::StreamExt as _;
 
         tokio_stream::iter(paths)
@@ -764,8 +758,8 @@ impl S3BinaryCacheClient {
     #[tracing::instrument(skip(self, outputs))]
     pub async fn query_missing_remote_outputs(
         &self,
-        outputs: BTreeMap<nix_utils::OutputName, Option<nix_utils::StorePath>>,
-    ) -> BTreeMap<nix_utils::OutputName, Option<nix_utils::StorePath>> {
+        outputs: BTreeMap<OutputName, Option<StorePath>>,
+    ) -> BTreeMap<OutputName, Option<StorePath>> {
         use futures::stream::StreamExt as _;
 
         tokio_stream::iter(outputs)
@@ -784,7 +778,7 @@ impl S3BinaryCacheClient {
     #[tracing::instrument(skip(self), err)]
     pub async fn generate_nar_upload_presigned_url(
         &self,
-        path: &nix_utils::StorePath,
+        path: &StorePath,
         nix32_nar_hash: &str,
         debug_info_build_ids: Vec<String>,
     ) -> Result<PresignedUploadResponse, CacheError> {

--- a/subprojects/crates/binary-cache/src/narinfo.rs
+++ b/subprojects/crates/binary-cache/src/narinfo.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use harmonia_store_core::signature::{SecretKey, Signature, fingerprint_path};
-use harmonia_store_core::store_path::StoreDir;
+use harmonia_store_core::store_path::{StoreDir, StorePath};
 use harmonia_store_nar_info::{UnkeyedNarInfo, format_narinfo_txt as harmonia_format_narinfo_txt};
 use harmonia_store_path_info::{NarHash, UnkeyedValidPathInfo};
 use harmonia_utils_hash::Hash;
@@ -29,7 +29,7 @@ pub fn parse_nar_hash(raw: &str) -> Option<NarHash> {
 
 /// Build a `NarInfo` from a `nix_utils::PathInfo`, optionally signing it.
 pub fn narinfo_from_path_info(
-    path: &nix_utils::StorePath,
+    path: &StorePath,
     path_info: nix_utils::PathInfo,
     compression: Compression,
     store_dir: &StoreDir,
@@ -43,7 +43,7 @@ pub fn narinfo_from_path_info(
         format!("{:#}", h.as_base32())
     };
 
-    let references: BTreeSet<nix_utils::StorePath> = path_info.refs.into_iter().collect();
+    let references: BTreeSet<StorePath> = path_info.refs.into_iter().collect();
     let signatures: BTreeSet<Signature> = path_info
         .sigs
         .iter()
@@ -90,7 +90,7 @@ pub fn narinfo_from_path_info(
 
 /// Build a simple `NarInfo` without signing.
 pub fn narinfo_simple(
-    path: &nix_utils::StorePath,
+    path: &StorePath,
     path_info: nix_utils::PathInfo,
     compression: Compression,
     store_dir: &StoreDir,
@@ -103,7 +103,7 @@ pub fn narinfo_simple(
         format!("{:#}", h.as_base32())
     };
 
-    let references: BTreeSet<nix_utils::StorePath> = path_info.refs.into_iter().collect();
+    let references: BTreeSet<StorePath> = path_info.refs.into_iter().collect();
     let signatures: BTreeSet<Signature> = path_info
         .sigs
         .iter()
@@ -200,7 +200,7 @@ pub enum NarInfoError {
 #[tracing::instrument(skip(input), err)]
 #[allow(clippy::too_many_lines)]
 pub fn parse_narinfo(input: &str) -> Result<NarInfo, NarInfoError> {
-    let mut store_path_opt: Option<nix_utils::StorePath> = None;
+    let mut store_path_opt: Option<StorePath> = None;
     let mut url_opt: Option<String> = None;
     let mut compression_opt: Option<String> = None;
     let mut file_hash: Option<Hash> = None;
@@ -208,8 +208,8 @@ pub fn parse_narinfo(input: &str) -> Result<NarInfo, NarInfoError> {
     let mut nar_hash_opt: Option<NarHash> = None;
     let mut nar_size: u64 = 0;
     let mut have_nar_size = false;
-    let mut references: BTreeSet<nix_utils::StorePath> = BTreeSet::new();
-    let mut deriver: Option<nix_utils::StorePath> = None;
+    let mut references: BTreeSet<StorePath> = BTreeSet::new();
+    let mut deriver: Option<StorePath> = None;
     let mut ca_str: Option<String> = None;
     let mut sigs: BTreeSet<Signature> = BTreeSet::new();
 

--- a/subprojects/crates/binary-cache/src/presigned.rs
+++ b/subprojects/crates/binary-cache/src/presigned.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use backon::Retryable;
 
 use bytes::Bytes;
+use harmonia_store_core::store_path::StorePath;
 use nix_utils::{BaseStore as _, LocalStore};
 
 use tokio_util::io::StreamReader;
@@ -146,7 +147,7 @@ impl PresignedUploadClient {
     async fn upload_nar(
         &self,
         store: &LocalStore,
-        store_path: &nix_utils::StorePath,
+        store_path: &StorePath,
         upload: &PresignedUpload,
     ) -> Result<PresignedUploadResult, CacheError> {
         let start = std::time::Instant::now();
@@ -200,7 +201,7 @@ impl PresignedUploadClient {
     async fn upload_ls(
         &self,
         store: &LocalStore,
-        store_path: &nix_utils::StorePath,
+        store_path: &StorePath,
         upload: &PresignedUpload,
     ) -> Result<PresignedUploadResult, CacheError> {
         let start = std::time::Instant::now();

--- a/subprojects/crates/nix-utils/src/drv.rs
+++ b/subprojects/crates/nix-utils/src/drv.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use harmonia_store_core::derived_path::OutputName;
 use harmonia_store_core::store_path::{StoreDir, StorePathName};
 
-pub use harmonia_store_core::derivation::Derivation;
+use harmonia_store_core::derivation::Derivation;
 
 use crate::StorePath;
 

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -18,6 +18,8 @@ mod store_path;
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use harmonia_store_core::derivation::{BasicDerivation, DerivationT};
+use harmonia_store_core::derived_path::{OutputName, SingleDerivedPath};
 use hashbrown::HashMap;
 
 #[derive(thiserror::Error, Debug)]
@@ -47,20 +49,11 @@ pub enum Error {
     Json(#[from] serde_json::Error),
 }
 
-pub use drv::{Derivation, output_paths, query_drv};
-pub use harmonia_store_core::derivation::{
-    BasicDerivation, DerivationOutput, DerivationOutputs, DerivationT,
-};
-pub use harmonia_store_core::derived_path::{
-    DerivedPath, OutputName, OutputSpec, SingleDerivedPath,
-};
-pub use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
-pub use harmonia_store_core::signature::Signature;
+pub use drv::{output_paths, query_drv};
 pub use realise::{BuildOptions, realise_drv, realise_drvs};
-pub use store_path::{
-    ParseStorePathError, StoreDir, StoreDirDisplay, StorePath, StorePathHash, StorePathName,
-    parse_store_path,
-};
+pub use store_path::parse_store_path;
+
+use harmonia_store_core::store_path::{StoreDir, StorePath};
 
 pub fn validate_statuscode(status: std::process::ExitStatus) -> Result<(), Error> {
     if status.success() {

--- a/subprojects/crates/nix-utils/src/realise.rs
+++ b/subprojects/crates/nix-utils/src/realise.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
+use harmonia_store_core::derived_path::{DerivedPath, OutputSpec, SingleDerivedPath};
+use harmonia_store_core::store_path::StorePath;
 use tokio::io::{AsyncBufReadExt as _, BufReader};
 use tokio_stream::wrappers::LinesStream;
 
 use crate::BaseStore as _;
-use crate::{DerivedPath, OutputSpec, SingleDerivedPath, StorePath};
 
 #[derive(Debug, Clone, Copy)]
 pub struct BuildOptions {

--- a/subprojects/crates/nix-utils/src/store_path.rs
+++ b/subprojects/crates/nix-utils/src/store_path.rs
@@ -1,7 +1,4 @@
-#[allow(unreachable_pub)]
-pub use harmonia_store_core::store_path::{
-    ParseStorePathError, StoreDir, StoreDirDisplay, StorePath, StorePathHash, StorePathName,
-};
+use harmonia_store_core::store_path::StorePath;
 
 /// Parse a store path from a string that may or may not have the store dir prefix.
 /// Handles paths inside store outputs (e.g. `/nix/store/hash-name/subdir/file`).

--- a/subprojects/crates/shared/Cargo.toml
+++ b/subprojects/crates/shared/Cargo.toml
@@ -13,4 +13,5 @@ sha2.workspace    = true
 tokio             = { workspace = true, features = [ "full" ] }
 tracing.workspace = true
 
-nix-utils.workspace = true
+harmonia-store-core.workspace = true
+nix-utils.workspace           = true

--- a/subprojects/crates/shared/src/lib.rs
+++ b/subprojects/crates/shared/src/lib.rs
@@ -20,7 +20,9 @@ use std::collections::BTreeMap;
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, BufReader};
 
-use nix_utils::{BaseStore as _, StorePath};
+use harmonia_store_core::derived_path::OutputName;
+use harmonia_store_core::store_path::{StoreDir, StorePath};
+use nix_utils::BaseStore as _;
 
 #[allow(clippy::expect_used)]
 static VALIDATE_METRICS_NAME: LazyLock<regex::Regex> =
@@ -93,7 +95,7 @@ trait FsOperations {
 
 #[derive(Debug, Clone)]
 struct FilesystemOperations {
-    store_dir: nix_utils::StoreDir,
+    store_dir: StoreDir,
 }
 
 impl FilesystemOperations {
@@ -247,7 +249,7 @@ where
 #[tracing::instrument(skip(store), err)]
 pub async fn parse_nix_support_from_outputs(
     store: &nix_utils::LocalStore,
-    derivation_outputs: &BTreeMap<nix_utils::OutputName, StorePath>,
+    derivation_outputs: &BTreeMap<OutputName, StorePath>,
 ) -> anyhow::Result<NixSupport> {
     let mut metrics = Vec::new();
     let mut failed = false;

--- a/subprojects/hydra-builder/src/grpc.rs
+++ b/subprojects/hydra-builder/src/grpc.rs
@@ -1,3 +1,4 @@
+use harmonia_store_core::store_path::StorePath;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
@@ -53,7 +54,7 @@ impl BuilderClient {
         &mut self,
         build_id: &str,
         machine_id: &str,
-        store_paths: Vec<(nix_utils::StorePath, String, Vec<String>)>,
+        store_paths: Vec<(StorePath, String, Vec<String>)>,
     ) -> anyhow::Result<Vec<hydra_proto::PresignedNarResponse>> {
         use hydra_proto::{PresignedNarRequest, PresignedUrlRequest};
 

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -1,3 +1,5 @@
+use harmonia_store_core::derived_path::OutputName;
+use harmonia_store_core::store_path::{ParseStorePathError, StorePath};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -18,7 +20,7 @@ use hydra_proto::{
     FetchRequisitesRequest, JoinMessage, NarData, NixSupport, Output, OutputNameOnly,
     OutputWithPath, PingMessage, StepStatus, StepUpdate, StorePaths, output,
 };
-use nix_utils::{BaseStore as _, OutputName};
+use nix_utils::BaseStore as _;
 
 const RETRY_MIN_DELAY: tokio::time::Duration = tokio::time::Duration::from_secs(3);
 const RETRY_MAX_DELAY: tokio::time::Duration = tokio::time::Duration::from_secs(90);
@@ -65,7 +67,7 @@ impl From<JobFailure> for BuildResultState {
 
 #[derive(Debug)]
 pub struct BuildInfo {
-    drv_path: nix_utils::StorePath,
+    drv_path: StorePath,
     handle: tokio::task::JoinHandle<()>,
     was_cancelled: Arc<AtomicBool>,
 }
@@ -339,7 +341,7 @@ impl State {
         Ok(())
     }
 
-    fn contains_build(&self, drv: &nix_utils::StorePath) -> bool {
+    fn contains_build(&self, drv: &StorePath) -> bool {
         let active = self.active_builds.read();
         active.values().any(|b| b.drv_path == *drv)
     }
@@ -504,10 +506,10 @@ impl State {
             )));
         }
 
-        let actual_out_drv: nix_utils::StorePath = store
+        let actual_out_drv: StorePath = store
             .store_dir()
             .parse(&output_raw[0].drv_path)
-            .map_err(|e: nix_utils::ParseStorePathError| JobFailure::PostProcessing(e.into()))?;
+            .map_err(|e: ParseStorePathError| JobFailure::PostProcessing(e.into()))?;
         if actual_out_drv != drv {
             return Err(JobFailure::PostProcessing(anyhow::anyhow!(
                 "Nix returned outputs for {actual_out_drv} when we expected {drv}"
@@ -519,13 +521,8 @@ impl State {
             .unwrap()
             .outputs
             .into_iter()
-            .map(|(name, path)| {
-                Ok((
-                    name,
-                    store.store_dir().parse::<nix_utils::StorePath>(&path)?,
-                ))
-            })
-            .collect::<anyhow::Result<BTreeMap<OutputName, nix_utils::StorePath>>>()
+            .map(|(name, path)| Ok((name, store.store_dir().parse::<StorePath>(&path)?)))
+            .collect::<anyhow::Result<BTreeMap<OutputName, StorePath>>>()
             .map_err(JobFailure::PostProcessing)?;
 
         for o in outputs.values() {
@@ -635,7 +632,7 @@ impl State {
     async fn upload_nars(
         &self,
         store: nix_utils::LocalStore,
-        nars: Vec<nix_utils::StorePath>,
+        nars: Vec<StorePath>,
         build_id: &str,
         machine_id: &str,
         presigned_url_opts: Option<hydra_proto::PresignedUploadOpts>,
@@ -661,8 +658,8 @@ impl State {
 async fn filter_missing(
     store: &nix_utils::LocalStore,
     gcroot: &Gcroot,
-    path: nix_utils::StorePath,
-) -> Option<nix_utils::StorePath> {
+    path: StorePath,
+) -> Option<StorePath> {
     if store.is_valid_path(&path).await {
         nix_utils::add_root(store, &gcroot.root, &path);
         None
@@ -673,7 +670,7 @@ async fn filter_missing(
 
 async fn substitute_paths(
     store: &nix_utils::LocalStore,
-    paths: &[nix_utils::StorePath],
+    paths: &[StorePath],
 ) -> anyhow::Result<()> {
     for p in paths {
         store.ensure_path(p).await?;
@@ -698,7 +695,7 @@ async fn import_paths(
     store: nix_utils::LocalStore,
     metrics: Arc<crate::metrics::Metrics>,
     gcroot: &Gcroot,
-    paths: Vec<nix_utils::StorePath>,
+    paths: Vec<StorePath>,
     filter: bool,
     use_substitutes: bool,
 ) -> anyhow::Result<()> {
@@ -765,12 +762,12 @@ async fn import_paths(
 
 #[tracing::instrument(skip(client, store, metrics, requisites), fields(%gcroot, %drv), err)]
 #[allow(clippy::too_many_arguments)]
-async fn import_requisites<T: IntoIterator<Item = nix_utils::StorePath>>(
+async fn import_requisites<T: IntoIterator<Item = StorePath>>(
     client: &mut BuilderClient,
     store: nix_utils::LocalStore,
     metrics: Arc<crate::metrics::Metrics>,
     gcroot: &Gcroot,
-    drv: &nix_utils::StorePath,
+    drv: &StorePath,
     requisites: T,
     max_concurrent_downloads: usize,
     use_substitutes: bool,
@@ -785,9 +782,8 @@ async fn import_requisites<T: IntoIterator<Item = nix_utils::StorePath>>(
     .collect::<Vec<_>>()
     .await;
 
-    let (input_drvs, input_srcs): (Vec<_>, Vec<_>) = requisites
-        .into_iter()
-        .partition(nix_utils::StorePath::is_derivation);
+    let (input_drvs, input_srcs): (Vec<_>, Vec<_>) =
+        requisites.into_iter().partition(StorePath::is_derivation);
 
     for srcs in input_srcs.chunks(max_concurrent_downloads) {
         import_paths(
@@ -857,7 +853,7 @@ async fn upload_nars_regular(
     mut client: BuilderClient,
     store: nix_utils::LocalStore,
     metrics: Arc<crate::metrics::Metrics>,
-    nars: Vec<nix_utils::StorePath>,
+    nars: Vec<StorePath>,
 ) -> anyhow::Result<()> {
     // Compute the full closure of output paths so that all referenced
     // store paths (e.g. dynamically-created derivations from recursive-nix)
@@ -958,7 +954,7 @@ async fn upload_nars_presigned(
     mut client: BuilderClient,
     upload_client: PresignedUploadClient,
     store: nix_utils::LocalStore,
-    output_paths: &[nix_utils::StorePath],
+    output_paths: &[StorePath],
     opts: hydra_proto::PresignedUploadOpts,
     build_id: &str,
     machine_id: &str,
@@ -1043,7 +1039,7 @@ async fn upload_nars_presigned(
 #[tracing::instrument(skip(store, nar_path, presigned_response), err)]
 async fn upload_single_nar_presigned(
     store: &nix_utils::LocalStore,
-    nar_path: &nix_utils::StorePath,
+    nar_path: &StorePath,
     build_id: &str,
     machine_id: &str,
     presigned_response: &hydra_proto::PresignedNarResponse,
@@ -1116,8 +1112,8 @@ async fn upload_single_nar_presigned(
 async fn new_success_build_result_info(
     store: nix_utils::LocalStore,
     machine_id: uuid::Uuid,
-    drv: &nix_utils::StorePath,
-    outputs: &BTreeMap<OutputName, nix_utils::StorePath>,
+    drv: &StorePath,
+    outputs: &BTreeMap<OutputName, StorePath>,
     timings: BuildTimings,
     build_id: String,
 ) -> anyhow::Result<BuildResultInfo> {

--- a/subprojects/hydra-builder/src/system.rs
+++ b/subprojects/hydra-builder/src/system.rs
@@ -1,3 +1,4 @@
+use harmonia_store_core::store_path::StoreDir;
 use hashbrown::HashMap;
 use procfs_core::FromRead as _;
 
@@ -159,7 +160,7 @@ impl SystemLoad {
         let meminfo = procfs_core::Meminfo::from_file("/proc/meminfo")?;
         let load = procfs_core::LoadAverage::from_file("/proc/loadavg")?;
 
-        let store_dir = nix_utils::StoreDir::new(
+        let store_dir = StoreDir::new(
             std::env::var("NIX_STORE_DIR").unwrap_or_else(|_| "/nix/store".to_owned()),
         )
         .unwrap_or_default();
@@ -182,7 +183,7 @@ impl SystemLoad {
         sys.refresh_memory();
         let load = sysinfo::System::load_average();
 
-        let store_dir = nix_utils::StoreDir::new(
+        let store_dir = StoreDir::new(
             std::env::var("NIX_STORE_DIR").unwrap_or_else(|_| "/nix/store".to_owned()),
         )
         .unwrap_or_default();

--- a/subprojects/hydra-builder/src/utils.rs
+++ b/subprojects/hydra-builder/src/utils.rs
@@ -1,3 +1,4 @@
+use harmonia_store_core::store_path::StorePath;
 use tokio::io::BufReader;
 use tokio_stream::wrappers::LinesStream;
 use tokio_util::io::ReaderStream;
@@ -10,7 +11,7 @@ pub(crate) type CompressionDecoder<R> = async_compression::tokio::bufread::ZstdD
 pub(crate) const DUPLEX_BUFFER_SIZE: usize = 256 * 1024;
 
 pub(crate) fn compressed_log_stream(
-    drv: &nix_utils::StorePath,
+    drv: &StorePath,
     log_output: LinesStream<BufReader<tokio::process::ChildStderr>>,
 ) -> impl tokio_stream::Stream<Item = LogChunk> + use<> {
     let (raw_writer, raw_reader) = tokio::io::duplex(DUPLEX_BUFFER_SIZE);

--- a/subprojects/hydra-queue-runner/src/io/build.rs
+++ b/subprojects/hydra-queue-runner/src/io/build.rs
@@ -1,10 +1,11 @@
+use harmonia_store_core::store_path::StorePath;
 use std::sync::atomic::Ordering;
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Build {
     id: db::models::BuildID,
-    drv_path: nix_utils::StorePath,
+    drv_path: StorePath,
     jobset_id: crate::state::JobsetID,
     name: String,
     timestamp: jiff::Timestamp,

--- a/subprojects/hydra-queue-runner/src/io/machine.rs
+++ b/subprojects/hydra-queue-runner/src/io/machine.rs
@@ -1,3 +1,4 @@
+use harmonia_store_core::store_path::StorePath;
 use std::sync::{Arc, atomic::Ordering};
 
 use smallvec::SmallVec;
@@ -162,7 +163,7 @@ pub struct Machine {
     use_substitutes: bool,
     nix_version: String,
     stats: MachineStats,
-    jobs: Vec<nix_utils::StorePath>,
+    jobs: Vec<StorePath>,
 
     has_capacity: bool,
     has_dynamic_capacity: bool,

--- a/subprojects/hydra-queue-runner/src/io/step.rs
+++ b/subprojects/hydra-queue-runner/src/io/step.rs
@@ -1,10 +1,11 @@
+use harmonia_store_core::store_path::StorePath;
 use std::sync::atomic::Ordering;
 
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Step {
-    drv_path: nix_utils::StorePath,
+    drv_path: StorePath,
     runnable: bool,
     finished: bool,
     previous_failure: bool,

--- a/subprojects/hydra-queue-runner/src/io/step_info.rs
+++ b/subprojects/hydra-queue-runner/src/io/step_info.rs
@@ -1,10 +1,11 @@
+use harmonia_store_core::store_path::StorePath;
 use std::sync::atomic::Ordering;
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StepInfo {
-    drv_path: nix_utils::StorePath,
+    drv_path: StorePath,
     already_scheduled: bool,
     runnable: bool,
     finished: bool,

--- a/subprojects/hydra-queue-runner/src/io/uploads.rs
+++ b/subprojects/hydra-queue-runner/src/io/uploads.rs
@@ -1,13 +1,15 @@
+use harmonia_store_core::store_path::StorePath;
+
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UploadsResponse {
-    paths: Vec<nix_utils::StorePath>,
+    paths: Vec<StorePath>,
     path_count: usize,
 }
 
 impl UploadsResponse {
     #[must_use]
-    pub const fn new(paths: Vec<nix_utils::StorePath>) -> Self {
+    pub const fn new(paths: Vec<StorePath>) -> Self {
         Self {
             path_count: paths.len(),
             paths,

--- a/subprojects/hydra-queue-runner/src/state/build.rs
+++ b/subprojects/hydra-queue-runner/src/state/build.rs
@@ -7,6 +7,8 @@ use hashbrown::{HashMap, HashSet};
 
 use super::{Jobset, JobsetID, Step};
 use db::models::{BuildID, BuildStatus};
+use harmonia_store_core::derived_path::OutputName;
+use harmonia_store_core::store_path::{StoreDir, StorePath};
 use nix_utils::BaseStore as _;
 use store_path_utils::RelativeStorePath;
 
@@ -15,8 +17,8 @@ pub(super) type AtomicBuildID = AtomicI32;
 #[derive(Debug)]
 pub struct Build {
     pub id: BuildID,
-    pub drv_path: nix_utils::StorePath,
-    pub outputs: BTreeMap<nix_utils::OutputName, nix_utils::StorePath>,
+    pub drv_path: StorePath,
+    pub outputs: BTreeMap<OutputName, StorePath>,
     pub jobset_id: JobsetID,
     pub name: String,
     pub timestamp: jiff::Timestamp,
@@ -49,7 +51,7 @@ impl Hash for Build {
 
 impl Build {
     #[must_use]
-    pub fn new_debug(drv_path: &nix_utils::StorePath) -> Arc<Self> {
+    pub fn new_debug(drv_path: &StorePath) -> Arc<Self> {
         Arc::new(Self {
             id: BuildID::MAX,
             drv_path: drv_path.to_owned(),
@@ -379,10 +381,7 @@ impl BuildProduct {
         })
     }
 
-    pub fn from_shared(
-        store_dir: &nix_utils::StoreDir,
-        v: shared::BuildProduct,
-    ) -> anyhow::Result<Self> {
+    pub fn from_shared(store_dir: &StoreDir, v: shared::BuildProduct) -> anyhow::Result<Self> {
         Ok(Self {
             path: Some(RelativeStorePath::from_path(store_dir, &v.path)?),
             default_path: Some(v.default_path),
@@ -446,7 +445,7 @@ pub struct BuildOutput {
     pub size: u64,
 
     pub products: Vec<BuildProduct>,
-    pub outputs: BTreeMap<nix_utils::OutputName, nix_utils::StorePath>,
+    pub outputs: BTreeMap<OutputName, StorePath>,
     pub metrics: Vec<BuildMetric>,
 }
 
@@ -535,7 +534,7 @@ impl BuildOutput {
     #[tracing::instrument(skip(store, outputs), err)]
     pub async fn new(
         store: &nix_utils::LocalStore,
-        outputs: BTreeMap<nix_utils::OutputName, Option<nix_utils::StorePath>>,
+        outputs: BTreeMap<OutputName, Option<StorePath>>,
     ) -> anyhow::Result<Self> {
         let resolved: BTreeMap<_, _> = outputs
             .iter()
@@ -709,7 +708,7 @@ mod tests {
             filesize: None,
             sha256hash: None,
             path: path.map(|(base, rel)| RelativeStorePath {
-                base_path: nix_utils::StorePath::from_base_path(base).unwrap(),
+                base_path: StorePath::from_base_path(base).unwrap(),
                 relative_path: rel.into(),
             }),
             name: "test-product".into(),

--- a/subprojects/hydra-queue-runner/src/state/drv.rs
+++ b/subprojects/hydra-queue-runner/src/state/drv.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 
-use nix_utils::SingleDerivedPath;
+use harmonia_store_core::derivation::Derivation;
+use harmonia_store_core::derived_path::{OutputName, SingleDerivedPath};
+use harmonia_store_core::store_path::StorePath;
 
 /// Output names of intermediate derivations for a dynamic derivation
 /// dependency, stored in reverse order so that the next level to resolve
@@ -12,10 +14,10 @@ use nix_utils::SingleDerivedPath;
 ///
 /// In the common case of depending on a static derivation, this is empty.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct OutputNameChain(pub Vec<nix_utils::OutputName>);
+pub struct OutputNameChain(pub Vec<OutputName>);
 
 impl OutputNameChain {
-    pub fn pop(&mut self) -> Option<nix_utils::OutputName> {
+    pub fn pop(&mut self) -> Option<OutputName> {
         self.0.pop()
     }
 }
@@ -26,7 +28,7 @@ impl OutputNameChain {
 /// [`OutputNameChain`]'s convention. For `Built { Opaque(A), "foo" }`,
 /// returns `(A, ["foo"])`. For `Opaque(A)`, returns `(A, [])`.
 #[must_use]
-pub fn flatten_path(sdp: &SingleDerivedPath) -> (nix_utils::StorePath, OutputNameChain) {
+pub fn flatten_path(sdp: &SingleDerivedPath) -> (StorePath, OutputNameChain) {
     match sdp {
         SingleDerivedPath::Opaque(p) => (p.clone(), OutputNameChain::default()),
         SingleDerivedPath::Built { drv_path, output } => flatten_chain(drv_path, output),
@@ -40,8 +42,8 @@ pub fn flatten_path(sdp: &SingleDerivedPath) -> (nix_utils::StorePath, OutputNam
 #[must_use]
 pub fn flatten_chain(
     drv_path: &SingleDerivedPath,
-    output_name: &nix_utils::OutputName,
-) -> (nix_utils::StorePath, OutputNameChain) {
+    output_name: &OutputName,
+) -> (StorePath, OutputNameChain) {
     let (root, mut chain) = flatten_path(drv_path);
     chain.0.push(output_name.clone());
     (root, chain)
@@ -53,9 +55,7 @@ pub fn flatten_chain(
 /// skipped — only derivation build dependencies are returned. For each
 /// `Built` input, the outermost output name (what we consume) is discarded;
 /// intermediate output names form the [`OutputNameChain`].
-pub fn input_drvs(
-    drv: &nix_utils::Derivation,
-) -> BTreeSet<(nix_utils::StorePath, OutputNameChain)> {
+pub fn input_drvs(drv: &Derivation) -> BTreeSet<(StorePath, OutputNameChain)> {
     drv.inputs
         .iter()
         .filter_map(|sdp| match sdp {

--- a/subprojects/hydra-queue-runner/src/state/fod_checker.rs
+++ b/subprojects/hydra-queue-runner/src/state/fod_checker.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
+use harmonia_store_core::derivation::{Derivation, DerivationOutput};
+use harmonia_store_core::store_path::StorePath;
 use hashbrown::{HashMap, HashSet};
-use nix_utils::{Derivation, LocalStore, StorePath};
+use nix_utils::LocalStore;
 
 #[derive(Debug)]
 pub struct FodChecker {
@@ -35,7 +37,7 @@ async fn collect_ca_derivations(
     };
 
     let ca_fixed_hash = parsed.outputs.values().find_map(|o| match o {
-        nix_utils::DerivationOutput::CAFixed(ca) => Some(ca.hash()),
+        DerivationOutput::CAFixed(ca) => Some(ca.hash()),
         _ => None,
     });
     let input_drvs: Vec<StorePath> =
@@ -76,7 +78,7 @@ impl FodChecker {
 
     pub(super) fn add_ca_drv_parsed(&self, drv: &StorePath, parsed: &Derivation) {
         let ca_fixed_hash = parsed.outputs.values().find_map(|o| match o {
-            nix_utils::DerivationOutput::CAFixed(ca) => Some(ca.hash()),
+            DerivationOutput::CAFixed(ca) => Some(ca.hash()),
             _ => None,
         });
         if ca_fixed_hash.is_some() {

--- a/subprojects/hydra-queue-runner/src/state/machine.rs
+++ b/subprojects/hydra-queue-runner/src/state/machine.rs
@@ -5,6 +5,7 @@ use smallvec::SmallVec;
 use tokio::sync::mpsc;
 
 use db::models::BuildID;
+use harmonia_store_core::store_path::StorePath;
 
 use super::{RemoteBuild, System};
 use crate::config::{MachineFreeFn, MachineSortFn};
@@ -457,14 +458,14 @@ impl Machines {
 #[derive(Debug, Clone)]
 pub struct Job {
     pub internal_build_id: uuid::Uuid,
-    pub path: nix_utils::StorePath,
+    pub path: StorePath,
     pub build_id: BuildID,
     pub step_nr: i32,
     pub result: RemoteBuild,
 }
 
 impl Job {
-    pub fn new(build_id: BuildID, path: nix_utils::StorePath) -> Self {
+    pub fn new(build_id: BuildID, path: StorePath) -> Self {
         Self {
             internal_build_id: uuid::Uuid::new_v4(),
             path,
@@ -482,7 +483,7 @@ pub enum Message {
     ConfigUpdate(ConfigUpdate),
     BuildMessage {
         build_id: uuid::Uuid,
-        drv: nix_utils::StorePath,
+        drv: StorePath,
         max_log_size: u64,
         max_silent_time: i32,
         build_timeout: i32,
@@ -635,7 +636,7 @@ impl Machine {
     pub async fn build_drv(
         &self,
         job: Job,
-        effective_drv: nix_utils::StorePath,
+        effective_drv: StorePath,
         opts: &nix_utils::BuildOptions,
         presigned_url_opts: Option<PresignedUploadOpts>,
     ) -> anyhow::Result<()> {
@@ -780,7 +781,7 @@ impl Machine {
     }
 
     #[tracing::instrument(skip(self), fields(%drv))]
-    pub fn get_build_id_and_step_nr(&self, drv: &nix_utils::StorePath) -> Option<(i32, i32)> {
+    pub fn get_build_id_and_step_nr(&self, drv: &StorePath) -> Option<(i32, i32)> {
         let jobs = self.jobs.read();
         jobs.iter()
             .find(|j| &j.path == drv)
@@ -796,7 +797,7 @@ impl Machine {
     }
 
     #[tracing::instrument(skip(self), fields(%build_id))]
-    pub fn get_job_drv_for_build_id(&self, build_id: uuid::Uuid) -> Option<nix_utils::StorePath> {
+    pub fn get_job_drv_for_build_id(&self, build_id: uuid::Uuid) -> Option<StorePath> {
         let jobs = self.jobs.read();
         jobs.iter()
             .find(|j| j.internal_build_id == build_id)
@@ -804,7 +805,7 @@ impl Machine {
     }
 
     #[tracing::instrument(skip(self), fields(%drv))]
-    pub fn get_internal_build_id_for_drv(&self, drv: &nix_utils::StorePath) -> Option<uuid::Uuid> {
+    pub fn get_internal_build_id_for_drv(&self, drv: &StorePath) -> Option<uuid::Uuid> {
         let jobs = self.jobs.read();
         jobs.iter()
             .find(|j| &j.path == drv)
@@ -819,7 +820,7 @@ impl Machine {
     }
 
     #[tracing::instrument(skip(self), fields(%drv))]
-    pub fn remove_job(&self, drv: &nix_utils::StorePath) -> Option<Job> {
+    pub fn remove_job(&self, drv: &StorePath) -> Option<Job> {
         let job = {
             let mut jobs = self.jobs.write();
             let job = jobs.iter().find(|j| &j.path == drv).cloned();

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -14,6 +14,7 @@ mod uploader;
 use anyhow::Context as _;
 pub use atomic::AtomicDateTime;
 pub use build::{Build, BuildOutput, BuildResultState, BuildTimings, Builds, RemoteBuild};
+use harmonia_store_core::store_path::StorePath;
 pub use jobset::{Jobset, JobsetID, Jobsets};
 pub use machine::{Machine, Message as MachineMessage, Pressure, Stats as MachineStats};
 pub use queue::{BuildQueueStats, Queues};
@@ -30,6 +31,9 @@ use hashbrown::{HashMap, HashSet};
 use secrecy::ExposeSecret as _;
 
 use db::models::{BuildID, BuildStatus};
+use harmonia_store_core::derivation::DerivationOutput;
+use harmonia_store_core::derived_path::{OutputName, SingleDerivedPath};
+use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use inspectable_channel::InspectableChannel;
 use nix_utils::BaseStore as _;
 
@@ -86,7 +90,7 @@ pub struct State {
     ///
     /// FIXME: Replace this with proper persisted column, so we don't have to re-resolve on
     /// restart.
-    pub resolved_drv_map: parking_lot::RwLock<HashMap<nix_utils::StorePath, nix_utils::StorePath>>,
+    pub resolved_drv_map: parking_lot::RwLock<HashMap<StorePath, StorePath>>,
 
     pub fod_checker: Option<Arc<FodChecker>>,
 
@@ -387,23 +391,24 @@ impl State {
                 // Only CA floating derivations need resolution, and only
                 // when they have `Built` inputs (dynamic derivation deps).
                 // `Opaque`-only inputs are already resolved.
-                let is_ca_with_built_inputs =
-                    drv_ref.outputs.iter().all(|output| {
-                        matches!(output.1, nix_utils::DerivationOutput::CAFloating(_))
-                    }) && drv_ref
+                let is_ca_with_built_inputs = drv_ref
+                    .outputs
+                    .iter()
+                    .all(|output| matches!(output.1, DerivationOutput::CAFloating(_)))
+                    && drv_ref
                         .inputs
                         .iter()
-                        .any(|input| matches!(input, nix_utils::SingleDerivedPath::Built { .. }));
+                        .any(|input| matches!(input, SingleDerivedPath::Built { .. }));
                 tracing::info!(
                     is_ca_with_built_inputs,
                     ca_floating = drv_ref
                         .outputs
                         .iter()
-                        .all(|o| matches!(o.1, nix_utils::DerivationOutput::CAFloating(_))),
+                        .all(|o| matches!(o.1, DerivationOutput::CAFloating(_))),
                     has_built_inputs = drv_ref
                         .inputs
                         .iter()
-                        .any(|i| matches!(i, nix_utils::SingleDerivedPath::Built { .. })),
+                        .any(|i| matches!(i, SingleDerivedPath::Built { .. })),
                     "resolution check for {drv}"
                 );
                 if !is_ca_with_built_inputs {
@@ -589,10 +594,7 @@ impl State {
     }
 
     #[tracing::instrument(skip(self), fields(%drv), err)]
-    async fn construct_log_file_path(
-        &self,
-        drv: &nix_utils::StorePath,
-    ) -> anyhow::Result<std::path::PathBuf> {
+    async fn construct_log_file_path(&self, drv: &StorePath) -> anyhow::Result<std::path::PathBuf> {
         let mut log_file = self.log_dir.clone();
         let base = drv.to_string();
         let (dir, file) = base.split_at(2);
@@ -603,10 +605,7 @@ impl State {
     }
 
     #[tracing::instrument(skip(self), fields(%drv), err)]
-    pub async fn new_log_file(
-        &self,
-        drv: &nix_utils::StorePath,
-    ) -> anyhow::Result<fs_err::tokio::File> {
+    pub async fn new_log_file(&self, drv: &StorePath) -> anyhow::Result<fs_err::tokio::File> {
         let log_file = self.construct_log_file_path(drv).await?;
         tracing::debug!("opening {log_file:?}");
 
@@ -625,11 +624,9 @@ impl State {
         &self,
         new_ids: Vec<BuildID>,
         new_builds_by_id: Arc<parking_lot::RwLock<HashMap<BuildID, Arc<Build>>>>,
-        new_builds_by_path: HashMap<nix_utils::StorePath, HashSet<BuildID>>,
+        new_builds_by_path: HashMap<StorePath, HashSet<BuildID>>,
     ) {
-        let finished_drvs = Arc::new(parking_lot::RwLock::new(
-            HashSet::<nix_utils::StorePath>::new(),
-        ));
+        let finished_drvs = Arc::new(parking_lot::RwLock::new(HashSet::<StorePath>::new()));
 
         let starttime = jiff::Timestamp::now();
         for id in new_ids {
@@ -728,7 +725,7 @@ impl State {
     pub async fn queue_one_build(
         &self,
         jobset_id: i32,
-        drv_path: &nix_utils::StorePath,
+        drv_path: &StorePath,
     ) -> anyhow::Result<()> {
         let mut db = self.db.get().await?;
         let drv = nix_utils::query_drv(&self.store, drv_path)
@@ -752,7 +749,7 @@ impl State {
     pub(crate) async fn manually_add_queue_build(&self, build_id: BuildID) -> anyhow::Result<()> {
         let mut new_ids = Vec::<BuildID>::new();
         let mut new_builds_by_id = HashMap::<BuildID, Arc<Build>>::new();
-        let mut new_builds_by_path = HashMap::<nix_utils::StorePath, HashSet<BuildID>>::new();
+        let mut new_builds_by_path = HashMap::<StorePath, HashSet<BuildID>>::new();
 
         {
             let mut conn = self.db.get().await?;
@@ -794,8 +791,7 @@ impl State {
 
         let mut new_ids = Vec::<BuildID>::with_capacity(1000);
         let mut new_builds_by_id = HashMap::<BuildID, Arc<Build>>::with_capacity(1000);
-        let mut new_builds_by_path =
-            HashMap::<nix_utils::StorePath, HashSet<BuildID>>::with_capacity(1000);
+        let mut new_builds_by_path = HashMap::<StorePath, HashSet<BuildID>>::with_capacity(1000);
 
         {
             let mut conn = self.db.get().await?;
@@ -1094,7 +1090,7 @@ impl State {
     pub async fn succeed_step(
         &self,
         machine_id: uuid::Uuid,
-        drv_path: &nix_utils::StorePath,
+        drv_path: &StorePath,
         output: BuildOutput,
     ) -> anyhow::Result<()> {
         tracing::info!("marking job as done: drv_path={drv_path}");
@@ -1232,7 +1228,7 @@ impl State {
             let has_ca_floating = drv_ref
                 .outputs
                 .values()
-                .any(|o| matches!(o, nix_utils::DerivationOutput::CAFloating(_)));
+                .any(|o| matches!(o, DerivationOutput::CAFloating(_)));
             if has_ca_floating {
                 let s3_stores: Vec<binary_cache::S3BinaryCacheClient> = {
                     let r = self.remote_stores.read();
@@ -1244,12 +1240,12 @@ impl State {
                         .collect()
                 };
                 for (output_name, out_path) in &output.outputs {
-                    let realisation = nix_utils::Realisation {
-                        key: nix_utils::DrvOutput {
+                    let realisation = Realisation {
+                        key: DrvOutput {
                             drv_path: drv_path.clone(),
                             output_name: output_name.clone(),
                         },
-                        value: nix_utils::UnkeyedRealisation {
+                        value: UnkeyedRealisation {
                             out_path: out_path.clone(),
                             signatures: Default::default(),
                         },
@@ -1388,7 +1384,7 @@ impl State {
     pub async fn fail_step(
         &self,
         machine_id: uuid::Uuid,
-        drv_path: &nix_utils::StorePath,
+        drv_path: &StorePath,
         state: BuildResultState,
         timings: BuildTimings,
     ) -> anyhow::Result<()> {
@@ -1520,7 +1516,7 @@ impl State {
     #[tracing::instrument(skip(self, machine, job, step), fields(%drv_path), err)]
     async fn inner_fail_job(
         &self,
-        drv_path: &nix_utils::StorePath,
+        drv_path: &StorePath,
         machine: Option<Arc<Machine>>,
         mut job: machine::Job,
         step: Arc<Step>,
@@ -1780,8 +1776,8 @@ impl State {
         build: Arc<Build>,
         nr_added: Arc<AtomicI64>,
         new_builds_by_id: Arc<parking_lot::RwLock<HashMap<BuildID, Arc<Build>>>>,
-        new_builds_by_path: &HashMap<nix_utils::StorePath, HashSet<BuildID>>,
-        finished_drvs: Arc<parking_lot::RwLock<HashSet<nix_utils::StorePath>>>,
+        new_builds_by_path: &HashMap<StorePath, HashSet<BuildID>>,
+        finished_drvs: Arc<parking_lot::RwLock<HashSet<StorePath>>>,
         new_runnable: Arc<parking_lot::RwLock<HashSet<Arc<Step>>>>,
     ) {
         self.metrics.queue_build_loads.inc();
@@ -1919,10 +1915,10 @@ impl State {
     async fn create_step(
         &self,
         build: Arc<Build>,
-        drv_path: nix_utils::StorePath,
+        drv_path: StorePath,
         referring_build: Option<Arc<Build>>,
         referring_step: Option<(Arc<Step>, drv::OutputNameChain)>,
-        finished_drvs: Arc<parking_lot::RwLock<HashSet<nix_utils::StorePath>>>,
+        finished_drvs: Arc<parking_lot::RwLock<HashSet<StorePath>>>,
         new_steps: Arc<parking_lot::RwLock<HashSet<Arc<Step>>>>,
         new_runnable: Arc<parking_lot::RwLock<HashSet<Arc<Step>>>>,
     ) -> CreateStepResult {
@@ -2049,7 +2045,7 @@ impl State {
             if !missing.is_empty() && missing_local_outputs.is_empty() {
                 // we have all paths locally, so we can just upload them to the remote_store
                 if let Ok(log_file) = self.construct_log_file_path(&drv_path).await {
-                    let missing_paths: Vec<nix_utils::StorePath> =
+                    let missing_paths: Vec<StorePath> =
                         missing.values().filter_map(Clone::clone).collect();
                     self.uploader
                         .schedule_upload(
@@ -2182,8 +2178,8 @@ impl State {
     #[tracing::instrument(skip(self))]
     async fn query_known_drv_outputs(
         &self,
-        drv_path: &nix_utils::StorePath,
-    ) -> anyhow::Result<BTreeMap<nix_utils::OutputName, nix_utils::StorePath>> {
+        drv_path: &StorePath,
+    ) -> anyhow::Result<BTreeMap<OutputName, StorePath>> {
         let mut db = self.db.get().await?;
         let mut tx = db.begin_transaction().await?;
         Ok(tx
@@ -2241,10 +2237,7 @@ impl State {
     }
 
     #[tracing::instrument(skip(self), err)]
-    async fn get_build_output_cached(
-        &self,
-        drv_path: &nix_utils::StorePath,
-    ) -> anyhow::Result<BuildOutput> {
+    async fn get_build_output_cached(&self, drv_path: &StorePath) -> anyhow::Result<BuildOutput> {
         let drv = nix_utils::query_drv(&self.store, drv_path)
             .await?
             .ok_or_else(|| anyhow::anyhow!("Derivation not found"))?;
@@ -2296,7 +2289,7 @@ impl State {
     }
 
     #[allow(unused)]
-    fn add_root(&self, store_path: &nix_utils::StorePath) {
+    fn add_root(&self, store_path: &StorePath) {
         let roots_dir = self.config.get_roots_dir();
         nix_utils::add_root(&self.store, &roots_dir, store_path);
     }

--- a/subprojects/hydra-queue-runner/src/state/queue.rs
+++ b/subprojects/hydra-queue-runner/src/state/queue.rs
@@ -4,6 +4,8 @@ use std::sync::{Arc, Weak};
 use hashbrown::{HashMap, HashSet};
 use smallvec::SmallVec;
 
+use harmonia_store_core::store_path::StorePath;
+
 use super::{StepInfo, System};
 use crate::config::StepSortFn;
 
@@ -173,10 +175,10 @@ impl ScheduledItem {
 #[derive(Debug)]
 pub(super) struct InnerQueues {
     // flat list of all step infos in queues, owning those steps inner queue dont own them
-    jobs: HashMap<nix_utils::StorePath, Arc<StepInfo>>,
+    jobs: HashMap<StorePath, Arc<StepInfo>>,
     inner: HashMap<System, Arc<BuildQueue>>,
     #[allow(clippy::type_complexity)]
-    scheduled: parking_lot::RwLock<HashMap<nix_utils::StorePath, ScheduledItem>>,
+    scheduled: parking_lot::RwLock<HashMap<StorePath, ScheduledItem>>,
 }
 
 impl Default for InnerQueues {
@@ -261,14 +263,14 @@ impl InnerQueues {
     }
 
     #[tracing::instrument(skip(self), fields(%drv))]
-    fn remove_job_from_scheduled(&self, drv: &nix_utils::StorePath) -> Option<ScheduledItem> {
+    fn remove_job_from_scheduled(&self, drv: &StorePath) -> Option<ScheduledItem> {
         let item = self.scheduled.write().remove(drv)?;
         item.step_info.set_already_scheduled(false);
         item.build_queue.decr_active();
         Some(item)
     }
 
-    fn remove_job_by_path(&mut self, drv: &nix_utils::StorePath) {
+    fn remove_job_by_path(&mut self, drv: &StorePath) {
         if self.jobs.remove(drv).is_none() {
             tracing::error!("Failed to remove stepinfo drv={drv} from jobs!");
         }
@@ -287,7 +289,7 @@ impl InnerQueues {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn kill_active_steps(&self) -> Vec<(nix_utils::StorePath, uuid::Uuid)> {
+    async fn kill_active_steps(&self) -> Vec<(StorePath, uuid::Uuid)> {
         tracing::info!("Kill all active steps");
         let active = {
             let scheduled = self.scheduled.read();
@@ -548,15 +550,12 @@ impl Queues {
     }
 
     #[tracing::instrument(skip(self), fields(%drv))]
-    pub async fn remove_job_from_scheduled(
-        &self,
-        drv: &nix_utils::StorePath,
-    ) -> Option<ScheduledItem> {
+    pub async fn remove_job_from_scheduled(&self, drv: &StorePath) -> Option<ScheduledItem> {
         let rq = self.inner.read().await;
         rq.remove_job_from_scheduled(drv)
     }
 
-    pub async fn remove_job_by_path(&self, drv: &nix_utils::StorePath) {
+    pub async fn remove_job_by_path(&self, drv: &StorePath) {
         let mut wq = self.inner.write().await;
         wq.remove_job_by_path(drv);
     }
@@ -568,7 +567,7 @@ impl Queues {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn kill_active_steps(&self) -> Vec<(nix_utils::StorePath, uuid::Uuid)> {
+    pub async fn kill_active_steps(&self) -> Vec<(StorePath, uuid::Uuid)> {
         let rq = self.inner.read().await;
         rq.kill_active_steps().await
     }

--- a/subprojects/hydra-queue-runner/src/state/step.rs
+++ b/subprojects/hydra-queue-runner/src/state/step.rs
@@ -7,6 +7,9 @@ use hashbrown::{HashMap, HashSet};
 
 use super::{Build, Jobset};
 use db::models::BuildID;
+use harmonia_store_core::derivation::Derivation;
+use harmonia_store_core::derived_path::OutputName;
+use harmonia_store_core::store_path::{StoreDir, StorePath};
 
 use super::drv::OutputNameChain;
 
@@ -105,8 +108,8 @@ impl StepState {
 
 #[derive(Debug)]
 pub struct Step {
-    drv_path: nix_utils::StorePath,
-    drv: arc_swap::ArcSwapOption<nix_utils::Derivation>,
+    drv_path: StorePath,
+    drv: arc_swap::ArcSwapOption<Derivation>,
 
     runnable: AtomicBool,
     finished: AtomicBool,
@@ -133,7 +136,7 @@ impl Hash for Step {
 
 impl Step {
     #[must_use]
-    pub fn new(drv_path: nix_utils::StorePath) -> Arc<Self> {
+    pub fn new(drv_path: StorePath) -> Arc<Self> {
         Arc::new(Self {
             drv_path,
             drv: arc_swap::ArcSwapOption::from(None),
@@ -149,7 +152,7 @@ impl Step {
     }
 
     #[inline]
-    pub const fn get_drv_path(&self) -> &nix_utils::StorePath {
+    pub const fn get_drv_path(&self) -> &StorePath {
         &self.drv_path
     }
 
@@ -178,12 +181,12 @@ impl Step {
         self.runnable.load(Ordering::SeqCst)
     }
 
-    pub fn get_drv(&self) -> Option<arc_swap::Guard<Option<Arc<nix_utils::Derivation>>>> {
+    pub fn get_drv(&self) -> Option<arc_swap::Guard<Option<Arc<Derivation>>>> {
         let drv = self.drv.load();
         if drv.is_some() { Some(drv) } else { None }
     }
 
-    pub fn set_drv(&self, drv: nix_utils::Derivation) {
+    pub fn set_drv(&self, drv: Derivation) {
         self.drv.store(Some(Arc::new(drv)));
     }
 
@@ -220,8 +223,8 @@ impl Step {
 
     pub fn get_output_paths(
         &self,
-        store_dir: &nix_utils::StoreDir,
-    ) -> Option<BTreeMap<nix_utils::OutputName, Option<nix_utils::StorePath>>> {
+        store_dir: &StoreDir,
+    ) -> Option<BTreeMap<OutputName, Option<StorePath>>> {
         let drv = self.drv.load_full();
         drv.as_ref()
             .map(|drv| nix_utils::output_paths(drv, store_dir))
@@ -399,7 +402,7 @@ impl Step {
     /// We collect into a `Vec` rather than returning an iterator because the
     /// write lock on the step's state must be released before the caller can
     /// do async work (e.g. `create_step`) with the results.
-    pub fn pop_dynamic_rdeps(&self) -> Vec<(Weak<Step>, nix_utils::OutputName, OutputNameChain)> {
+    pub fn pop_dynamic_rdeps(&self) -> Vec<(Weak<Step>, OutputName, OutputNameChain)> {
         let mut state = self.state.write();
         state
             .rdeps
@@ -463,7 +466,7 @@ impl Step {
 
 #[derive(Debug, Clone)]
 pub struct Steps {
-    inner: Arc<parking_lot::RwLock<HashMap<nix_utils::StorePath, Weak<Step>>>>,
+    inner: Arc<parking_lot::RwLock<HashMap<StorePath, Weak<Step>>>>,
 }
 
 impl Default for Steps {
@@ -558,7 +561,7 @@ impl Steps {
     #[must_use]
     pub fn create(
         &self,
-        drv_path: &nix_utils::StorePath,
+        drv_path: &StorePath,
         referring_build: Option<&Arc<Build>>,
         referring_step: Option<(&Arc<Step>, OutputNameChain)>,
     ) -> (Arc<Step>, bool) {
@@ -583,7 +586,7 @@ impl Steps {
         (step, is_new)
     }
 
-    pub fn remove(&self, drv_path: &nix_utils::StorePath) {
+    pub fn remove(&self, drv_path: &StorePath) {
         let mut steps = self.inner.write();
         steps.remove(drv_path);
     }
@@ -593,7 +596,7 @@ impl Steps {
 mod tests {
     use super::*;
 
-    fn drv(name: &str) -> nix_utils::StorePath {
+    fn drv(name: &str) -> StorePath {
         nix_utils::parse_store_path(&format!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-{name}.drv"))
     }
 

--- a/subprojects/hydra-queue-runner/src/state/step_info.rs
+++ b/subprojects/hydra-queue-runner/src/state/step_info.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use db::models::BuildID;
-use nix_utils::SingleDerivedPath;
+use harmonia_store_core::derivation::{BasicDerivation, Derivation, DerivationOutput};
+use harmonia_store_core::derived_path::{OutputName, SingleDerivedPath};
+use harmonia_store_core::store_path::{StoreDir, StorePath};
 
 use super::Step;
 use super::drv::flatten_chain;
@@ -28,7 +30,7 @@ impl StepInfo {
     }
 
     /// Resolve a derivation's inputs into concrete store paths, returning a
-    /// [`BasicDerivation`](nix_utils::BasicDerivation).
+    /// [`BasicDerivation`](BasicDerivation).
     ///
     /// Returns [`None`] if the derivation is input-addressed (shouldn't be resolved),
     /// or if resolution fails because required outputs haven't been built yet.
@@ -39,17 +41,17 @@ impl StepInfo {
     /// We only need a store dir, not a store, because all the info we need comes from the Hydra
     /// database.
     pub(super) async fn try_resolve(
-        store_dir: &nix_utils::StoreDir,
+        store_dir: &StoreDir,
         db: &db::Database,
-        drv: &nix_utils::Derivation,
-        resolved_drv_map: &hashbrown::HashMap<nix_utils::StorePath, nix_utils::StorePath>,
-    ) -> Option<nix_utils::BasicDerivation> {
+        drv: &Derivation,
+        resolved_drv_map: &hashbrown::HashMap<StorePath, StorePath>,
+    ) -> Option<BasicDerivation> {
         // Input-addressed derivations should not be resolved because this would change their
         // output paths.
         let all_input_addressed = drv
             .outputs
             .values()
-            .any(|o| matches!(o, nix_utils::DerivationOutput::InputAddressed(_)));
+            .any(|o| matches!(o, DerivationOutput::InputAddressed(_)));
         if all_input_addressed {
             return None;
         }
@@ -74,10 +76,8 @@ impl StepInfo {
         let mut conn = db.get().await.ok()?;
 
         // Memoize depth-1 lookups across all chains resolved in this call.
-        let mut memo = std::collections::HashMap::<
-            (nix_utils::StorePath, nix_utils::OutputName),
-            Option<nix_utils::StorePath>,
-        >::new();
+        let mut memo =
+            std::collections::HashMap::<(StorePath, OutputName), Option<StorePath>>::new();
 
         drv.try_resolve(store_dir, &mut |inputs| {
             tokio::task::block_in_place(|| {

--- a/subprojects/hydra-queue-runner/src/state/uploader.rs
+++ b/subprojects/hydra-queue-runner/src/state/uploader.rs
@@ -1,5 +1,6 @@
 use backon::ExponentialBuilder;
 use backon::Retryable as _;
+use harmonia_store_core::store_path::StorePath;
 use nix_utils::BaseStore as _;
 
 #[allow(clippy::unnecessary_wraps)]
@@ -14,7 +15,7 @@ where
 struct Message {
     #[serde(skip_serializing, deserialize_with = "deserialize_with_new_v4")]
     id: uuid::Uuid,
-    store_paths: std::sync::Arc<Vec<nix_utils::StorePath>>,
+    store_paths: std::sync::Arc<Vec<StorePath>>,
     log_remote_path: std::sync::Arc<String>,
     log_local_path: std::sync::Arc<String>,
 }
@@ -77,7 +78,7 @@ impl Uploader {
     #[tracing::instrument(skip(self))]
     pub async fn schedule_upload(
         &self,
-        store_paths: Vec<nix_utils::StorePath>,
+        store_paths: Vec<StorePath>,
         log_remote_path: String,
         log_local_path: String,
     ) {
@@ -237,7 +238,7 @@ impl Uploader {
         self.queue.len()
     }
 
-    pub fn paths_in_queue(&self) -> Vec<nix_utils::StorePath> {
+    pub fn paths_in_queue(&self) -> Vec<StorePath> {
         self.queue
             .inspect()
             .into_iter()

--- a/subprojects/hydra-queue-runner/src/utils.rs
+++ b/subprojects/hydra-queue-runner/src/utils.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 
 use db::models::BuildID;
-use nix_utils::{BaseStore as _, StorePath};
+use harmonia_store_core::derived_path::OutputName;
+use harmonia_store_core::store_path::StorePath;
+use nix_utils::BaseStore as _;
 
 use crate::state::RemoteBuild;
 
@@ -13,7 +15,7 @@ pub async fn finish_build_step(
     step_nr: i32,
     res: &RemoteBuild,
     machine: Option<&str>,
-    output_paths: Option<&BTreeMap<nix_utils::OutputName, StorePath>>,
+    output_paths: Option<&BTreeMap<OutputName, StorePath>>,
 ) -> anyhow::Result<()> {
     let mut conn = db.get().await?;
     let mut tx = conn.begin_transaction().await?;
@@ -62,7 +64,7 @@ pub async fn finish_build_step(
 pub async fn substitute_output(
     db: db::Database,
     store: nix_utils::LocalStore,
-    o: (nix_utils::OutputName, Option<StorePath>),
+    o: (OutputName, Option<StorePath>),
     build_id: BuildID,
     drv_path: &StorePath,
     remote_store: Option<&binary_cache::S3BinaryCacheClient>,
@@ -114,7 +116,7 @@ pub async fn make_local_step(
     store: &nix_utils::LocalStore,
     build_id: BuildID,
     drv_path: &StorePath,
-    missing: &BTreeMap<nix_utils::OutputName, Option<StorePath>>,
+    missing: &BTreeMap<OutputName, Option<StorePath>>,
 ) -> anyhow::Result<()> {
     let time = i32::try_from(jiff::Timestamp::now().as_second())?;
 


### PR DESCRIPTION
Consumers now import `StorePath`, `StoreDir`, `OutputName`, etc. directly from `harmonia-store-core` rather than through `nix-utils` re-exports. This makes the actual dependency on harmonia explicit at each use site.

`nix-utils` retains its own local functionality (`parse_store_path`, `BaseStore`, `LocalStore`, `realise_drv`, etc.) but no longer acts as a forwarding layer for harmonia types.