### PR TITLE
Use structured proto types for `Hash`, `Signature`, and `ContentAddress` 

### DIFF
--- a/subprojects/crates/proto/src/lib.rs
+++ b/subprojects/crates/proto/src/lib.rs
@@ -23,11 +23,11 @@ include!(concat!(env!("OUT_DIR"), "/proto_version.rs"));
 
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("streaming_descriptor");
 
-impl From<store_path_utils::RelativeStorePath> for RelativeStorePath {
-    fn from(r: store_path_utils::RelativeStorePath) -> Self {
+impl From<&store_path_utils::RelativeStorePath> for RelativeStorePath {
+    fn from(r: &store_path_utils::RelativeStorePath) -> Self {
         Self {
-            store_path: Some(ProtoStorePath::from(r.base_path)),
-            sub_path: r.relative_path.into(),
+            store_path: Some(ProtoStorePath::from(&r.base_path)),
+            sub_path: r.relative_path.to_string(),
         }
     }
 }
@@ -44,59 +44,9 @@ impl TryFrom<RelativeStorePath> for store_path_utils::RelativeStorePath {
     }
 }
 
-// -- NarInfo / ValidPathInfo conversions --
+// -- Conversions between proto types and harmonia types --
 
-use harmonia_utils_hash::Hash;
-use harmonia_utils_hash::fmt::CommonHash as _;
-
-fn parse_hash(raw: &str) -> Option<Hash> {
-    raw.parse::<harmonia_utils_hash::fmt::Any<Hash>>()
-        .map(harmonia_utils_hash::fmt::Any::into_hash)
-        .ok()
-}
-
-impl From<harmonia_store_path_info::UnkeyedValidPathInfo> for UnkeyedValidPathInfo {
-    fn from(v: harmonia_store_path_info::UnkeyedValidPathInfo) -> Self {
-        let nar_hash_obj: Hash = v.nar_hash.into();
-        Self {
-            deriver: v.deriver.map(ProtoStorePath::from),
-            nar_hash: format!("{}", nar_hash_obj.as_base32()),
-            references: v.references.into_iter().map(ProtoStorePath::from).collect(),
-            registration_time: v.registration_time.map(|t| t.get()),
-            nar_size: v.nar_size,
-            ultimate: v.ultimate,
-            signatures: v.signatures.iter().map(|s| s.to_string()).collect(),
-            ca: v.ca.map(|ca| ca.to_string()),
-            store_dir: v.store_dir.to_string(),
-        }
-    }
-}
-
-impl From<harmonia_store_nar_info::UnkeyedNarInfo> for UnkeyedNarInfo {
-    fn from(n: harmonia_store_nar_info::UnkeyedNarInfo) -> Self {
-        Self {
-            info: Some(n.info.into()),
-            url: n.url.unwrap_or_default(),
-            compression: n.compression.unwrap_or_default(),
-            file_hash: n
-                .download_hash
-                .map(|h| format!("{}", h.as_base32()))
-                .unwrap_or_default(),
-            file_size: n.download_size.unwrap_or(0),
-        }
-    }
-}
-
-impl From<harmonia_store_nar_info::NarInfo> for NarInfo {
-    fn from(n: harmonia_store_nar_info::NarInfo) -> Self {
-        Self {
-            path: Some(ProtoStorePath::from(n.path)),
-            info: Some(n.info.into()),
-        }
-    }
-}
-
-/// Error type for converting proto `NarInfo` to harmonia `NarInfo`.
+/// Error type for converting proto types to harmonia types.
 #[derive(Debug, Clone)]
 pub struct NarInfoConvertError(pub &'static str);
 
@@ -106,11 +56,138 @@ impl std::fmt::Display for NarInfoConvertError {
     }
 }
 
+// -- Hash --
+
+impl From<&harmonia_utils_hash::Hash> for nix::store::v1::Hash {
+    fn from(h: &harmonia_utils_hash::Hash) -> Self {
+        use harmonia_utils_hash::Algorithm;
+        let algorithm = match h.algorithm() {
+            Algorithm::SHA256 => nix::store::v1::hash::Algorithm::Sha256,
+            Algorithm::SHA512 => nix::store::v1::hash::Algorithm::Sha512,
+            Algorithm::SHA1 => nix::store::v1::hash::Algorithm::Sha1,
+            Algorithm::MD5 => nix::store::v1::hash::Algorithm::Md5,
+        };
+        Self {
+            algorithm: algorithm as i32,
+            digest: h.as_ref().to_vec(),
+        }
+    }
+}
+
+impl TryFrom<nix::store::v1::Hash> for harmonia_utils_hash::Hash {
+    type Error = &'static str;
+
+    fn try_from(h: nix::store::v1::Hash) -> Result<Self, Self::Error> {
+        use harmonia_utils_hash::Algorithm;
+        let algo = match nix::store::v1::hash::Algorithm::try_from(h.algorithm) {
+            Ok(nix::store::v1::hash::Algorithm::Sha256) => Algorithm::SHA256,
+            Ok(nix::store::v1::hash::Algorithm::Sha512) => Algorithm::SHA512,
+            Ok(nix::store::v1::hash::Algorithm::Sha1) => Algorithm::SHA1,
+            Ok(nix::store::v1::hash::Algorithm::Md5) => Algorithm::MD5,
+            Err(_) => return Err("unknown hash algorithm"),
+        };
+        harmonia_utils_hash::Hash::from_slice(algo, &h.digest)
+            .map_err(|_| "invalid hash digest length")
+    }
+}
+
+// -- Signature --
+
+impl From<&harmonia_store_core::signature::Signature> for nix::store::v1::Signature {
+    fn from(sig: &harmonia_store_core::signature::Signature) -> Self {
+        Self {
+            key_name: sig.key_name.clone(),
+            sig: sig.sig.to_string(),
+        }
+    }
+}
+
+impl TryFrom<nix::store::v1::Signature> for harmonia_store_core::signature::Signature {
+    type Error = &'static str;
+
+    fn try_from(sig: nix::store::v1::Signature) -> Result<Self, Self::Error> {
+        Ok(Self {
+            key_name: sig.key_name.clone(),
+            sig: sig.sig.parse().map_err(|_| "invalid signature")?,
+        })
+    }
+}
+
+// -- ContentAddress --
+
+impl From<&harmonia_store_core::store_path::ContentAddress> for nix::store::v1::ContentAddress {
+    fn from(ca: &harmonia_store_core::store_path::ContentAddress) -> Self {
+        use harmonia_store_core::store_path::ContentAddress as CA;
+        match ca {
+            CA::Text(h) => Self {
+                method: nix::store::v1::content_address::Method::Text as i32,
+                hash: Some(nix::store::v1::Hash::from(
+                    &harmonia_utils_hash::Hash::from(*h),
+                )),
+            },
+            CA::Flat(h) => Self {
+                method: nix::store::v1::content_address::Method::Flat as i32,
+                hash: Some(nix::store::v1::Hash::from(h)),
+            },
+            CA::NixArchive(h) => Self {
+                method: nix::store::v1::content_address::Method::NixArchive as i32,
+                hash: Some(nix::store::v1::Hash::from(h)),
+            },
+        }
+    }
+}
+
+impl TryFrom<nix::store::v1::ContentAddress> for harmonia_store_core::store_path::ContentAddress {
+    type Error = &'static str;
+
+    fn try_from(ca: nix::store::v1::ContentAddress) -> Result<Self, Self::Error> {
+        use harmonia_store_core::store_path::ContentAddress as CA;
+        let hash: harmonia_utils_hash::Hash = ca.hash.ok_or("missing CA hash")?.try_into()?;
+        match nix::store::v1::content_address::Method::try_from(ca.method) {
+            Ok(nix::store::v1::content_address::Method::Text) => {
+                let sha256 = harmonia_utils_hash::Sha256::try_from(hash)
+                    .map_err(|_| "Text CA requires SHA256")?;
+                Ok(CA::Text(sha256))
+            }
+            Ok(nix::store::v1::content_address::Method::Flat) => Ok(CA::Flat(hash)),
+            Ok(nix::store::v1::content_address::Method::NixArchive) => Ok(CA::NixArchive(hash)),
+            Err(_) => Err("unknown CA method"),
+        }
+    }
+}
+
+// -- UnkeyedValidPathInfo --
+
+impl From<&harmonia_store_path_info::UnkeyedValidPathInfo> for UnkeyedValidPathInfo {
+    fn from(v: &harmonia_store_path_info::UnkeyedValidPathInfo) -> Self {
+        let nar_hash: harmonia_utils_hash::Hash = v.nar_hash.into();
+        Self {
+            deriver: v.deriver.as_ref().map(ProtoStorePath::from),
+            nar_hash: Some(nix::store::v1::Hash::from(&nar_hash)),
+            references: v.references.iter().map(ProtoStorePath::from).collect(),
+            registration_time: v.registration_time.map(|t| t.get()),
+            nar_size: v.nar_size,
+            ultimate: v.ultimate,
+            signatures: v
+                .signatures
+                .iter()
+                .map(nix::store::v1::Signature::from)
+                .collect(),
+            ca: v.ca.as_ref().map(nix::store::v1::ContentAddress::from),
+            store_dir: v.store_dir.to_string(),
+        }
+    }
+}
+
 impl TryFrom<UnkeyedValidPathInfo> for harmonia_store_path_info::UnkeyedValidPathInfo {
     type Error = NarInfoConvertError;
 
     fn try_from(v: UnkeyedValidPathInfo) -> Result<Self, Self::Error> {
-        let raw_hash = parse_hash(&v.nar_hash).ok_or(NarInfoConvertError("invalid nar_hash"))?;
+        let raw_hash: harmonia_utils_hash::Hash = v
+            .nar_hash
+            .ok_or(NarInfoConvertError("missing nar_hash"))?
+            .try_into()
+            .map_err(|_| NarInfoConvertError("invalid nar_hash"))?;
         let nar_hash = harmonia_store_path_info::NarHash::try_from(raw_hash)
             .map_err(|_| NarInfoConvertError("nar_hash is not sha256"))?;
 
@@ -124,12 +201,30 @@ impl TryFrom<UnkeyedValidPathInfo> for harmonia_store_path_info::UnkeyedValidPat
             signatures: v
                 .signatures
                 .into_iter()
-                .filter_map(|s| s.parse().ok())
+                .filter_map(|s| harmonia_store_core::signature::Signature::try_from(s).ok())
                 .collect(),
-            ca: v.ca.as_deref().and_then(|s| s.parse().ok()),
+            ca: v
+                .ca
+                .map(harmonia_store_core::store_path::ContentAddress::try_from)
+                .transpose()
+                .map_err(|_| NarInfoConvertError("invalid ca"))?,
             store_dir: harmonia_store_core::store_path::StoreDir::new(&v.store_dir)
                 .unwrap_or_default(),
         })
+    }
+}
+
+// -- UnkeyedNarInfo --
+
+impl From<&harmonia_store_nar_info::UnkeyedNarInfo> for UnkeyedNarInfo {
+    fn from(n: &harmonia_store_nar_info::UnkeyedNarInfo) -> Self {
+        Self {
+            info: Some(UnkeyedValidPathInfo::from(&n.info)),
+            url: n.url.clone().unwrap_or_default(),
+            compression: n.compression.clone().unwrap_or_default(),
+            download_hash: n.download_hash.as_ref().map(nix::store::v1::Hash::from),
+            download_size: n.download_size,
+        }
     }
 }
 
@@ -149,13 +244,24 @@ impl TryFrom<UnkeyedNarInfo> for harmonia_store_nar_info::UnkeyedNarInfo {
             } else {
                 Some(n.compression)
             },
-            download_hash: parse_hash(&n.file_hash),
-            download_size: if n.file_size == 0 {
-                None
-            } else {
-                Some(n.file_size)
-            },
+            download_hash: n
+                .download_hash
+                .map(harmonia_utils_hash::Hash::try_from)
+                .transpose()
+                .map_err(|_| NarInfoConvertError("invalid download_hash"))?,
+            download_size: n.download_size,
         })
+    }
+}
+
+// -- NarInfo --
+
+impl From<&harmonia_store_nar_info::NarInfo> for NarInfo {
+    fn from(n: &harmonia_store_nar_info::NarInfo) -> Self {
+        Self {
+            path: Some(ProtoStorePath::from(n.path.clone())),
+            info: Some(UnkeyedNarInfo::from(&n.info)),
+        }
     }
 }
 

--- a/subprojects/crates/proto/src/store_path.rs
+++ b/subprojects/crates/proto/src/store_path.rs
@@ -40,6 +40,12 @@ impl From<StorePath> for ProtoStorePath {
     }
 }
 
+impl From<&StorePath> for ProtoStorePath {
+    fn from(p: &StorePath) -> Self {
+        Self(p.clone())
+    }
+}
+
 impl From<ProtoStorePath> for StorePath {
     fn from(p: ProtoStorePath) -> StorePath {
         p.0

--- a/subprojects/crates/proto/src/tests.rs
+++ b/subprojects/crates/proto/src/tests.rs
@@ -1,18 +1,156 @@
 use super::*;
 use std::collections::BTreeSet;
 
-use harmonia_store_core::store_path::StoreDir;
+use harmonia_store_core::signature::Signature;
+use harmonia_store_core::store_path::{ContentAddress, StoreDir, StorePath};
 use harmonia_store_path_info::NarHash;
+use harmonia_utils_hash::{Algorithm, Hash, Sha256};
 
-fn roundtrip(original: &harmonia_store_nar_info::NarInfo) -> harmonia_store_nar_info::NarInfo {
-    let proto: NarInfo = original.clone().into();
+fn test_store_dir() -> StoreDir {
+    StoreDir::default()
+}
+
+fn test_sig() -> Signature {
+    "cache.nixos.org-1:0CpHca+06TwFp9VkMyz5OaphT3E8mnS+1SWymYlvFaghKSYPCMQ66TS1XPAr1+y9rfQZPLaHrBjjnIRktE/nAA==".parse().unwrap()
+}
+
+fn test_path() -> StorePath {
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello".parse().unwrap()
+}
+
+fn test_unkeyed_valid_path_info() -> harmonia_store_path_info::UnkeyedValidPathInfo {
+    harmonia_store_path_info::UnkeyedValidPathInfo {
+        deriver: Some("cccccccccccccccccccccccccccccccc-drv.drv".parse().unwrap()),
+        nar_hash: NarHash::from_slice(&[0xab; 32]).unwrap(),
+        references: BTreeSet::from(["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-dep".parse().unwrap()]),
+        registration_time: std::num::NonZero::new(1700000000),
+        nar_size: 42000,
+        ultimate: true,
+        signatures: BTreeSet::from([test_sig()]),
+        ca: Some(ContentAddress::NixArchive(
+            Hash::from_slice(Algorithm::SHA256, &[0x55; 32]).unwrap(),
+        )),
+        store_dir: test_store_dir(),
+    }
+}
+
+fn roundtrip<A, B>(original: &A) -> A
+where
+    for<'a> &'a A: Into<B>,
+    B: TryInto<A>,
+    <B as TryInto<A>>::Error: std::fmt::Debug,
+{
+    let proto: B = original.into();
     proto.try_into().unwrap()
 }
+
+// -- Hash round-trips --
+
+#[test]
+fn hash_roundtrip_sha256() {
+    let h = Hash::from_slice(Algorithm::SHA256, &[0xab; 32]).unwrap();
+    assert_eq!(roundtrip::<Hash, nix::store::v1::Hash>(&h), h);
+}
+
+#[test]
+fn hash_roundtrip_sha512() {
+    let h = Hash::from_slice(Algorithm::SHA512, &[0xcd; 64]).unwrap();
+    assert_eq!(roundtrip::<Hash, nix::store::v1::Hash>(&h), h);
+}
+
+#[test]
+fn signature_roundtrip() {
+    let sig: Signature = test_sig();
+    assert_eq!(roundtrip::<Signature, nix::store::v1::Signature>(&sig), sig);
+}
+
+#[test]
+fn content_address_roundtrip_text() {
+    let ca = ContentAddress::Text(Sha256::from_slice(&[0x11; 32]).unwrap());
+    assert_eq!(
+        roundtrip::<ContentAddress, nix::store::v1::ContentAddress>(&ca),
+        ca
+    );
+}
+
+#[test]
+fn content_address_roundtrip_flat() {
+    let ca = ContentAddress::Flat(Hash::from_slice(Algorithm::SHA256, &[0x22; 32]).unwrap());
+    assert_eq!(
+        roundtrip::<ContentAddress, nix::store::v1::ContentAddress>(&ca),
+        ca
+    );
+}
+
+#[test]
+fn content_address_roundtrip_nar() {
+    let ca = ContentAddress::NixArchive(Hash::from_slice(Algorithm::SHA256, &[0x33; 32]).unwrap());
+    assert_eq!(
+        roundtrip::<ContentAddress, nix::store::v1::ContentAddress>(&ca),
+        ca
+    );
+}
+
+// -- RelativeStorePath round-trips --
+
+#[test]
+fn relative_store_path_roundtrip() {
+    let rsp = store_path_utils::RelativeStorePath {
+        base_path: test_path(),
+        relative_path: "share/doc/manual".into(),
+    };
+    assert_eq!(
+        roundtrip::<store_path_utils::RelativeStorePath, RelativeStorePath>(&rsp),
+        rsp
+    );
+}
+
+#[test]
+fn relative_store_path_roundtrip_bare() {
+    let rsp = store_path_utils::RelativeStorePath {
+        base_path: test_path(),
+        relative_path: "".into(),
+    };
+    assert_eq!(
+        roundtrip::<store_path_utils::RelativeStorePath, RelativeStorePath>(&rsp),
+        rsp
+    );
+}
+
+// -- UnkeyedValidPathInfo round-trips --
+
+#[test]
+fn unkeyed_valid_path_info_roundtrip() {
+    let v = test_unkeyed_valid_path_info();
+    assert_eq!(
+        roundtrip::<harmonia_store_path_info::UnkeyedValidPathInfo, UnkeyedValidPathInfo>(&v),
+        v
+    );
+}
+
+// -- UnkeyedNarInfo round-trips --
+
+#[test]
+fn unkeyed_nar_info_roundtrip() {
+    let v = harmonia_store_nar_info::UnkeyedNarInfo {
+        info: test_unkeyed_valid_path_info(),
+        url: Some("nar/foo.nar.zst".to_owned()),
+        compression: Some("zstd".to_owned()),
+        download_hash: Some(Hash::from_slice(Algorithm::SHA256, &[0xee; 32]).unwrap()),
+        download_size: Some(500),
+    };
+    assert_eq!(
+        roundtrip::<harmonia_store_nar_info::UnkeyedNarInfo, UnkeyedNarInfo>(&v),
+        v
+    );
+}
+
+// -- NarInfo round-trips --
 
 #[test]
 fn narinfo_roundtrip_minimal() {
     let ni = harmonia_store_nar_info::NarInfo {
-        path: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello".parse().unwrap(),
+        path: test_path(),
         info: harmonia_store_nar_info::UnkeyedNarInfo {
             info: harmonia_store_path_info::UnkeyedValidPathInfo {
                 deriver: None,
@@ -25,7 +163,7 @@ fn narinfo_roundtrip_minimal() {
                 ultimate: false,
                 signatures: BTreeSet::new(),
                 ca: None,
-                store_dir: StoreDir::new("/nix/store").unwrap(),
+                store_dir: test_store_dir(),
             },
             url: Some("nar/abc.nar".to_owned()),
             compression: Some("zstd".to_owned()),
@@ -33,32 +171,28 @@ fn narinfo_roundtrip_minimal() {
             download_size: None,
         },
     };
-    assert_eq!(roundtrip(&ni), ni);
+    assert_eq!(
+        roundtrip::<harmonia_store_nar_info::NarInfo, NarInfo>(&ni),
+        ni
+    );
 }
 
 #[test]
-fn narinfo_roundtrip_with_download_info() {
+fn narinfo_roundtrip_with_all_fields() {
     let ni = harmonia_store_nar_info::NarInfo {
-        path: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello".parse().unwrap(),
+        path: test_path(),
         info: harmonia_store_nar_info::UnkeyedNarInfo {
-            info: harmonia_store_path_info::UnkeyedValidPathInfo {
-                deriver: Some("cccccccccccccccccccccccccccccccc-drv.drv".parse().unwrap()),
-                nar_hash: NarHash::from_slice(&[0xcd; 32]).unwrap(),
-                references: BTreeSet::new(),
-                registration_time: None,
-                nar_size: 99999,
-                ultimate: false,
-                signatures: BTreeSet::new(),
-                ca: None,
-                store_dir: StoreDir::new("/nix/store").unwrap(),
-            },
+            info: test_unkeyed_valid_path_info(),
             url: Some("nar/xyz.nar.zst".to_owned()),
             compression: Some("zstd".to_owned()),
-            download_hash: parse_hash("sha256:1b2m2y8asgthdy6knt0d3k5z6s8p7nd0df8sm3k"),
+            download_hash: Some(Hash::from_slice(Algorithm::SHA256, &[0xee; 32]).unwrap()),
             download_size: Some(9999),
         },
     };
-    assert_eq!(roundtrip(&ni), ni);
+    assert_eq!(
+        roundtrip::<harmonia_store_nar_info::NarInfo, NarInfo>(&ni),
+        ni
+    );
 }
 
 #[test]
@@ -69,8 +203,8 @@ fn narinfo_missing_path_fails() {
             info: None,
             url: String::new(),
             compression: String::new(),
-            file_hash: String::new(),
-            file_size: 0,
+            download_hash: None,
+            download_size: None,
         }),
     };
     let result: Result<harmonia_store_nar_info::NarInfo, _> = proto.try_into();
@@ -80,11 +214,7 @@ fn narinfo_missing_path_fails() {
 #[test]
 fn narinfo_missing_info_fails() {
     let proto = NarInfo {
-        path: Some(ProtoStorePath::from(
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x"
-                .parse::<harmonia_store_core::store_path::StorePath>()
-                .unwrap(),
-        )),
+        path: Some(ProtoStorePath::from(test_path())),
         info: None,
     };
     let result: Result<harmonia_store_nar_info::NarInfo, _> = proto.try_into();

--- a/subprojects/crates/store-path-utils/src/lib.rs
+++ b/subprojects/crates/store-path-utils/src/lib.rs
@@ -5,7 +5,7 @@ use harmonia_store_core::store_path::{ParseStorePathError, StoreDir, StorePath};
 /// Represents paths like `/nix/store/<hash>-<name>/share/doc/nix/manual`,
 /// split into the base `StorePath` (`<hash>-<name>`) and the relative
 /// suffix (`share/doc/nix/manual`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RelativeStorePath {
     pub base_path: StorePath,
     pub relative_path: Box<str>,

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -1097,7 +1097,7 @@ async fn upload_single_nar_presigned(
         let completion_msg = hydra_proto::PresignedUploadComplete {
             build_id: build_id.to_owned(),
             machine_id: machine_id.to_owned(),
-            nar_info: Some(updated_narinfo.into()),
+            nar_info: Some((&updated_narinfo).into()),
         };
 
         client
@@ -1168,7 +1168,7 @@ async fn new_success_build_result_info(
                     let rel =
                         store_path_utils::RelativeStorePath::from_path(store.store_dir(), &p.path)?;
                     Ok(BuildProduct {
-                        path: Some(rel.into()),
+                        path: Some((&rel).into()),
                         default_path: p.default_path,
                         r#type: p.r#type,
                         subtype: p.subtype,

--- a/subprojects/hydra-queue-runner/examples/collect-fods.rs
+++ b/subprojects/hydra-queue-runner/examples/collect-fods.rs
@@ -1,3 +1,6 @@
+use harmonia_store_core::derivation::Derivation;
+use harmonia_store_core::store_path::StorePath;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let p = nix_utils::parse_store_path("dzgpbp0vp7lj7lgj26rjgmnjicq2wf4k-hello-2.12.2.drv");
@@ -8,11 +11,9 @@ async fn main() -> anyhow::Result<()> {
     fod.to_traverse(&p);
     fod.trigger_traverse();
     let _ = rx.recv().await;
-    fod.process(
-        async move |path: nix_utils::StorePath, _: nix_utils::Derivation| {
-            println!("{path}");
-        },
-    )
+    fod.process(async move |path: StorePath, _: Derivation| {
+        println!("{path}");
+    })
     .await;
     Ok(())
 }

--- a/subprojects/proto/v1/store.proto
+++ b/subprojects/proto/v1/store.proto
@@ -15,15 +15,41 @@ message RelativeStorePath {
   string sub_path = 2;
 }
 
+message Hash {
+  enum Algorithm {
+    SHA256 = 0;
+    SHA512 = 1;
+    SHA1 = 2;
+    MD5 = 3;
+  }
+  Algorithm algorithm = 1;
+  bytes digest = 2;
+}
+
+message ContentAddress {
+  enum Method {
+    TEXT = 0;
+    FLAT = 1;
+    NIX_ARCHIVE = 2;
+  }
+  Method method = 1;
+  Hash hash = 2;
+}
+
+message Signature {
+  string key_name = 1;
+  string sig = 2;
+}
+
 message UnkeyedValidPathInfo {
   optional StorePath deriver = 1;
-  string nar_hash = 2;
+  Hash nar_hash = 2;
   repeated StorePath references = 3;
   optional int64 registration_time = 4;
   uint64 nar_size = 5;
   bool ultimate = 6;
-  repeated string signatures = 7;
-  optional string ca = 8;
+  repeated Signature signatures = 7;
+  optional ContentAddress ca = 8;
   string store_dir = 9;
 }
 
@@ -36,8 +62,8 @@ message UnkeyedNarInfo {
   UnkeyedValidPathInfo info = 1;
   string url = 2;
   string compression = 3;
-  string file_hash = 4;
-  uint64 file_size = 5;
+  optional Hash download_hash = 4;
+  optional uint64 download_size = 5;
 }
 
 message NarInfo {


### PR DESCRIPTION
Replace stringly-typed fields in `store.proto` with proper message types:

- `Hash` — algorithm enum + raw digest bytes
- `Signature` — key name + signature string
- `ContentAddress` — method enum + hash

`UnkeyedValidPathInfo.nar_hash` is now `Hash` (not string),
`signatures` is `repeated Signature` (not `repeated string`),
`ca` is `optional ContentAddress` (not `optional string`).
`UnkeyedNarInfo.file_hash`/`file_size` renamed to
`download_hash`/`download_size` with proper `Hash` type.

All `From`/`TryFrom` impls use `&` for harmonia→proto direction
(no need to consume the source) and by-value for proto→harmonia
(proto types are consumed). Round-trip tests cover every layer.