### PR TITLE
Simplify `query_requisites` and the `FetchRequisites` gRPC RPC

### DIFF
--- a/subprojects/crates/binary-cache/examples/query_missing_paths.rs
+++ b/subprojects/crates/binary-cache/examples/query_missing_paths.rs
@@ -15,13 +15,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let drv = "z3d15qi11dvljq5qz84kak3h0nb12wca-rsyslog-8.2510.0"
         .parse()
         .unwrap();
-    let ps = store.query_requisites(&[&drv], false).await.unwrap();
+    let ps = store.query_requisites(&[&drv]).await.unwrap();
     println!("ps before: {}", ps.len());
 
     let ps = client.query_missing_paths(ps.clone()).await;
     println!("ps after: {}", ps.len());
 
-    let ps = store.query_requisites(&[&drv], true).await.unwrap();
+    let ps = store.query_requisites(&[&drv]).await.unwrap();
     for p in ps {
         println!("{}", store.print_store_path(&p));
     }

--- a/subprojects/crates/binary-cache/examples/simple_presigned.rs
+++ b/subprojects/crates/binary-cache/examples/simple_presigned.rs
@@ -20,14 +20,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let upload_client = PresignedUploadClient::new();
 
     let paths_to_copy = store
-        .query_requisites(
-            &[&harmonia_store_core::store_path::StoreDir::default()
-                .parse::<harmonia_store_core::store_path::StorePath>(
-                    "/nix/store/m1r53pnnm6hnjwyjmxska24y8amvlpjp-hello-2.12.1",
-                )
-                .unwrap()],
-            true,
-        )
+        .query_requisites(&[&harmonia_store_core::store_path::StoreDir::default()
+            .parse::<harmonia_store_core::store_path::StorePath>(
+                "/nix/store/m1r53pnnm6hnjwyjmxska24y8amvlpjp-hello-2.12.1",
+            )
+            .unwrap()])
         .await
         .unwrap_or_default();
 

--- a/subprojects/crates/binary-cache/examples/upload_file.rs
+++ b/subprojects/crates/binary-cache/examples/upload_file.rs
@@ -17,12 +17,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("{:#?}", client.cfg);
 
     let paths_to_copy = local
-        .query_requisites(
-            &[&"m1r53pnnm6hnjwyjmxska24y8amvlpjp-hello-2.12.1"
-                .parse()
-                .unwrap()],
-            true,
-        )
+        .query_requisites(&[&"m1r53pnnm6hnjwyjmxska24y8amvlpjp-hello-2.12.1"
+            .parse()
+            .unwrap()])
         .await
         .unwrap_or_default();
 

--- a/subprojects/crates/nix-utils/examples/query_requisites.rs
+++ b/subprojects/crates/nix-utils/examples/query_requisites.rs
@@ -7,15 +7,7 @@ async fn main() {
     let drv = "z3d15qi11dvljq5qz84kak3h0nb12wca-rsyslog-8.2510.0"
         .parse()
         .unwrap();
-    let ps = store.query_requisites(&[&drv], false).await.unwrap();
-    for p in ps {
-        println!("{}", store.print_store_path(&p));
-    }
-
-    println!();
-    println!();
-
-    let ps = store.query_requisites(&[&drv], true).await.unwrap();
+    let ps = store.query_requisites(&[&drv]).await.unwrap();
     for p in ps {
         println!("{}", store.print_store_path(&p));
     }

--- a/subprojects/crates/nix-utils/include/nix.h
+++ b/subprojects/crates/nix-utils/include/nix.h
@@ -37,14 +37,9 @@ bool is_valid_path(const StoreWrapper &wrapper, rust::Str path);
 InternalPathInfo query_path_info(const StoreWrapper &wrapper, rust::Str path);
 void clear_path_info_cache(const StoreWrapper &wrapper);
 uint64_t compute_closure_size(const StoreWrapper &wrapper, rust::Str path);
-rust::Vec<rust::String> compute_fs_closure(const StoreWrapper &wrapper,
-                                           rust::Str path, bool flip_direction,
-                                           bool include_outputs,
-                                           bool include_derivers);
 rust::Vec<rust::String>
 compute_fs_closures(const StoreWrapper &wrapper,
-                    rust::Slice<const rust::Str> paths, bool flip_direction,
-                    bool include_outputs, bool include_derivers, bool toposort);
+                    rust::Slice<const rust::Str> paths);
 void upsert_file(const StoreWrapper &wrapper, rust::Str path, rust::Str data,
                  rust::Str mime_type);
 StoreStats get_store_stats(const StoreWrapper &wrapper);

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -140,23 +140,7 @@ mod ffi {
         fn query_path_info(store: &StoreWrapper, path: &str) -> Result<InternalPathInfo>;
         fn compute_closure_size(store: &StoreWrapper, path: &str) -> Result<u64>;
         fn clear_path_info_cache(store: &StoreWrapper) -> Result<()>;
-        #[allow(clippy::fn_params_excessive_bools)]
-        fn compute_fs_closure(
-            store: &StoreWrapper,
-            path: &str,
-            flip_direction: bool,
-            include_outputs: bool,
-            include_derivers: bool,
-        ) -> Result<Vec<String>>;
-        #[allow(clippy::fn_params_excessive_bools)]
-        fn compute_fs_closures(
-            store: &StoreWrapper,
-            paths: &[&str],
-            flip_direction: bool,
-            include_outputs: bool,
-            include_derivers: bool,
-            toposort: bool,
-        ) -> Result<Vec<String>>;
+        fn compute_fs_closures(store: &StoreWrapper, paths: &[&str]) -> Result<Vec<String>>;
         fn upsert_file(store: &StoreWrapper, path: &str, data: &str, mime_type: &str)
         -> Result<()>;
         fn get_store_stats(store: &StoreWrapper) -> Result<StoreStats>;
@@ -398,29 +382,9 @@ pub trait BaseStore {
 
     fn clear_path_info_cache(&self);
 
-    #[allow(clippy::fn_params_excessive_bools)]
-    fn compute_fs_closure(
-        &self,
-        path: &str,
-        flip_direction: bool,
-        include_outputs: bool,
-        include_derivers: bool,
-    ) -> Result<Vec<String>, cxx::Exception>;
-
-    #[allow(clippy::fn_params_excessive_bools)]
-    fn compute_fs_closures(
-        &self,
-        paths: &[&StorePath],
-        flip_direction: bool,
-        include_outputs: bool,
-        include_derivers: bool,
-        toposort: bool,
-    ) -> impl Future<Output = Result<Vec<StorePath>, Error>>;
-
     fn query_requisites(
         &self,
-        drvs: &[&StorePath],
-        include_outputs: bool,
+        paths: &[&StorePath],
     ) -> impl Future<Output = Result<Vec<StorePath>, Error>>;
 
     fn get_store_stats(&self) -> Result<StoreStats, cxx::Exception>;
@@ -493,6 +457,30 @@ impl BaseStoreImpl {
             wrapper: std::sync::Arc::new(FFIStore(std::cell::UnsafeCell::new(store))),
             store_dir,
         }
+    }
+
+    async fn query_requisites(&self, paths: &[&StorePath]) -> Result<Vec<StorePath>, Error> {
+        let store = self.wrapper.clone();
+        let store_dir = self.store_dir.clone();
+        let paths = paths
+            .iter()
+            .map(|v| self.print_store_path(v))
+            .collect::<Vec<_>>();
+
+        let mut out: Vec<StorePath> = asyncify(move || {
+            let slice = paths.iter().map(String::as_str).collect::<Vec<_>>();
+            Ok(ffi::compute_fs_closures(store.as_raw(), &slice)?
+                .into_iter()
+                .map(|v| {
+                    store_dir
+                        .parse::<StorePath>(&v)
+                        .unwrap_or_else(|e| panic!("invalid store path '{v}': {e}"))
+                })
+                .collect())
+        })
+        .await?;
+        out.reverse();
+        Ok(out)
     }
 }
 
@@ -594,72 +582,8 @@ impl BaseStore for BaseStoreImpl {
         let _ = ffi::clear_path_info_cache(self.wrapper.as_raw());
     }
 
-    #[inline]
-    #[tracing::instrument(skip(self), err)]
-    fn compute_fs_closure(
-        &self,
-        path: &str,
-        flip_direction: bool,
-        include_outputs: bool,
-        include_derivers: bool,
-    ) -> Result<Vec<String>, cxx::Exception> {
-        ffi::compute_fs_closure(
-            self.wrapper.as_raw(),
-            path,
-            flip_direction,
-            include_outputs,
-            include_derivers,
-        )
-    }
-
-    #[inline]
-    #[tracing::instrument(skip(self), err)]
-    async fn compute_fs_closures(
-        &self,
-        paths: &[&StorePath],
-        flip_direction: bool,
-        include_outputs: bool,
-        include_derivers: bool,
-        toposort: bool,
-    ) -> Result<Vec<StorePath>, Error> {
-        let store = self.wrapper.clone();
-        let store_dir = self.store_dir.clone();
-        let paths = paths
-            .iter()
-            .map(|v| self.print_store_path(v))
-            .collect::<Vec<_>>();
-
-        asyncify(move || {
-            let slice = paths.iter().map(String::as_str).collect::<Vec<_>>();
-            Ok(ffi::compute_fs_closures(
-                store.as_raw(),
-                &slice,
-                flip_direction,
-                include_outputs,
-                include_derivers,
-                toposort,
-            )?
-            .into_iter()
-            .map(|v| {
-                store_dir
-                    .parse::<StorePath>(&v)
-                    .unwrap_or_else(|e| panic!("invalid store path '{v}': {e}"))
-            })
-            .collect())
-        })
-        .await
-    }
-
-    async fn query_requisites(
-        &self,
-        drvs: &[&StorePath],
-        include_outputs: bool,
-    ) -> Result<Vec<StorePath>, Error> {
-        let mut out = self
-            .compute_fs_closures(drvs, false, include_outputs, false, true)
-            .await?;
-        out.reverse();
-        Ok(out)
+    async fn query_requisites(&self, paths: &[&StorePath]) -> Result<Vec<StorePath>, Error> {
+        BaseStoreImpl::query_requisites(self, paths).await
     }
 
     fn get_store_stats(&self) -> Result<StoreStats, cxx::Exception> {
@@ -896,46 +820,8 @@ impl BaseStore for LocalStore {
 
     #[inline]
     #[tracing::instrument(skip(self), err)]
-    fn compute_fs_closure(
-        &self,
-        path: &str,
-        flip_direction: bool,
-        include_outputs: bool,
-        include_derivers: bool,
-    ) -> Result<Vec<String>, cxx::Exception> {
-        self.base
-            .compute_fs_closure(path, flip_direction, include_outputs, include_derivers)
-    }
-
-    #[inline]
-    #[tracing::instrument(skip(self), err)]
-    async fn compute_fs_closures(
-        &self,
-        paths: &[&StorePath],
-        flip_direction: bool,
-        include_outputs: bool,
-        include_derivers: bool,
-        toposort: bool,
-    ) -> Result<Vec<StorePath>, Error> {
-        self.base
-            .compute_fs_closures(
-                paths,
-                flip_direction,
-                include_outputs,
-                include_derivers,
-                toposort,
-            )
-            .await
-    }
-
-    #[inline]
-    #[tracing::instrument(skip(self), err)]
-    async fn query_requisites(
-        &self,
-        drvs: &[&StorePath],
-        include_outputs: bool,
-    ) -> Result<Vec<StorePath>, Error> {
-        self.base.query_requisites(drvs, include_outputs).await
+    async fn query_requisites(&self, paths: &[&StorePath]) -> Result<Vec<StorePath>, Error> {
+        self.base.query_requisites(paths).await
     }
 
     #[inline]
@@ -1111,46 +997,8 @@ impl BaseStore for RemoteStore {
 
     #[inline]
     #[tracing::instrument(skip(self), err)]
-    fn compute_fs_closure(
-        &self,
-        path: &str,
-        flip_direction: bool,
-        include_outputs: bool,
-        include_derivers: bool,
-    ) -> Result<Vec<String>, cxx::Exception> {
-        self.base
-            .compute_fs_closure(path, flip_direction, include_outputs, include_derivers)
-    }
-
-    #[inline]
-    #[tracing::instrument(skip(self), err)]
-    async fn compute_fs_closures(
-        &self,
-        paths: &[&StorePath],
-        flip_direction: bool,
-        include_outputs: bool,
-        include_derivers: bool,
-        toposort: bool,
-    ) -> Result<Vec<StorePath>, Error> {
-        self.base
-            .compute_fs_closures(
-                paths,
-                flip_direction,
-                include_outputs,
-                include_derivers,
-                toposort,
-            )
-            .await
-    }
-
-    #[inline]
-    #[tracing::instrument(skip(self), err)]
-    async fn query_requisites(
-        &self,
-        drvs: &[&StorePath],
-        include_outputs: bool,
-    ) -> Result<Vec<StorePath>, Error> {
-        self.base.query_requisites(drvs, include_outputs).await
+    async fn query_requisites(&self, paths: &[&StorePath]) -> Result<Vec<StorePath>, Error> {
+        self.base.query_requisites(paths).await
     }
 
     #[inline]

--- a/subprojects/crates/nix-utils/src/nix.cpp
+++ b/subprojects/crates/nix-utils/src/nix.cpp
@@ -160,35 +160,16 @@ void clear_path_info_cache(const StoreWrapper &wrapper) {
   store->clearPathInfoCache();
 }
 
-rust::Vec<rust::String> compute_fs_closure(const StoreWrapper &wrapper,
-                                           rust::Str path, bool flip_direction,
-                                           bool include_outputs,
-                                           bool include_derivers) {
-  auto store = wrapper._store;
-  nix::StorePathSet path_set;
-  store->computeFSClosure(store->parseStorePath(AS_VIEW(path)), path_set,
-                          flip_direction, include_outputs, include_derivers);
-  return extract_path_set(*store, path_set);
-}
-
 rust::Vec<rust::String> compute_fs_closures(const StoreWrapper &wrapper,
-                                            rust::Slice<const rust::Str> paths,
-                                            bool flip_direction,
-                                            bool include_outputs,
-                                            bool include_derivers,
-                                            bool toposort) {
+                                            rust::Slice<const rust::Str> paths) {
   auto store = wrapper._store;
   nix::StorePathSet path_set;
   for (auto &path : paths) {
     store->computeFSClosure(store->parseStorePath(AS_VIEW(path)), path_set,
-                            flip_direction, include_outputs, include_derivers);
+                            false, false, false);
   }
-  if (toposort) {
-    auto sorted = store->topoSortPaths(path_set);
-    return extract_paths(*store, sorted);
-  } else {
-    return extract_path_set(*store, path_set);
-  }
+  auto sorted = store->topoSortPaths(path_set);
+  return extract_paths(*store, sorted);
 }
 
 void upsert_file(const StoreWrapper &wrapper, rust::Str path, rust::Str data,

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -16,8 +16,8 @@ use crate::types::BuildTimings;
 use binary_cache::{Compression, PresignedUpload, PresignedUploadClient};
 use hydra_proto::ProtoStorePath;
 use hydra_proto::{
-    AbortMessage, BuildMessage, BuildResultInfo, BuildResultState, FetchRequisitesRequest,
-    JoinMessage, NarData, OutputInfo, PingMessage, StepStatus, StepUpdate, StorePaths,
+    AbortMessage, BuildMessage, BuildResultInfo, BuildResultState, JoinMessage, NarData,
+    OutputInfo, PingMessage, StepStatus, StepUpdate, StorePaths,
 };
 use nix_utils::BaseStore as _;
 
@@ -411,10 +411,7 @@ impl State {
             })
             .await;
         let requisites = client
-            .fetch_drv_requisites(FetchRequisitesRequest {
-                path: Some(ProtoStorePath::from(drv.clone())),
-                include_outputs: false,
-            })
+            .fetch_requisites(ProtoStorePath::from(drv.clone()))
             .await
             .map_err(|e| JobFailure::Import(e.into()))?
             .into_inner()
@@ -425,7 +422,6 @@ impl State {
             store.clone(),
             self.metrics.clone(),
             &gcroot,
-            &drv,
             requisites.into_iter().map(|s| s.0),
             usize::try_from(self.max_concurrent_downloads.load(Ordering::Relaxed)).unwrap_or(5),
             self.config.use_substitutes,
@@ -775,14 +771,12 @@ async fn import_paths(
     Ok(())
 }
 
-#[tracing::instrument(skip(client, store, metrics, requisites), fields(%gcroot, %drv), err)]
-#[allow(clippy::too_many_arguments)]
+#[tracing::instrument(skip(client, store, metrics, requisites), fields(%gcroot), err)]
 async fn import_requisites<T: IntoIterator<Item = StorePath>>(
     client: &mut BuilderClient,
     store: nix_utils::LocalStore,
     metrics: Arc<crate::metrics::Metrics>,
     gcroot: &Gcroot,
-    drv: &StorePath,
     requisites: T,
     max_concurrent_downloads: usize,
     use_substitutes: bool,
@@ -826,40 +820,6 @@ async fn import_requisites<T: IntoIterator<Item = StorePath>>(
         .await?;
     }
 
-    let full_requisites = client
-        .clone()
-        .fetch_drv_requisites(FetchRequisitesRequest {
-            path: Some(ProtoStorePath::from(drv.clone())),
-            include_outputs: true,
-        })
-        .await?
-        .into_inner()
-        .requisites
-        .into_iter()
-        .map(|s| s.0)
-        .collect::<Vec<_>>();
-    let full_requisites = futures::StreamExt::map(tokio_stream::iter(full_requisites), |p| {
-        filter_missing(&store, gcroot, p)
-    })
-    .buffered(50)
-    .filter_map(|o| async { o })
-    .collect::<Vec<_>>()
-    .await;
-
-    for other in full_requisites.chunks(max_concurrent_downloads) {
-        // we can skip filtering here as we already done that
-        import_paths(
-            client.clone(),
-            store.clone(),
-            metrics.clone(),
-            gcroot,
-            other.to_vec(),
-            false,
-            use_substitutes,
-        )
-        .await?;
-    }
-
     Ok(())
 }
 
@@ -870,11 +830,8 @@ async fn upload_nars_regular(
     metrics: Arc<crate::metrics::Metrics>,
     nars: Vec<StorePath>,
 ) -> anyhow::Result<()> {
-    // Compute the full closure of output paths so that all referenced
-    // store paths (e.g. dynamically-created derivations from recursive-nix)
-    // are uploaded alongside the direct outputs.
     let nars = store
-        .query_requisites(&nars.iter().collect::<Vec<_>>(), true)
+        .query_requisites(&nars.iter().collect::<Vec<_>>())
         .await
         .unwrap_or(nars);
 
@@ -980,7 +937,7 @@ async fn upload_nars_presigned(
     let before_upload = Instant::now();
 
     let paths_to_upload = store
-        .query_requisites(&output_paths.iter().collect::<Vec<_>>(), true)
+        .query_requisites(&output_paths.iter().collect::<Vec<_>>())
         .await
         .unwrap_or_default();
     let paths_to_upload_ref = paths_to_upload.iter().collect::<Vec<_>>();

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -9,10 +9,10 @@ use tracing::Instrument as _;
 use crate::state::{Machine, MachineMessage, State};
 use hydra_proto::ProtoStorePath;
 use hydra_proto::{
-    BuildResultInfo, BuilderRequest, FetchRequisitesRequest, JoinResponse, LogChunk, NarData,
-    PROTO_API_VERSION, PresignedUploadComplete, PresignedUrlRequest, PresignedUrlResponse,
-    RunnerRequest, SimplePingMessage, StepUpdate, StorePaths, VersionCheckRequest,
-    VersionCheckResponse, builder_request,
+    BuildResultInfo, BuilderRequest, JoinResponse, LogChunk, NarData, PROTO_API_VERSION,
+    PresignedUploadComplete, PresignedUrlRequest, PresignedUrlResponse, RunnerRequest,
+    SimplePingMessage, StepUpdate, StorePaths, VersionCheckRequest, VersionCheckResponse,
+    builder_request,
     runner_service_server::{RunnerService, RunnerServiceServer},
 };
 use nix_utils::BaseStore as _;
@@ -557,20 +557,16 @@ impl RunnerService for Server {
     }
 
     #[tracing::instrument(skip(self, req), err)]
-    async fn fetch_drv_requisites(
+    async fn fetch_requisites(
         &self,
-        req: tonic::Request<FetchRequisitesRequest>,
-    ) -> BuilderResult<hydra_proto::DrvRequisitesMessage> {
+        req: tonic::Request<ProtoStorePath>,
+    ) -> BuilderResult<hydra_proto::RequisitesResponse> {
         let state = self.state.clone();
-        let req = req.into_inner();
-        let drv = req
-            .path
-            .ok_or_else(|| tonic::Status::invalid_argument("missing path"))?
-            .0;
+        let path = req.into_inner().0;
 
         let requisites = state
             .store
-            .query_requisites(&[&drv], req.include_outputs)
+            .query_requisites(&[&path])
             .await
             .map_err(|e| {
                 tracing::error!("failed to toposort drv e={e}");
@@ -580,7 +576,7 @@ impl RunnerService for Server {
             .map(ProtoStorePath::from)
             .collect();
 
-        Ok(tonic::Response::new(hydra_proto::DrvRequisitesMessage {
+        Ok(tonic::Response::new(hydra_proto::RequisitesResponse {
             requisites,
         }))
     }

--- a/subprojects/hydra-queue-runner/src/state/uploader.rs
+++ b/subprojects/hydra-queue-runner/src/state/uploader.rs
@@ -104,7 +104,7 @@ impl Uploader {
         tracing::info!("Start uploading {} paths", msg.store_paths.len());
 
         let paths_to_copy = match local_store
-            .query_requisites(&msg.store_paths.iter().collect::<Vec<_>>(), true)
+            .query_requisites(&msg.store_paths.iter().collect::<Vec<_>>())
             .await
         {
             Ok(paths) => paths,

--- a/subprojects/hydra-queue-runner/src/utils.rs
+++ b/subprojects/hydra-queue-runner/src/utils.rs
@@ -80,10 +80,7 @@ pub async fn substitute_output(
         return Ok(false);
     }
     if let Some(remote_store) = remote_store {
-        let paths_to_copy = store
-            .query_requisites(&[&path], false)
-            .await
-            .unwrap_or_default();
+        let paths_to_copy = store.query_requisites(&[&path]).await.unwrap_or_default();
         let paths_to_copy = remote_store.query_missing_paths(paths_to_copy).await;
         if let Err(e) = remote_store.copy_paths(&store, paths_to_copy, false).await {
             tracing::error!(

--- a/subprojects/proto/v1/streaming.proto
+++ b/subprojects/proto/v1/streaming.proto
@@ -16,7 +16,7 @@ service RunnerService {
   rpc BuildResult(stream NarData) returns (Empty) {}
   rpc BuildStepUpdate(StepUpdate) returns (Empty) {}
   rpc CompleteBuild(BuildResultInfo) returns (Empty) {}
-  rpc FetchDrvRequisites(FetchRequisitesRequest) returns (DrvRequisitesMessage) {}
+  rpc FetchRequisites(nix.store.v1.StorePath) returns (RequisitesResponse) {}
   rpc HasPath(nix.store.v1.StorePath) returns (HasPathResponse) {}
   rpc StreamFile(nix.store.v1.StorePath) returns (stream NarData) {}
   rpc StreamFiles(nix.store.v1.StorePaths) returns (stream NarData) {}
@@ -137,7 +137,7 @@ message BuildMessage {
   // bool enforce_determinism = 6;
 }
 
-message DrvRequisitesMessage {
+message RequisitesResponse {
   repeated nix.store.v1.StorePath requisites = 1;
 }
 
@@ -148,11 +148,6 @@ message AbortMessage {
 message LogChunk {
   nix.store.v1.StorePath drv = 1;
   bytes data = 2;
-}
-
-message FetchRequisitesRequest {
-  nix.store.v1.StorePath path = 1;
-  bool include_outputs = 2;
 }
 
 message HasPathResponse {


### PR DESCRIPTION
The builder's `import_requisites` had a second phase that fetched the derivation closure *with outputs* from the queue runner and imported any missing paths. This was dead weight — the builder hasn't built yet at that point, so outputs aren't available, and the input closure (fetched in the first phase) already covers everything needed.

With that removed, the `include_outputs` field on
`FetchRequisitesRequest` was always `false`. The remaining `true` callers of `query_requisites` all start from output paths (for uploading), where `include_outputs` should have no practical effect (or if it does, it is wrong). So `include_outputs` is removed entirely.

While here, also:

- Rename `FetchDrvRequisites` → `FetchRequisites` (not drv-specific)

- Replace `FetchRequisitesRequest` with bare `StorePath` in the proto

- Rename `DrvRequisitesMessage` → `RequisitesResponse`

- Remove `compute_fs_closure` (singular) — unused outside nix-utils

- Remove `compute_fs_closures` from the `BaseStore` trait — only used internally by `query_requisites`, now private to `BaseStoreImpl`

- Hardcode `flip_direction: false`, `include_derivers: false`, `toposort: true` in the C++ FFI since all callers passed those constant values