### PR TITLE
Clean up `InternalPathInfo` FFI struct 

### DIFF
--- a/subprojects/crates/nix-utils/include/utils.h
+++ b/subprojects/crates/nix-utils/include/utils.h
@@ -6,9 +6,6 @@
 #define AS_VIEW(rstr) std::string_view(rstr.data(), rstr.length())
 #define AS_STRING(rstr) std::string(rstr.data(), rstr.length())
 
-rust::String extract_opt_path(const nix::Store &store,
-                              const std::optional<nix::StorePath> &v);
-rust::Vec<rust::String> extract_path_set(const nix::Store &store,
-                                         const nix::StorePathSet &set);
-rust::Vec<rust::String> extract_paths(const nix::Store &store,
-                                      const nix::StorePaths &set);
+rust::String extract_opt_path(const std::optional<nix::StorePath> &v);
+rust::Vec<rust::String> extract_path_set(const nix::StorePathSet &set);
+rust::Vec<rust::String> extract_paths(const nix::StorePaths &set);

--- a/subprojects/crates/nix-utils/src/cxx/utils.cpp
+++ b/subprojects/crates/nix-utils/src/cxx/utils.cpp
@@ -2,28 +2,29 @@
 
 #include <nix/store/store-api.hh>
 
-rust::String extract_opt_path(const nix::Store &store,
-                              const std::optional<nix::StorePath> &v) {
+rust::String extract_opt_path(const std::optional<nix::StorePath> &v) {
   // TODO(conni2461): Replace with option
-  return v ? store.printStorePath(*v) : "";
+  if (!v) return "";
+  auto s = v->to_string();
+  return rust::String(s.data(), s.size());
 }
 
-rust::Vec<rust::String> extract_path_set(const nix::Store &store,
-                                         const nix::StorePathSet &set) {
+rust::Vec<rust::String> extract_path_set(const nix::StorePathSet &set) {
   rust::Vec<rust::String> data;
   data.reserve(set.size());
   for (const nix::StorePath &path : set) {
-    data.emplace_back(store.printStorePath(path));
+    auto s = path.to_string();
+    data.push_back(rust::String(s.data(), s.size()));
   }
   return data;
 }
 
-rust::Vec<rust::String> extract_paths(const nix::Store &store,
-                                      const nix::StorePaths &set) {
+rust::Vec<rust::String> extract_paths(const nix::StorePaths &set) {
   rust::Vec<rust::String> data;
   data.reserve(set.size());
   for (const nix::StorePath &path : set) {
-    data.emplace_back(store.printStorePath(path));
+    auto s = path.to_string();
+    data.push_back(rust::String(s.data(), s.size()));
   }
   return data;
 }

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -79,6 +79,7 @@ mod ffi {
 
     #[derive(Debug, Clone)]
     struct InternalPathInfo {
+        store_dir: String,
         deriver: String,
         nar_hash: Vec<u8>,
         registration_time: i64,
@@ -334,15 +335,16 @@ fn parse_ca(s: &str) -> Option<harmonia_store_core::store_path::ContentAddress> 
 
 impl From<ffi::InternalPathInfo> for UnkeyedValidPathInfo {
     fn from(val: ffi::InternalPathInfo) -> Self {
-        let store_dir = get_store_dir();
+        let store_dir = StoreDir::new(&val.store_dir)
+            .unwrap_or_else(|e| panic!("invalid store dir '{}': {e}", val.store_dir));
         Self {
             deriver: if val.deriver.is_empty() {
                 None
             } else {
                 Some(
-                    store_dir
-                        .parse::<StorePath>(&val.deriver)
-                        .unwrap_or_else(|e| panic!("invalid deriver path '{}': {e}", val.deriver)),
+                    val.deriver
+                        .parse::<StorePath>()
+                        .unwrap_or_else(|e| panic!("invalid deriver '{}': {e}", val.deriver)),
                 )
             },
             nar_hash: nar_hash_from_bytes(&val.nar_hash),
@@ -352,9 +354,8 @@ impl From<ffi::InternalPathInfo> for UnkeyedValidPathInfo {
                 .refs
                 .iter()
                 .map(|v| {
-                    store_dir
-                        .parse::<StorePath>(v)
-                        .unwrap_or_else(|e| panic!("invalid reference path '{v}': {e}"))
+                    v.parse::<StorePath>()
+                        .unwrap_or_else(|e| panic!("invalid reference '{v}': {e}"))
                 })
                 .collect(),
             signatures: val.sigs.iter().map(|s| parse_signature(s)).collect(),
@@ -461,7 +462,6 @@ impl BaseStoreImpl {
 
     async fn query_requisites(&self, paths: &[&StorePath]) -> Result<Vec<StorePath>, Error> {
         let store = self.wrapper.clone();
-        let store_dir = self.store_dir.clone();
         let paths = paths
             .iter()
             .map(|v| self.print_store_path(v))
@@ -472,8 +472,7 @@ impl BaseStoreImpl {
             Ok(ffi::compute_fs_closures(store.as_raw(), &slice)?
                 .into_iter()
                 .map(|v| {
-                    store_dir
-                        .parse::<StorePath>(&v)
+                    v.parse::<StorePath>()
                         .unwrap_or_else(|e| panic!("invalid store path '{v}': {e}"))
                 })
                 .collect())

--- a/subprojects/crates/nix-utils/src/nix.cpp
+++ b/subprojects/crates/nix-utils/src/nix.cpp
@@ -122,17 +122,19 @@ InternalPathInfo query_path_info(const StoreWrapper &wrapper, rust::Str path) {
     narhash_bytes.push_back(info->narHash.hash[i]);
   }
 
-  rust::Vec<rust::String> refs = extract_path_set(*store, info->references);
+  rust::Vec<rust::String> refs = extract_path_set(info->references);
 
   rust::Vec<rust::String> sigs;
   sigs.reserve(info->sigs.size());
   for (const auto &sig : info->sigs) {
-    sigs.push_back(sig.to_string());
+    auto s = sig.to_string();
+    sigs.push_back(rust::String(s.data(), s.size()));
   }
 
   // TODO(conni2461): Replace "" with option
   return InternalPathInfo{
-      extract_opt_path(*store, info->deriver),
+      rust::String(store->storeDir.data(), store->storeDir.size()),
+      extract_opt_path(info->deriver),
       narhash_bytes,
       info->registrationTime,
       info->narSize,
@@ -169,7 +171,7 @@ rust::Vec<rust::String> compute_fs_closures(const StoreWrapper &wrapper,
                             false, false, false);
   }
   auto sorted = store->topoSortPaths(path_set);
-  return extract_paths(*store, sorted);
+  return extract_paths(sorted);
 }
 
 void upsert_file(const StoreWrapper &wrapper, rust::Str path, rust::Str data,


### PR DESCRIPTION
- Add `store_dir` field so the store directory travels with the path
  info rather than being recovered from a global

- Return deriver and references as bare base names (no `/nix/store/`
  prefix) — the Rust side parses them with `StorePath::from_base_path`
  instead of `StoreDir::parse`, removing the redundant store dir prefix
  from every string

- Update `extract_path_set` / `extract_paths` / `extract_opt_path`
  helpers to return bare names and drop the unused `Store &` parameter