### PR TITLE
Use NAR sizes to split the decompressed stream in Rust

### DIFF
--- a/subprojects/crates/nix-utils/include/nix.h
+++ b/subprojects/crates/nix-utils/include/nix.h
@@ -47,10 +47,10 @@ void copy_paths(const StoreWrapper &src_store, const StoreWrapper &dst_store,
                 rust::Slice<const rust::Str> paths, bool repair,
                 bool check_sigs, bool substitute);
 
-void add_multiple_to_store(
-    const StoreWrapper &wrapper, rust::Slice<const rust::Str> paths,
-    const rust::Vec<InternalPathInfo> &infos, bool check_sigs,
-    size_t runtime, size_t reader,
+void add_to_store(
+    const StoreWrapper &wrapper, rust::Str path,
+    const InternalPathInfo &info, bool check_sigs, size_t runtime,
+    size_t reader,
     rust::Fn<size_t(rust::Slice<uint8_t>, size_t, size_t, size_t)> callback,
     size_t user_data);
 void nar_from_path(const StoreWrapper &src_store, rust::Str path,

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -154,10 +154,10 @@ mod ffi {
             substitute: bool,
         ) -> Result<()>;
 
-        fn add_multiple_to_store(
+        fn add_to_store(
             store: &StoreWrapper,
-            paths: &[&str],
-            infos: &Vec<InternalPathInfo>,
+            path: &str,
+            info: &InternalPathInfo,
             check_sigs: bool,
             runtime: usize,
             reader: usize,
@@ -409,13 +409,11 @@ pub trait BaseStore {
 
     fn get_store_stats(&self) -> Result<StoreStats, cxx::Exception>;
 
-    /// Add multiple store paths with their NAR data to the store.
-    /// Paths must be in dependency order (references before referrers).
-    /// The NAR stream must contain the NARs for all paths concatenated
-    /// in the same order.
-    fn add_multiple_to_store<S>(
+    /// Add a single store path with its NAR data to the store.
+    /// The C++ side verifies that exactly `nar_size` bytes are consumed.
+    fn add_to_store<S>(
         &self,
-        path_infos: &[harmonia_store_path_info::ValidPathInfo],
+        path_info: &harmonia_store_path_info::ValidPathInfo,
         nar_stream: S,
         check_sigs: bool,
     ) -> impl Future<Output = Result<(), Error>>
@@ -603,9 +601,9 @@ impl BaseStore for BaseStoreImpl {
     }
 
     #[tracing::instrument(skip(self, nar_stream), err)]
-    async fn add_multiple_to_store<S>(
+    async fn add_to_store<S>(
         &self,
-        path_infos: &[harmonia_store_path_info::ValidPathInfo],
+        path_info: &harmonia_store_path_info::ValidPathInfo,
         nar_stream: S,
         check_sigs: bool,
     ) -> Result<(), Error>
@@ -615,19 +613,12 @@ impl BaseStore for BaseStoreImpl {
             + Unpin
             + 'static,
     {
-        let store_dir = self.store_dir();
-        let path_strs: Vec<String> = path_infos
-            .iter()
-            .map(|pi| self.print_store_path(&pi.path))
-            .collect();
-        let internal_infos: Vec<ffi::InternalPathInfo> = path_infos
-            .iter()
-            .map(|pi| to_internal_path_info(store_dir, &pi.info))
-            .collect();
+        let path_str = self.print_store_path(&path_info.path);
+        let internal_info = to_internal_path_info(self.store_dir(), &path_info.info);
         let reader = Box::new(tokio_util::io::StreamReader::new(nar_stream));
         let store = self.clone();
         tokio::task::spawn_blocking(move || {
-            store.add_multiple_to_store_with_cb(path_strs, internal_infos, reader, check_sigs)
+            store.add_to_store_with_cb(path_str, internal_info, reader, check_sigs)
         })
         .await?
     }
@@ -666,10 +657,10 @@ impl BaseStore for BaseStoreImpl {
 
 impl BaseStoreImpl {
     #[tracing::instrument(skip(self, reader), err)]
-    fn add_multiple_to_store_with_cb<S>(
+    fn add_to_store_with_cb<S>(
         &self,
-        paths: Vec<String>,
-        infos: Vec<ffi::InternalPathInfo>,
+        path: String,
+        info: ffi::InternalPathInfo,
         reader: Box<tokio_util::io::StreamReader<S, bytes::Bytes>>,
         check_sigs: bool,
     ) -> Result<(), Error>
@@ -688,12 +679,11 @@ impl BaseStoreImpl {
             runtime.block_on(async { reader.read(data).await.unwrap_or(0) })
         };
 
-        let path_strs: Vec<&str> = paths.iter().map(String::as_str).collect();
         let runtime = Box::new(tokio::runtime::Runtime::new()?);
-        ffi::add_multiple_to_store(
+        ffi::add_to_store(
             self.wrapper.as_raw(),
-            &path_strs,
-            &infos,
+            &path,
+            &info,
             check_sigs,
             std::ptr::addr_of!(runtime).cast::<std::ffi::c_void>() as usize,
             std::ptr::addr_of!(reader).cast::<std::ffi::c_void>() as usize,
@@ -826,9 +816,9 @@ impl BaseStore for LocalStore {
         self.base.get_store_stats()
     }
 
-    async fn add_multiple_to_store<S>(
+    async fn add_to_store<S>(
         &self,
-        path_infos: &[harmonia_store_path_info::ValidPathInfo],
+        path_info: &harmonia_store_path_info::ValidPathInfo,
         nar_stream: S,
         check_sigs: bool,
     ) -> Result<(), Error>
@@ -839,7 +829,7 @@ impl BaseStore for LocalStore {
             + 'static,
     {
         self.base
-            .add_multiple_to_store(path_infos, nar_stream, check_sigs)
+            .add_to_store(path_info, nar_stream, check_sigs)
             .await
     }
 
@@ -990,9 +980,9 @@ impl BaseStore for RemoteStore {
         self.base.get_store_stats()
     }
 
-    async fn add_multiple_to_store<S>(
+    async fn add_to_store<S>(
         &self,
-        path_infos: &[harmonia_store_path_info::ValidPathInfo],
+        path_info: &harmonia_store_path_info::ValidPathInfo,
         nar_stream: S,
         check_sigs: bool,
     ) -> Result<(), Error>
@@ -1003,7 +993,7 @@ impl BaseStore for RemoteStore {
             + 'static,
     {
         self.base
-            .add_multiple_to_store(path_infos, nar_stream, check_sigs)
+            .add_to_store(path_info, nar_stream, check_sigs)
             .await
     }
 

--- a/subprojects/crates/nix-utils/src/nix.cpp
+++ b/subprojects/crates/nix-utils/src/nix.cpp
@@ -246,13 +246,14 @@ reconstruct_vpi(nix::ref<nix::Store> store, rust::Str path,
   return nix::ValidPathInfo(storePath, std::move(upi));
 }
 
-void add_multiple_to_store(
-    const StoreWrapper &wrapper, rust::Slice<const rust::Str> paths,
-    const rust::Vec<InternalPathInfo> &infos, bool check_sigs,
+void add_to_store(
+    const StoreWrapper &wrapper, rust::Str path,
+    const InternalPathInfo &info, bool check_sigs,
     size_t runtime, size_t reader,
     rust::Fn<size_t(rust::Slice<uint8_t>, size_t, size_t, size_t)> callback,
     size_t user_data) {
   auto store = wrapper._store;
+  auto vpi = reconstruct_vpi(store, path, info);
 
   nix::LambdaSource source([=](char *out, size_t out_len) {
     auto data = rust::Slice<uint8_t>((uint8_t *)out, out_len);
@@ -263,11 +264,8 @@ void add_multiple_to_store(
     return ret;
   });
 
-  for (size_t i = 0; i < paths.size(); i++) {
-    auto vpi = reconstruct_vpi(store, paths[i], infos[i]);
-    store->addToStore(vpi, source, nix::NoRepair,
-                      check_sigs ? nix::CheckSigs : nix::NoCheckSigs);
-  }
+  store->addToStore(vpi, source, nix::NoRepair,
+                    check_sigs ? nix::CheckSigs : nix::NoCheckSigs);
 }
 
 class StopExport : public std::exception {

--- a/subprojects/crates/store-transfer/src/export.rs
+++ b/subprojects/crates/store-transfer/src/export.rs
@@ -7,8 +7,8 @@ use nix_utils::BaseStore;
 /// Export store paths as `AddToStoreRequest` messages over a gRPC channel.
 ///
 /// Sends an [`AddToStoreHeader`] containing all path infos first,
-/// then zstd-compressed `nar_chunk` messages for each path's NAR
-/// data concatenated in the same order.
+/// then zstd-compressed `nar_chunk` messages with all NARs
+/// concatenated in the same order. One continuous zstd stream.
 ///
 /// The `infos` map must contain an entry for every path. Paths
 /// missing from the map are skipped.
@@ -45,22 +45,32 @@ pub fn export(
         return;
     }
 
-    // Stream all NARs compressed with zstd.
+    // Stream all NARs as one continuous zstd-compressed stream.
     let mut encoder =
         zstd::stream::Encoder::new(NarChunkWriter(tx), 3).expect("failed to create zstd encoder");
 
     for path in paths {
-        if !infos.contains_key(path) {
+        let Some(info) = infos.get(path) else {
             continue;
-        }
+        };
+
+        let mut bytes_written: u64 = 0;
         let enc = &mut encoder;
+        let written = &mut bytes_written;
         let closure = |data: &[u8]| -> bool {
             use std::io::Write;
+            *written += data.len() as u64;
             enc.write_all(data).is_ok()
         };
         if store.nar_from_path(path, closure).is_err() {
             break;
         }
+
+        assert_eq!(
+            bytes_written, info.nar_size,
+            "NAR size mismatch for {path}: wrote {bytes_written} bytes, expected {}",
+            info.nar_size
+        );
     }
 
     let _ = encoder.finish();

--- a/subprojects/crates/store-transfer/src/import.rs
+++ b/subprojects/crates/store-transfer/src/import.rs
@@ -3,11 +3,13 @@
 /// Import store paths from a gRPC `stream AddToStoreRequest`.
 ///
 /// The first message must be an [`AddToStoreHeader`] containing all
-/// [`ValidPathInfo`]s. Subsequent messages must be zstd-compressed
-/// `nar_chunk` bytes containing the NARs for all paths concatenated
-/// in the same (dependency) order as the header.
-pub async fn import(
-    store: &impl nix_utils::BaseStore,
+/// [`ValidPathInfo`]s (including NAR sizes). Then zstd-compressed
+/// `nar_chunk` bytes with all NARs concatenated in header order.
+///
+/// Rust splits the decompressed stream by counting `nar_size` bytes
+/// per path and feeds each slice into `add_to_store`.
+pub async fn import<Store: nix_utils::BaseStore + Clone + Send + 'static>(
+    store: &Store,
     mut stream: tonic::Streaming<hydra_proto::AddToStoreRequest>,
 ) -> Result<Vec<harmonia_store_core::store_path::StorePath>, nix_utils::Error> {
     use futures::StreamExt as _;
@@ -49,14 +51,10 @@ pub async fn import(
         return Ok(paths);
     }
 
-    // Pipe compressed NAR data through a zstd decoder into
-    // add_multiple_to_store. Spawn the stream reader so it can write
-    // concurrently while add_multiple_to_store reads from the other end.
+    // Pipe compressed gRPC chunks through a zstd decoder. A spawned
+    // task writes the compressed data; we read decompressed bytes
+    // from the other end.
     let (mut compressed_writer, compressed_reader) = tokio::io::duplex(256 * 1024);
-    let decoder = async_compression::tokio::bufread::ZstdDecoder::new(tokio::io::BufReader::new(
-        compressed_reader,
-    ));
-    let nar_stream = tokio_util::io::ReaderStream::new(decoder);
 
     let writer_handle = tokio::spawn(async move {
         while let Some(msg) = stream.next().await {
@@ -70,9 +68,43 @@ pub async fn import(
         Ok::<(), anyhow::Error>(())
     });
 
-    store
-        .add_multiple_to_store(&path_infos, nar_stream, false)
-        .await?;
+    let mut decoder = async_compression::tokio::bufread::ZstdDecoder::new(
+        tokio::io::BufReader::new(compressed_reader),
+    );
+
+    // Import each path by reading exactly nar_size decompressed bytes
+    // into a per-path duplex pipe feeding add_to_store.
+    for pi in &path_infos {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let (mut nar_writer, nar_reader) = tokio::io::duplex(256 * 1024);
+        let nar_stream = tokio_util::io::ReaderStream::new(nar_reader);
+
+        let copy_fut = async {
+            let mut remaining = pi.info.nar_size;
+            let mut buf = vec![0u8; 64 * 1024];
+            while remaining > 0 {
+                let to_read = buf.len().min(remaining as usize);
+                let n = decoder.read(&mut buf[..to_read]).await?;
+                if n == 0 {
+                    return Err(anyhow::anyhow!(
+                        "unexpected end of NAR stream for {}, {remaining} bytes remaining",
+                        pi.path
+                    ));
+                }
+                nar_writer.write_all(&buf[..n]).await?;
+                remaining -= n as u64;
+            }
+            drop(nar_writer);
+            Ok::<(), anyhow::Error>(())
+        };
+
+        let store_fut = store.add_to_store(pi, nar_stream, false);
+
+        let (copy_result, store_result) = futures::future::join(copy_fut, store_fut).await;
+        copy_result.map_err(Error::Anyhow)?;
+        store_result?;
+    }
 
     writer_handle
         .await

--- a/subprojects/proto/v1/streaming.proto
+++ b/subprojects/proto/v1/streaming.proto
@@ -157,9 +157,12 @@ message AddToStoreRequest {
   // Rules below for streaming (i.e. `stream AddToStoreRequest`). Pity we cannot
   // encode this in gRPC types.
   oneof content {
-    // First send one of these
+    // First send one of these. The header includes NAR sizes so the
+    // receiver knows how many uncompressed bytes to expect per path.
     AddToStoreHeader header = 1;
-    // Then send as many of these as are needed.
+    // Then send as many of these as are needed. These are for a single
+    // zstd-compressed NAR data for all paths concatenated in header
+    // order.
     bytes nar_chunk = 2;
   }
 }


### PR DESCRIPTION
On the import side, the per-path loop now lives in Rust (`store-transfer::import`), not C++. For each path, Rust reads exactly `nar_size` decompressed bytes and feeds them into a per-path `add_to_store` call. This means Rust owns all the framing logic — the C++ FFI is just a thin single-path `addToStore` wrapper with no loop. In particular, we are no longer relying on the `addToStore` to only consume the NAR and nothing after, which was doing by parsing the NAR.

The export side asserts that bytes produced by `nar_from_path` match `nar_size`. This doesn't catch anything the importere would catch, but is a nice-to-have to catch mistakes sooner.

Removed `add_multiple_to_store` from both the C++ FFI and the Rust `BaseStore` trait, replaced by single-path `add_to_store`.