### PR TITLE
Remove `OutputNameOnly` from proto, error on missing path info

### DIFF
--- a/subprojects/crates/proto/build.rs
+++ b/subprojects/crates/proto/build.rs
@@ -6,6 +6,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let workspace_version = env::var("CARGO_PKG_VERSION")?;
 
+    println!("cargo:rerun-if-changed=../../proto/v1/streaming.proto");
+    println!("cargo:rerun-if-changed=../../proto/v1/store.proto");
+
     let proto_path = "../../proto/v1/streaming.proto";
     let proto_content = fs_err::read_to_string(proto_path)?;
     let mut hasher = sha2::Sha256::new();

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -17,8 +17,8 @@ use binary_cache::{Compression, PresignedUpload, PresignedUploadClient};
 use hydra_proto::ProtoStorePath;
 use hydra_proto::{
     AbortMessage, BuildMessage, BuildMetric, BuildProduct, BuildResultInfo, BuildResultState,
-    FetchRequisitesRequest, JoinMessage, NarData, NixSupport, Output, OutputNameOnly,
-    OutputWithPath, PingMessage, StepStatus, StepUpdate, StorePaths, output,
+    FetchRequisitesRequest, JoinMessage, NarData, NixSupport, OutputPathInfo, PingMessage,
+    StepStatus, StepUpdate, StorePaths,
 };
 use nix_utils::BaseStore as _;
 
@@ -532,6 +532,23 @@ impl State {
         timings.build_elapsed = before_build.elapsed();
         tracing::info!("Finished building {drv}");
 
+        // Query path info for each output up front — these are needed both
+        // for building the result message and are expected to exist for a
+        // successful build.
+        let mut output_infos = BTreeMap::new();
+        for (name, path) in &outputs {
+            let info = store.query_path_info(path).await.ok_or_else(|| {
+                JobFailure::PostProcessing(anyhow::anyhow!("missing path info for output `{name}`"))
+            })?;
+            output_infos.insert(
+                name.clone(),
+                harmonia_store_path_info::ValidPathInfo {
+                    path: path.clone(),
+                    info,
+                },
+            );
+        }
+
         let _ = client // we ignore the error here, as this step status has no prio
             .build_step_update(StepUpdate {
                 build_id: m.build_id.clone(),
@@ -563,7 +580,7 @@ impl State {
             store.clone(),
             machine_id,
             &drv,
-            &outputs,
+            &output_infos,
             *timings,
             m.build_id.clone(),
         ))
@@ -1108,42 +1125,36 @@ async fn upload_single_nar_presigned(
     Ok(())
 }
 
-#[tracing::instrument(skip(store, outputs), fields(%drv), ret(level = tracing::Level::DEBUG), err)]
+#[tracing::instrument(skip(store, output_infos), fields(%drv), ret(level = tracing::Level::DEBUG), err)]
 async fn new_success_build_result_info(
     store: nix_utils::LocalStore,
     machine_id: uuid::Uuid,
     drv: &StorePath,
-    outputs: &BTreeMap<OutputName, StorePath>,
+    output_infos: &BTreeMap<OutputName, harmonia_store_path_info::ValidPathInfo>,
     timings: BuildTimings,
     build_id: String,
 ) -> anyhow::Result<BuildResultInfo> {
-    let pathinfos = store
-        .query_path_infos(&outputs.values().collect::<Vec<_>>())
-        .await;
+    let outputs: BTreeMap<_, _> = output_infos
+        .iter()
+        .map(|(name, vpi)| (name.clone(), vpi.path.clone()))
+        .collect();
     let nix_support = Box::pin(nix_support::parse_nix_support_from_outputs(
         store.get_store_dir(),
-        outputs,
+        &outputs,
     ))
     .await?;
 
     let mut build_outputs = vec![];
-    for (name, path) in outputs {
-        build_outputs.push(Output {
-            output: Some(match pathinfos.get(path) {
-                Some(info) => output::Output::Withpath(OutputWithPath {
-                    name: name.to_string(),
-                    closure_size: store.compute_closure_size(path).await,
-                    path: Some(ProtoStorePath::from(path.clone())),
-                    nar_size: info.nar_size,
-                    nar_hash: {
-                        let h: harmonia_utils_hash::Hash = info.nar_hash.into();
-                        Some((&h).into())
-                    },
-                }),
-                None => output::Output::Nameonly(OutputNameOnly {
-                    name: name.to_string(),
-                }),
-            }),
+    for (name, vpi) in output_infos {
+        build_outputs.push(OutputPathInfo {
+            name: name.to_string(),
+            path: Some(ProtoStorePath::from(vpi.path.clone())),
+            closure_size: store.compute_closure_size(&vpi.path).await,
+            nar_size: vpi.info.nar_size,
+            nar_hash: {
+                let h: harmonia_utils_hash::Hash = vpi.info.nar_hash.into();
+                Some((&h).into())
+            },
         });
     }
 

--- a/subprojects/hydra-queue-runner/src/state/build.rs
+++ b/subprojects/hydra-queue-runner/src/state/build.rs
@@ -480,21 +480,13 @@ impl BuildOutput {
         let mut nar_size = 0;
 
         for o in v.outputs {
-            match o.output {
-                Some(hydra_proto::output::Output::Nameonly(_)) => {
-                    // We dont care about outputs that dont have a path,
-                }
-                Some(hydra_proto::output::Output::Withpath(o)) => {
-                    let path = o
-                        .path
-                        .ok_or_else(|| anyhow::anyhow!("output missing path"))?
-                        .0;
-                    outputs.insert(o.name.parse()?, path);
-                    closure_size += o.closure_size;
-                    nar_size += o.nar_size;
-                }
-                None => (),
-            }
+            let path = o
+                .path
+                .ok_or_else(|| anyhow::anyhow!("output missing path"))?
+                .0;
+            outputs.insert(o.name.parse()?, path);
+            closure_size += o.closure_size;
+            nar_size += o.nar_size;
         }
         let (failed, release_name, products, metrics) = if let Some(nix_support) = v.nix_support {
             (

--- a/subprojects/proto/v1/streaming.proto
+++ b/subprojects/proto/v1/streaming.proto
@@ -162,23 +162,12 @@ message NarData {
   bytes chunk = 1;
 }
 
-message OutputNameOnly {
-  string name = 1;
-}
-
-message OutputWithPath {
+message OutputPathInfo {
   string name = 1;
   nix.store.v1.StorePath path = 2;
   uint64 closure_size = 3;
   uint64 nar_size = 4;
   nix.store.v1.Hash nar_hash = 5;
-}
-
-message Output {
-  oneof output {
-    OutputNameOnly nameonly = 1;
-    OutputWithPath withpath = 2;
-  }
 }
 
 message BuildMetric {
@@ -243,7 +232,7 @@ message BuildResultInfo {
   uint64 upload_time_ms = 5;
   BuildResultState result_state = 6;
   NixSupport nix_support = 7;
-  repeated Output outputs = 8;
+  repeated OutputPathInfo outputs = 8;
 }
 
 message PresignedNarRequest {


### PR DESCRIPTION
A successful build must have path info for all its outputs — the
`OutputNameOnly` variant was defensive code that silently dropped
outputs when `query_path_info` failed, hiding bugs.

Replace the `Output` oneof (`OutputNameOnly` | `OutputWithPath`) with
a single `OutputPathInfo` message. The builder now queries path info
per-output immediately after building and errors if any are missing,
before uploads begin. The combined `BTreeMap<OutputName, (StorePath,
PathInfo)>` is passed to `new_success_build_result_info` to avoid
re-querying.

> [!NOTE]
> 
>  `OutputNameOnly` does seem like something that was added on purpose, though. So it is possible that there is a legitamate reason for a successful build to be missing outputs that I am completely not thinking of. In that case, we'll revert this commit, and add a test for that scenario