### PR TITLE
Replace `harmonia-store-core` with its split-out successor crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,11 +291,13 @@ dependencies = [
  "futures",
  "harmonia-file-core",
  "harmonia-file-nar",
- "harmonia-store-core",
+ "harmonia-store-derivation",
  "harmonia-store-nar-info",
+ "harmonia-store-path",
  "harmonia-store-path-info",
  "harmonia-utils-hash",
  "harmonia-utils-io",
+ "harmonia-utils-signature",
  "hashbrown 0.16.1",
  "hydra-tracing",
  "moka",
@@ -856,7 +858,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
- "harmonia-store-core",
+ "harmonia-store-derivation",
+ "harmonia-store-path",
  "harmonia-utils-hash",
  "hashbrown 0.16.1",
  "jiff",
@@ -1321,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "harmonia-file-core"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#a00729d8917d9155e7144c532f867499a89006c6"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
 dependencies = [
  "serde",
  "serde_json",
@@ -1331,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "harmonia-file-nar"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#a00729d8917d9155e7144c532f867499a89006c6"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
 dependencies = [
  "bstr",
  "bytes",
@@ -1355,9 +1358,12 @@ dependencies = [
 [[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#a00729d8917d9155e7144c532f867499a89006c6"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
 dependencies = [
- "harmonia-store-core",
+ "bytes",
+ "harmonia-store-content-address",
+ "harmonia-store-derivation",
+ "harmonia-store-path",
  "harmonia-utils-hash",
  "memchr",
  "serde_json",
@@ -1365,51 +1371,78 @@ dependencies = [
 ]
 
 [[package]]
-name = "harmonia-store-core"
+name = "harmonia-store-content-address"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
+dependencies = [
+ "derive_more",
+ "harmonia-store-path",
+ "harmonia-utils-hash",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "harmonia-store-derivation"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#a00729d8917d9155e7144c532f867499a89006c6"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
 dependencies = [
  "bytes",
  "data-encoding",
  "derive_more",
- "ed25519-dalek",
- "getrandom 0.4.2",
+ "harmonia-store-content-address",
+ "harmonia-store-path",
  "harmonia-utils-base-encoding",
  "harmonia-utils-hash",
+ "harmonia-utils-signature",
  "serde",
  "serde_json",
- "subtle",
  "thiserror",
- "tracing",
  "zerocopy",
- "zeroize",
 ]
 
 [[package]]
 name = "harmonia-store-nar-info"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#a00729d8917d9155e7144c532f867499a89006c6"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
 dependencies = [
- "harmonia-store-core",
+ "harmonia-store-content-address",
+ "harmonia-store-path",
  "harmonia-store-path-info",
  "harmonia-utils-hash",
+ "harmonia-utils-signature",
  "serde",
+]
+
+[[package]]
+name = "harmonia-store-path"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
+dependencies = [
+ "derive_more",
+ "harmonia-utils-base-encoding",
+ "harmonia-utils-hash",
+ "serde",
+ "thiserror",
+ "zerocopy",
 ]
 
 [[package]]
 name = "harmonia-store-path-info"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#a00729d8917d9155e7144c532f867499a89006c6"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
 dependencies = [
- "harmonia-store-core",
+ "harmonia-store-content-address",
+ "harmonia-store-path",
  "harmonia-utils-hash",
+ "harmonia-utils-signature",
  "serde",
 ]
 
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#a00729d8917d9155e7144c532f867499a89006c6"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1419,7 +1452,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#a00729d8917d9155e7144c532f867499a89006c6"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1435,12 +1468,27 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#a00729d8917d9155e7144c532f867499a89006c6"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
 dependencies = [
  "bytes",
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "harmonia-utils-signature"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#da75ec931d6867f7ee41c67d64ce9d6b14a72e27"
+dependencies = [
+ "data-encoding",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "harmonia-utils-base-encoding",
+ "serde",
+ "subtle",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -1610,7 +1658,8 @@ dependencies = [
  "fs-err",
  "futures",
  "gethostname",
- "harmonia-store-core",
+ "harmonia-store-derivation",
+ "harmonia-store-path",
  "harmonia-store-path-info",
  "harmonia-utils-hash",
  "hashbrown 0.16.1",
@@ -1648,10 +1697,12 @@ version = "0.1.0"
 dependencies = [
  "db",
  "fs-err",
- "harmonia-store-core",
+ "harmonia-store-content-address",
  "harmonia-store-nar-info",
+ "harmonia-store-path",
  "harmonia-store-path-info",
  "harmonia-utils-hash",
+ "harmonia-utils-signature",
  "nix-support",
  "prost",
  "sha2 0.10.9",
@@ -1679,8 +1730,9 @@ dependencies = [
  "futures",
  "futures-util",
  "h2",
- "harmonia-store-core",
+ "harmonia-store-derivation",
  "harmonia-store-nar-info",
+ "harmonia-store-path",
  "harmonia-store-path-info",
  "harmonia-utils-hash",
  "hashbrown 0.16.1",
@@ -2292,7 +2344,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fs-err",
- "harmonia-store-core",
+ "harmonia-store-derivation",
+ "harmonia-store-path",
  "harmonia-utils-hash",
  "regex",
  "sha2 0.10.9",
@@ -2312,9 +2365,12 @@ dependencies = [
  "fs-err",
  "futures",
  "harmonia-store-aterm",
- "harmonia-store-core",
+ "harmonia-store-content-address",
+ "harmonia-store-derivation",
+ "harmonia-store-path",
  "harmonia-store-path-info",
  "harmonia-utils-hash",
+ "harmonia-utils-signature",
  "hashbrown 0.16.1",
  "pkg-config",
  "serde",
@@ -3855,7 +3911,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "store-path-utils"
 version = "0.1.0"
 dependencies = [
- "harmonia-store-core",
+ "harmonia-store-path",
 ]
 
 [[package]]
@@ -3866,7 +3922,7 @@ dependencies = [
  "async-compression",
  "bytes",
  "futures",
- "harmonia-store-core",
+ "harmonia-store-path",
  "harmonia-store-path-info",
  "hashbrown 0.16.1",
  "hydra-proto",
@@ -4934,15 +4990,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4974,28 +5021,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5020,12 +5050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5036,12 +5060,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5056,22 +5074,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5086,12 +5092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5102,12 +5102,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5122,12 +5116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5138,12 +5126,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,15 @@ h2 = "0.4"
 harmonia-file-core = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-file-nar = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-store-aterm = { git = "https://github.com/nix-community/harmonia.git" }
-harmonia-store-core = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-content-address = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-derivation = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-store-nar-info = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-path = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-store-path-info = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-hash = { git = "https://github.com/nix-community/harmonia.git" }
 harmonia-utils-io = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-signature = { git = "https://github.com/nix-community/harmonia.git" }
 hashbrown = "0.16"
 http = "1.1"
 http-body-util = "0.1"
@@ -111,12 +114,15 @@ store-transfer   = { path = "subprojects/crates/store-transfer" }
 test-utils       = { path = "subprojects/crates/test-utils" }
 
 [patch.crates-io]
-harmonia-file-core           = { git = "https://github.com/nix-community/harmonia.git" }
-harmonia-file-nar            = { git = "https://github.com/nix-community/harmonia.git" }
-harmonia-store-aterm         = { git = "https://github.com/nix-community/harmonia.git" }
-harmonia-store-core          = { git = "https://github.com/nix-community/harmonia.git" }
-harmonia-store-nar-info      = { git = "https://github.com/nix-community/harmonia.git" }
-harmonia-store-path-info     = { git = "https://github.com/nix-community/harmonia.git" }
-harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia.git" }
-harmonia-utils-hash          = { git = "https://github.com/nix-community/harmonia.git" }
-harmonia-utils-io            = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-file-core             = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-file-nar              = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-aterm           = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-content-address = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-derivation      = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-nar-info        = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-path            = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-path-info       = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-base-encoding   = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-hash            = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-io              = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-signature       = { git = "https://github.com/nix-community/harmonia.git" }

--- a/packaging/cargo-output-hashes.nix
+++ b/packaging/cargo-output-hashes.nix
@@ -1,5 +1,5 @@
 # Shared outputHashes for cargoLock across all Rust crates.
 # Update this file when the harmonia dependency changes.
 {
-  "harmonia-store-core-0.0.0-alpha.0" = "sha256-bSKOZiqpwRA+RZ+Q1lYgkNMd2PhJDFD1SGqTlyN9lFU=";
+  "harmonia-store-derivation-0.0.0-alpha.0" = "sha256-8fdUxZKxrUmj3Ymzo5/pDXnRM/xC5M7jv+ULPGwWuCs=";
 }

--- a/subprojects/crates/binary-cache/Cargo.toml
+++ b/subprojects/crates/binary-cache/Cargo.toml
@@ -37,14 +37,16 @@ tokio = { workspace = true, features = [ "full" ] }
 tokio-stream = { workspace = true, features = [ "io-util" ] }
 tokio-util = { workspace = true, features = [ "io", "io-util" ] }
 
-harmonia-file-core.workspace       = true
-harmonia-file-nar.workspace        = true
-harmonia-store-core.workspace      = true
-harmonia-store-nar-info.workspace  = true
-harmonia-store-path-info.workspace = true
-harmonia-utils-hash.workspace      = true
-harmonia-utils-io.workspace        = true
-nix-utils.workspace                = true
+harmonia-file-core.workspace        = true
+harmonia-file-nar.workspace         = true
+harmonia-store-derivation.workspace = true
+harmonia-store-nar-info.workspace   = true
+harmonia-store-path.workspace       = true
+harmonia-store-path-info.workspace  = true
+harmonia-utils-hash.workspace       = true
+harmonia-utils-io.workspace         = true
+harmonia-utils-signature.workspace  = true
+nix-utils.workspace                 = true
 
 [dev-dependencies]
 hydra-tracing.workspace = true

--- a/subprojects/crates/binary-cache/examples/simple_presigned.rs
+++ b/subprojects/crates/binary-cache/examples/simple_presigned.rs
@@ -20,8 +20,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let upload_client = PresignedUploadClient::new();
 
     let paths_to_copy = store
-        .query_requisites(&[&harmonia_store_core::store_path::StoreDir::default()
-            .parse::<harmonia_store_core::store_path::StorePath>(
+        .query_requisites(&[&harmonia_store_path::StoreDir::default()
+            .parse::<harmonia_store_path::StorePath>(
                 "/nix/store/m1r53pnnm6hnjwyjmxska24y8amvlpjp-hello-2.12.1",
             )
             .unwrap()])

--- a/subprojects/crates/binary-cache/examples/upload_realisation.rs
+++ b/subprojects/crates/binary-cache/examples/upload_realisation.rs
@@ -1,5 +1,5 @@
 use binary_cache::S3BinaryCacheClient;
-use harmonia_store_core::realisation::DrvOutput;
+use harmonia_store_derivation::realisation::DrvOutput;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/subprojects/crates/binary-cache/src/debug_info.rs
+++ b/subprojects/crates/binary-cache/src/debug_info.rs
@@ -4,7 +4,7 @@
 //! from NIX store paths that contain debug symbols in the standard
 //! `lib/debug/.build-id` directory structure.
 
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use nix_utils::BaseStore as _;
 
 use crate::CacheError;
@@ -132,7 +132,7 @@ pub(crate) trait DebugInfoClient {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use harmonia_store_core::store_path::StoreDir;
+    use harmonia_store_path::StoreDir;
 
     use super::*;
 

--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -24,9 +24,9 @@ use object_store::{ObjectStore as _, ObjectStoreExt as _, signer::Signer as _};
 use secrecy::ExposeSecret;
 use smallvec::SmallVec;
 
-use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::realisation::{DrvOutput, Realisation};
-use harmonia_store_core::store_path::{StoreDir, StorePath};
+use harmonia_store_derivation::derived_path::OutputName;
+use harmonia_store_derivation::realisation::{DrvOutput, Realisation};
+use harmonia_store_path::{StoreDir, StorePath};
 use nix_utils::BaseStore as _;
 // Realisation writing is now done by the caller, not via FFI query.
 
@@ -682,7 +682,7 @@ impl S3BinaryCacheClient {
             .signing_keys
             .iter()
             .filter_map(|s| s.expose_secret().parse().ok())
-            .collect::<SmallVec<[harmonia_store_core::signature::SecretKey; 4]>>();
+            .collect::<SmallVec<[harmonia_utils_signature::SecretKey; 4]>>();
         realisation.value.sign_mut(&realisation.key, &keys);
 
         let json = serde_json::to_string(&realisation)?;

--- a/subprojects/crates/binary-cache/src/narinfo.rs
+++ b/subprojects/crates/binary-cache/src/narinfo.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeSet;
 
-use harmonia_store_core::signature::{SecretKey, Signature, fingerprint_path};
-use harmonia_store_core::store_path::{ParseStorePathError, StoreDir, StorePath};
 use harmonia_store_nar_info::{UnkeyedNarInfo, format_narinfo_txt as harmonia_format_narinfo_txt};
+use harmonia_store_path::{ParseStorePathError, StoreDir, StorePath};
+use harmonia_store_path_info::fingerprint_path;
 use harmonia_store_path_info::{NarHash, UnkeyedValidPathInfo};
 use harmonia_utils_hash::Hash;
 use harmonia_utils_hash::fmt::CommonHash as _;
+use harmonia_utils_signature::{SecretKey, Signature};
 use secrecy::ExposeSecret as _;
 
 use crate::Compression;
@@ -95,9 +96,14 @@ pub fn clear_sigs_and_sign(
     signing_keys: &[secrecy::SecretString],
 ) -> NarInfo {
     narinfo.info.info.signatures.clear();
-    if !signing_keys.is_empty()
-        && let Some(fp) = narinfo_fingerprint(&narinfo, store_dir)
-    {
+    if !signing_keys.is_empty() {
+        let fp = fingerprint_path(
+            store_dir,
+            &narinfo.path,
+            &narinfo.info.info.nar_hash,
+            narinfo.info.info.nar_size,
+            &narinfo.info.info.references,
+        );
         for s in signing_keys {
             if let Ok(sk) = s.expose_secret().parse::<SecretKey>() {
                 narinfo.info.info.signatures.insert(sk.sign(&fp));
@@ -105,21 +111,6 @@ pub fn clear_sigs_and_sign(
         }
     }
     narinfo
-}
-
-fn narinfo_fingerprint(narinfo: &NarInfo, store_dir: &StoreDir) -> Option<Vec<u8>> {
-    let nar_hash_str = {
-        let h: Hash = narinfo.info.info.nar_hash.into();
-        format!("{}", h.as_base32())
-    };
-    fingerprint_path(
-        store_dir,
-        &narinfo.path,
-        nar_hash_str.as_bytes(),
-        narinfo.info.info.nar_size,
-        &narinfo.info.info.references,
-    )
-    .ok()
 }
 
 /// Return the `.ls` listing key for this narinfo.

--- a/subprojects/crates/binary-cache/src/presigned.rs
+++ b/subprojects/crates/binary-cache/src/presigned.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use backon::Retryable;
 
 use bytes::Bytes;
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use nix_utils::{BaseStore as _, LocalStore};
 
 use tokio_util::io::StreamReader;

--- a/subprojects/crates/db/Cargo.toml
+++ b/subprojects/crates/db/Cargo.toml
@@ -6,14 +6,15 @@ license                = "GPL-3.0"
 rust-version.workspace = true
 
 [dependencies]
-anyhow.workspace              = true
-futures.workspace             = true
-harmonia-store-core.workspace = true
-harmonia-utils-hash.workspace = true
-hashbrown.workspace           = true
-nix-support.workspace         = true
-store-path-utils.workspace    = true
-tracing.workspace             = true
+anyhow.workspace                    = true
+futures.workspace                   = true
+harmonia-store-derivation.workspace = true
+harmonia-store-path.workspace       = true
+harmonia-utils-hash.workspace       = true
+hashbrown.workspace                 = true
+nix-support.workspace               = true
+store-path-utils.workspace          = true
+tracing.workspace                   = true
 
 jiff.workspace       = true
 serde_json.workspace = true

--- a/subprojects/crates/db/src/connection.rs
+++ b/subprojects/crates/db/src/connection.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use sqlx::Acquire;
 
-use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::store_path::{StoreDir, StorePath};
+use harmonia_store_derivation::derived_path::OutputName;
+use harmonia_store_path::{StoreDir, StorePath};
 
 use super::models::{
     Build, BuildSmall, BuildStatus, BuildSteps, InsertBuildMetric, InsertBuildProduct,

--- a/subprojects/crates/db/src/lib.rs
+++ b/subprojects/crates/db/src/lib.rs
@@ -19,7 +19,7 @@ pub mod models;
 use std::str::FromStr as _;
 
 pub use connection::{Connection, Transaction};
-pub use harmonia_store_core::store_path::StoreDir;
+pub use harmonia_store_path::StoreDir;
 pub use sqlx::Error;
 
 #[derive(Debug, Clone)]

--- a/subprojects/crates/db/src/models.rs
+++ b/subprojects/crates/db/src/models.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::store_path::{ParseStorePathError, StoreDir, StorePath};
+use harmonia_store_derivation::derived_path::OutputName;
+use harmonia_store_path::{ParseStorePathError, StoreDir, StorePath};
 use hashbrown::HashMap;
 
 pub type BuildID = i32;
@@ -79,7 +79,7 @@ pub struct BuildSmall {
 }
 
 #[derive(Debug)]
-pub struct Build<StorePath = harmonia_store_core::store_path::StorePath> {
+pub struct Build<StorePath = harmonia_store_path::StorePath> {
     pub id: BuildID,
     pub jobset_id: i32,
     pub project: String,
@@ -153,7 +153,7 @@ pub struct InsertBuildStep<'a> {
 }
 
 #[derive(Debug)]
-pub struct InsertBuildStepOutput<StorePath = harmonia_store_core::store_path::StorePath> {
+pub struct InsertBuildStepOutput<StorePath = harmonia_store_path::StorePath> {
     pub build_id: BuildID,
     pub step_nr: i32,
     pub name: OutputName,
@@ -302,7 +302,7 @@ impl From<OwnedBuildMetric> for (nix_support::BuildMetricName, nix_support::Buil
 }
 
 #[derive(Debug)]
-pub struct MarkBuildSuccessData<'a, StorePath = harmonia_store_core::store_path::StorePath> {
+pub struct MarkBuildSuccessData<'a, StorePath = harmonia_store_path::StorePath> {
     pub id: BuildID,
     pub name: &'a str,
     pub project_name: &'a str,

--- a/subprojects/crates/nix-support/Cargo.toml
+++ b/subprojects/crates/nix-support/Cargo.toml
@@ -13,6 +13,7 @@ sha2.workspace    = true
 tokio             = { workspace = true, features = [ "full" ] }
 tracing.workspace = true
 
-harmonia-store-core.workspace = true
-harmonia-utils-hash.workspace = true
-store-path-utils.workspace    = true
+harmonia-store-derivation.workspace = true
+harmonia-store-path.workspace       = true
+harmonia-utils-hash.workspace       = true
+store-path-utils.workspace          = true

--- a/subprojects/crates/nix-support/src/lib.rs
+++ b/subprojects/crates/nix-support/src/lib.rs
@@ -29,8 +29,8 @@ use std::{collections::BTreeMap, os::unix::fs::MetadataExt as _, sync::LazyLock}
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, BufReader};
 
-use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_derivation::derived_path::OutputName;
+use harmonia_store_path::StorePath;
 use store_path_utils::RelativeStorePath;
 
 #[allow(clippy::expect_used)]
@@ -181,7 +181,7 @@ fn real_path(store_dir: &std::path::Path, path: &StorePath) -> std::path::PathBu
 }
 
 async fn parse_build_product<F: FsOperations>(
-    store_dir: &harmonia_store_core::store_path::StoreDir,
+    store_dir: &harmonia_store_path::StoreDir,
     fs: &F,
     line: &str,
 ) -> Option<BuildProduct> {
@@ -272,7 +272,7 @@ impl NixSupport {
 /// `fs` provides filesystem access for build product metadata and hashing
 /// (see [`FilesystemOperations`] for the real implementation).
 pub async fn parse_nix_support_for_output<F: FsOperations>(
-    store_dir: &harmonia_store_core::store_path::StoreDir,
+    store_dir: &harmonia_store_path::StoreDir,
     real_store_dir: &std::path::Path,
     fs: &F,
     output_name: &OutputName,
@@ -350,7 +350,7 @@ pub async fn parse_nix_support_for_output<F: FsOperations>(
 
 /// Parse `nix-support/` files from all outputs, returning per-output data.
 pub async fn parse_nix_support_from_outputs<F: FsOperations>(
-    store_dir: &harmonia_store_core::store_path::StoreDir,
+    store_dir: &harmonia_store_path::StoreDir,
     real_store_dir: &std::path::Path,
     fs: &F,
     derivation_outputs: &BTreeMap<OutputName, StorePath>,
@@ -491,7 +491,7 @@ mod tests {
         store_dir
     }
 
-    use harmonia_store_core::store_path::StoreDir;
+    use harmonia_store_path::StoreDir;
 
     #[tokio::test]
     async fn test_build_product_regular_file() {

--- a/subprojects/crates/nix-utils/Cargo.toml
+++ b/subprojects/crates/nix-utils/Cargo.toml
@@ -21,11 +21,14 @@ tokio-util           = { workspace = true, features = [ "io", "io-util" ] }
 tracing.workspace    = true
 url.workspace        = true
 
-cxx.workspace                      = true
-harmonia-store-aterm.workspace     = true
-harmonia-store-core.workspace      = true
-harmonia-store-path-info.workspace = true
-harmonia-utils-hash.workspace      = true
+cxx.workspace                            = true
+harmonia-store-aterm.workspace           = true
+harmonia-store-content-address.workspace = true
+harmonia-store-derivation.workspace      = true
+harmonia-store-path.workspace            = true
+harmonia-store-path-info.workspace       = true
+harmonia-utils-hash.workspace            = true
+harmonia-utils-signature.workspace       = true
 
 [build-dependencies]
 cxx-build.workspace  = true

--- a/subprojects/crates/nix-utils/src/drv.rs
+++ b/subprojects/crates/nix-utils/src/drv.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::store_path::{StoreDir, StorePathName};
+use harmonia_store_derivation::derived_path::OutputName;
+use harmonia_store_path::{StoreDir, StorePathName};
 
-use harmonia_store_core::derivation::Derivation;
+use harmonia_store_derivation::derivation::Derivation;
 
 use crate::StorePath;
 
@@ -62,8 +62,8 @@ pub fn output_paths(
 mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use harmonia_store_core::derivation::DerivationOutput;
-    use harmonia_store_core::store_path::StoreDir;
+    use harmonia_store_derivation::derivation::DerivationOutput;
+    use harmonia_store_path::StoreDir;
 
     use crate::drv::parse_drv;
 

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -17,9 +17,9 @@ mod realise;
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use harmonia_store_core::derivation::{BasicDerivation, DerivationT};
-use harmonia_store_core::derived_path::{OutputName, SingleDerivedPath};
-use harmonia_store_core::store_path::{StoreDir, StorePath};
+use harmonia_store_derivation::derivation::{BasicDerivation, DerivationT};
+use harmonia_store_derivation::derived_path::{OutputName, SingleDerivedPath};
+use harmonia_store_path::{StoreDir, StorePath};
 use harmonia_store_path_info::UnkeyedValidPathInfo;
 use hashbrown::HashMap;
 
@@ -320,11 +320,11 @@ fn nar_hash_from_bytes(bytes: &[u8]) -> harmonia_store_path_info::NarHash {
     hash.try_into().expect("sha256 should convert to NarHash")
 }
 
-fn parse_signature(s: &str) -> harmonia_store_core::signature::Signature {
+fn parse_signature(s: &str) -> harmonia_utils_signature::Signature {
     s.parse().expect("invalid signature from nix FFI")
 }
 
-fn parse_ca(s: &str) -> Option<harmonia_store_core::store_path::ContentAddress> {
+fn parse_ca(s: &str) -> Option<harmonia_store_content_address::ContentAddress> {
     if s.is_empty() { None } else { s.parse().ok() }
 }
 

--- a/subprojects/crates/nix-utils/src/realise.rs
+++ b/subprojects/crates/nix-utils/src/realise.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use harmonia_store_core::derived_path::{DerivedPath, OutputSpec, SingleDerivedPath};
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_derivation::derived_path::{DerivedPath, OutputSpec, SingleDerivedPath};
+use harmonia_store_path::StorePath;
 use tokio::io::{AsyncBufReadExt as _, BufReader};
 use tokio_stream::wrappers::LinesStream;
 

--- a/subprojects/crates/proto/Cargo.toml
+++ b/subprojects/crates/proto/Cargo.toml
@@ -6,13 +6,15 @@ license                = "GPL-3.0"
 rust-version.workspace = true
 
 [dependencies]
-harmonia-store-core.workspace      = true
-harmonia-store-nar-info.workspace  = true
-harmonia-store-path-info.workspace = true
-harmonia-utils-hash.workspace      = true
-prost.workspace                    = true
-tonic.workspace                    = true
-tonic-prost.workspace              = true
+harmonia-store-content-address.workspace = true
+harmonia-store-nar-info.workspace        = true
+harmonia-store-path.workspace            = true
+harmonia-store-path-info.workspace       = true
+harmonia-utils-hash.workspace            = true
+harmonia-utils-signature.workspace       = true
+prost.workspace                          = true
+tonic.workspace                          = true
+tonic-prost.workspace                    = true
 
 db                         = { workspace = true, optional = true }
 nix-support.workspace      = true

--- a/subprojects/crates/proto/src/lib.rs
+++ b/subprojects/crates/proto/src/lib.rs
@@ -93,8 +93,8 @@ impl TryFrom<nix::store::v1::Hash> for harmonia_utils_hash::Hash {
 
 // -- Signature --
 
-impl From<&harmonia_store_core::signature::Signature> for nix::store::v1::Signature {
-    fn from(sig: &harmonia_store_core::signature::Signature) -> Self {
+impl From<&harmonia_utils_signature::Signature> for nix::store::v1::Signature {
+    fn from(sig: &harmonia_utils_signature::Signature) -> Self {
         Self {
             key_name: sig.key_name.clone(),
             sig: sig.sig.to_string(),
@@ -102,7 +102,7 @@ impl From<&harmonia_store_core::signature::Signature> for nix::store::v1::Signat
     }
 }
 
-impl TryFrom<nix::store::v1::Signature> for harmonia_store_core::signature::Signature {
+impl TryFrom<nix::store::v1::Signature> for harmonia_utils_signature::Signature {
     type Error = &'static str;
 
     fn try_from(sig: nix::store::v1::Signature) -> Result<Self, Self::Error> {
@@ -115,9 +115,9 @@ impl TryFrom<nix::store::v1::Signature> for harmonia_store_core::signature::Sign
 
 // -- ContentAddress --
 
-impl From<&harmonia_store_core::store_path::ContentAddress> for nix::store::v1::ContentAddress {
-    fn from(ca: &harmonia_store_core::store_path::ContentAddress) -> Self {
-        use harmonia_store_core::store_path::ContentAddress as CA;
+impl From<&harmonia_store_content_address::ContentAddress> for nix::store::v1::ContentAddress {
+    fn from(ca: &harmonia_store_content_address::ContentAddress) -> Self {
+        use harmonia_store_content_address::ContentAddress as CA;
         match ca {
             CA::Text(h) => Self {
                 method: nix::store::v1::content_address::Method::Text as i32,
@@ -137,11 +137,11 @@ impl From<&harmonia_store_core::store_path::ContentAddress> for nix::store::v1::
     }
 }
 
-impl TryFrom<nix::store::v1::ContentAddress> for harmonia_store_core::store_path::ContentAddress {
+impl TryFrom<nix::store::v1::ContentAddress> for harmonia_store_content_address::ContentAddress {
     type Error = &'static str;
 
     fn try_from(ca: nix::store::v1::ContentAddress) -> Result<Self, Self::Error> {
-        use harmonia_store_core::store_path::ContentAddress as CA;
+        use harmonia_store_content_address::ContentAddress as CA;
         let hash: harmonia_utils_hash::Hash = ca.hash.ok_or("missing CA hash")?.try_into()?;
         match nix::store::v1::content_address::Method::try_from(ca.method) {
             Ok(nix::store::v1::content_address::Method::Text) => {
@@ -201,15 +201,14 @@ impl TryFrom<UnkeyedValidPathInfo> for harmonia_store_path_info::UnkeyedValidPat
             signatures: v
                 .signatures
                 .into_iter()
-                .filter_map(|s| harmonia_store_core::signature::Signature::try_from(s).ok())
+                .filter_map(|s| harmonia_utils_signature::Signature::try_from(s).ok())
                 .collect(),
             ca: v
                 .ca
-                .map(harmonia_store_core::store_path::ContentAddress::try_from)
+                .map(harmonia_store_content_address::ContentAddress::try_from)
                 .transpose()
                 .map_err(|_| NarInfoConvertError("invalid ca"))?,
-            store_dir: harmonia_store_core::store_path::StoreDir::new(&v.store_dir)
-                .unwrap_or_default(),
+            store_dir: harmonia_store_path::StoreDir::new(&v.store_dir).unwrap_or_default(),
         })
     }
 }
@@ -218,13 +217,13 @@ impl TryFrom<UnkeyedValidPathInfo> for harmonia_store_path_info::UnkeyedValidPat
 
 impl
     From<(
-        &harmonia_store_core::store_path::StorePath,
+        &harmonia_store_path::StorePath,
         &harmonia_store_path_info::UnkeyedValidPathInfo,
     )> for ValidPathInfo
 {
     fn from(
         (path, info): (
-            &harmonia_store_core::store_path::StorePath,
+            &harmonia_store_path::StorePath,
             &harmonia_store_path_info::UnkeyedValidPathInfo,
         ),
     ) -> Self {

--- a/subprojects/crates/proto/src/store_path.rs
+++ b/subprojects/crates/proto/src/store_path.rs
@@ -1,7 +1,7 @@
 //! Newtype wrappers for using harmonia store types with prost/tonic.
 //!
 //! These exist to work around the orphan rule: we cannot implement
-//! `prost::Message` for `harmonia_store_core::store_path::StorePath`
+//! `prost::Message` for `harmonia_store_path::StorePath`
 //! directly because both the trait and the type are foreign.  Instead,
 //! we define thin newtypes here (inside the hydra workspace) and map
 //! them via `extern_path` in the prost-build configuration.
@@ -10,7 +10,7 @@ use prost::DecodeError;
 use prost::bytes::{Buf, BufMut};
 use prost::encoding::{self, DecodeContext, WireType};
 
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 
 /// A [`StorePath`] that implements [`prost::Message`].
 ///

--- a/subprojects/crates/proto/src/tests.rs
+++ b/subprojects/crates/proto/src/tests.rs
@@ -1,10 +1,11 @@
 use super::*;
 use std::collections::{BTreeMap, BTreeSet};
 
-use harmonia_store_core::signature::Signature;
-use harmonia_store_core::store_path::{ContentAddress, StoreDir, StorePath};
+use harmonia_store_content_address::ContentAddress;
+use harmonia_store_path::{StoreDir, StorePath};
 use harmonia_store_path_info::NarHash;
 use harmonia_utils_hash::{Algorithm, Hash, Sha256};
+use harmonia_utils_signature::Signature;
 
 fn test_store_dir() -> StoreDir {
     StoreDir::default()

--- a/subprojects/crates/store-path-utils/Cargo.toml
+++ b/subprojects/crates/store-path-utils/Cargo.toml
@@ -6,4 +6,4 @@ license                = "GPL-3.0"
 rust-version.workspace = true
 
 [dependencies]
-harmonia-store-core.workspace = true
+harmonia-store-path.workspace = true

--- a/subprojects/crates/store-path-utils/src/lib.rs
+++ b/subprojects/crates/store-path-utils/src/lib.rs
@@ -1,4 +1,4 @@
-use harmonia_store_core::store_path::{ParseStorePathError, StoreDir, StorePath};
+use harmonia_store_path::{ParseStorePathError, StoreDir, StorePath};
 
 /// A store path with an optional relative sub-path.
 ///

--- a/subprojects/crates/store-transfer/Cargo.toml
+++ b/subprojects/crates/store-transfer/Cargo.toml
@@ -18,7 +18,7 @@ tonic.workspace        = true
 tracing.workspace      = true
 zstd.workspace         = true
 
-harmonia-store-core.workspace      = true
+harmonia-store-path.workspace      = true
 harmonia-store-path-info.workspace = true
 hydra-proto.workspace              = true
 nix-utils.workspace                = true

--- a/subprojects/crates/store-transfer/src/export.rs
+++ b/subprojects/crates/store-transfer/src/export.rs
@@ -1,6 +1,6 @@
 //! Shared logic for exporting store paths as an `AddToStoreRequest` stream.
 
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use harmonia_store_path_info::UnkeyedValidPathInfo;
 use nix_utils::BaseStore;
 

--- a/subprojects/crates/store-transfer/src/import.rs
+++ b/subprojects/crates/store-transfer/src/import.rs
@@ -11,7 +11,7 @@
 pub async fn import<Store: nix_utils::BaseStore + Clone + Send + 'static>(
     store: &Store,
     mut stream: tonic::Streaming<hydra_proto::AddToStoreRequest>,
-) -> Result<Vec<harmonia_store_core::store_path::StorePath>, nix_utils::Error> {
+) -> Result<Vec<harmonia_store_path::StorePath>, nix_utils::Error> {
     use futures::StreamExt as _;
     use nix_utils::Error;
 

--- a/subprojects/hydra-builder/Cargo.toml
+++ b/subprojects/hydra-builder/Cargo.toml
@@ -35,8 +35,9 @@ url.workspace          = true
 serde.workspace      = true
 serde_json.workspace = true
 
-harmonia-store-core.workspace = true
-harmonia-utils-hash.workspace = true
+harmonia-store-derivation.workspace = true
+harmonia-store-path.workspace       = true
+harmonia-utils-hash.workspace       = true
 
 gethostname.workspace = true
 nix                   = { workspace = true, features = [ "fs" ] }

--- a/subprojects/hydra-builder/src/grpc.rs
+++ b/subprojects/hydra-builder/src/grpc.rs
@@ -1,4 +1,4 @@
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -1,5 +1,5 @@
-use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::store_path::{ParseStorePathError, StorePath};
+use harmonia_store_derivation::derived_path::OutputName;
+use harmonia_store_path::{ParseStorePathError, StorePath};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};

--- a/subprojects/hydra-builder/src/system.rs
+++ b/subprojects/hydra-builder/src/system.rs
@@ -1,4 +1,4 @@
-use harmonia_store_core::store_path::StoreDir;
+use harmonia_store_path::StoreDir;
 use hashbrown::HashMap;
 use procfs_core::FromRead as _;
 

--- a/subprojects/hydra-builder/src/utils.rs
+++ b/subprojects/hydra-builder/src/utils.rs
@@ -1,4 +1,4 @@
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use tokio::io::BufReader;
 use tokio_stream::wrappers::LinesStream;
 use tokio_util::io::ReaderStream;

--- a/subprojects/hydra-queue-runner/Cargo.toml
+++ b/subprojects/hydra-queue-runner/Cargo.toml
@@ -52,17 +52,18 @@ prometheus               = { workspace = true, features = [ "process" ] }
 tower                    = { workspace = true, features = [ "util" ] }
 tower-http               = { workspace = true, features = [ "trace" ] }
 
-binary-cache.workspace             = true
-db.workspace                       = true
-harmonia-store-core.workspace      = true
-harmonia-store-nar-info.workspace  = true
-harmonia-store-path-info.workspace = true
-harmonia-utils-hash.workspace      = true
-hydra-proto                        = { workspace = true, features = [ "db", "server" ] }
-hydra-tracing                      = { workspace = true, features = [ "tonic" ] }
-nix-support.workspace              = true
-nix-utils.workspace                = true
-store-transfer.workspace           = true
+binary-cache.workspace              = true
+db.workspace                        = true
+harmonia-store-derivation.workspace = true
+harmonia-store-nar-info.workspace   = true
+harmonia-store-path.workspace       = true
+harmonia-store-path-info.workspace  = true
+harmonia-utils-hash.workspace       = true
+hydra-proto                         = { workspace = true, features = [ "db", "server" ] }
+hydra-tracing                       = { workspace = true, features = [ "tonic" ] }
+nix-support.workspace               = true
+nix-utils.workspace                 = true
+store-transfer.workspace            = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator.workspace = true

--- a/subprojects/hydra-queue-runner/examples/collect-fods.rs
+++ b/subprojects/hydra-queue-runner/examples/collect-fods.rs
@@ -1,5 +1,5 @@
-use harmonia_store_core::derivation::Derivation;
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_derivation::derivation::Derivation;
+use harmonia_store_path::StorePath;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/subprojects/hydra-queue-runner/src/io/build.rs
+++ b/subprojects/hydra-queue-runner/src/io/build.rs
@@ -1,4 +1,4 @@
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use std::sync::atomic::Ordering;
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/subprojects/hydra-queue-runner/src/io/machine.rs
+++ b/subprojects/hydra-queue-runner/src/io/machine.rs
@@ -1,4 +1,4 @@
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use std::sync::{Arc, atomic::Ordering};
 
 use smallvec::SmallVec;

--- a/subprojects/hydra-queue-runner/src/io/step.rs
+++ b/subprojects/hydra-queue-runner/src/io/step.rs
@@ -1,4 +1,4 @@
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use std::sync::atomic::Ordering;
 
 #[derive(Debug, serde::Serialize)]

--- a/subprojects/hydra-queue-runner/src/io/step_info.rs
+++ b/subprojects/hydra-queue-runner/src/io/step_info.rs
@@ -1,4 +1,4 @@
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use std::sync::atomic::Ordering;
 
 #[allow(clippy::struct_excessive_bools)]

--- a/subprojects/hydra-queue-runner/src/io/uploads.rs
+++ b/subprojects/hydra-queue-runner/src/io/uploads.rs
@@ -1,4 +1,4 @@
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -601,7 +601,7 @@ impl RunnerService for Server {
         for presigned_request in req.request {
             let store_path = presigned_request
                 .store_path
-                .parse::<harmonia_store_core::store_path::StorePath>()
+                .parse::<harmonia_store_path::StorePath>()
                 .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
 
             let proto_hash = presigned_request

--- a/subprojects/hydra-queue-runner/src/server/http.rs
+++ b/subprojects/hydra-queue-runner/src/server/http.rs
@@ -29,7 +29,7 @@ pub enum Error {
     Sqlx(#[from] db::Error),
 
     #[error("store path parse error: `{0}`")]
-    StorePath(#[from] harmonia_store_core::store_path::ParseStorePathError),
+    StorePath(#[from] harmonia_store_path::ParseStorePathError),
 
     #[error("Not found")]
     NotFound,
@@ -357,7 +357,7 @@ mod handler {
             let whole_body = req.collect().await?.aggregate();
             let data: io::BuildPayload = serde_json::from_reader(whole_body.reader())?;
 
-            let drv_path: harmonia_store_core::store_path::StorePath = data.drv.parse()?;
+            let drv_path: harmonia_store_path::StorePath = data.drv.parse()?;
             state.queue_one_build(data.jobset_id, &drv_path).await?;
             construct_json_ok_response(&io::Empty {})
         }

--- a/subprojects/hydra-queue-runner/src/state/build.rs
+++ b/subprojects/hydra-queue-runner/src/state/build.rs
@@ -7,8 +7,8 @@ use hashbrown::{HashMap, HashSet};
 
 use super::{Jobset, JobsetID, Step};
 use db::models::{BuildID, BuildStatus};
-use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_derivation::derived_path::OutputName;
+use harmonia_store_path::StorePath;
 use nix_utils::BaseStore as _;
 
 pub(super) type AtomicBuildID = AtomicI32;

--- a/subprojects/hydra-queue-runner/src/state/drv.rs
+++ b/subprojects/hydra-queue-runner/src/state/drv.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeSet;
 
-use harmonia_store_core::derivation::Derivation;
-use harmonia_store_core::derived_path::{OutputName, SingleDerivedPath};
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_derivation::derivation::Derivation;
+use harmonia_store_derivation::derived_path::{OutputName, SingleDerivedPath};
+use harmonia_store_path::StorePath;
 
 /// Output names of intermediate derivations for a dynamic derivation
 /// dependency, stored in reverse order so that the next level to resolve

--- a/subprojects/hydra-queue-runner/src/state/fod_checker.rs
+++ b/subprojects/hydra-queue-runner/src/state/fod_checker.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use harmonia_store_core::derivation::{Derivation, DerivationOutput};
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_derivation::derivation::{Derivation, DerivationOutput};
+use harmonia_store_path::StorePath;
 use hashbrown::{HashMap, HashSet};
 use nix_utils::LocalStore;
 
@@ -41,7 +41,7 @@ async fn collect_ca_derivations(
         _ => None,
     });
     let input_drvs: Vec<StorePath> =
-        harmonia_store_core::derivation::DerivationInputs::from(&parsed.inputs)
+        harmonia_store_derivation::derivation::DerivationInputs::from(&parsed.inputs)
             .drvs
             .into_keys()
             .collect();
@@ -178,7 +178,7 @@ mod tests {
     #[tokio::test]
     async fn test_traverse() {
         let store = nix_utils::LocalStore::init();
-        let hello_drv: harmonia_store_core::store_path::StorePath =
+        let hello_drv: harmonia_store_path::StorePath =
             "rl5m4zxd24mkysmpbp4j9ak6q7ia6vj8-hello-2.12.2.drv"
                 .parse()
                 .unwrap();

--- a/subprojects/hydra-queue-runner/src/state/machine.rs
+++ b/subprojects/hydra-queue-runner/src/state/machine.rs
@@ -5,7 +5,7 @@ use smallvec::SmallVec;
 use tokio::sync::mpsc;
 
 use db::models::BuildID;
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 
 use super::{RemoteBuild, System};
 use crate::config::{MachineFreeFn, MachineSortFn};

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -14,7 +14,7 @@ mod uploader;
 use anyhow::Context as _;
 pub use atomic::AtomicDateTime;
 pub use build::{Build, BuildOutput, BuildResultState, BuildTimings, Builds, RemoteBuild};
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 pub use jobset::{Jobset, JobsetID, Jobsets};
 pub use machine::{Machine, Message as MachineMessage, Pressure, Stats as MachineStats};
 pub use queue::{BuildQueueStats, Queues};
@@ -31,9 +31,9 @@ use hashbrown::{HashMap, HashSet};
 use secrecy::ExposeSecret as _;
 
 use db::models::{BuildID, BuildStatus};
-use harmonia_store_core::derivation::DerivationOutput;
-use harmonia_store_core::derived_path::{OutputName, SingleDerivedPath};
-use harmonia_store_core::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
+use harmonia_store_derivation::derivation::DerivationOutput;
+use harmonia_store_derivation::derived_path::{OutputName, SingleDerivedPath};
+use harmonia_store_derivation::realisation::{DrvOutput, Realisation, UnkeyedRealisation};
 use inspectable_channel::InspectableChannel;
 use nix_utils::BaseStore as _;
 
@@ -1988,7 +1988,7 @@ impl State {
         let system_type = std::str::from_utf8(&drv.platform).expect("platform must be valid UTF-8");
         #[allow(clippy::cast_precision_loss)]
         self.metrics.observe_build_input_drvs(
-            harmonia_store_core::derivation::DerivationInputs::from(&drv.inputs)
+            harmonia_store_derivation::derivation::DerivationInputs::from(&drv.inputs)
                 .drvs
                 .len() as f64,
             system_type,

--- a/subprojects/hydra-queue-runner/src/state/queue.rs
+++ b/subprojects/hydra-queue-runner/src/state/queue.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Weak};
 use hashbrown::{HashMap, HashSet};
 use smallvec::SmallVec;
 
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 
 use super::{StepInfo, System};
 use crate::config::StepSortFn;

--- a/subprojects/hydra-queue-runner/src/state/step.rs
+++ b/subprojects/hydra-queue-runner/src/state/step.rs
@@ -7,9 +7,9 @@ use hashbrown::{HashMap, HashSet};
 
 use super::{Build, Jobset};
 use db::models::BuildID;
-use harmonia_store_core::derivation::Derivation;
-use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::store_path::{StoreDir, StorePath};
+use harmonia_store_derivation::derivation::Derivation;
+use harmonia_store_derivation::derived_path::OutputName;
+use harmonia_store_path::{StoreDir, StorePath};
 
 use super::drv::OutputNameChain;
 

--- a/subprojects/hydra-queue-runner/src/state/step_info.rs
+++ b/subprojects/hydra-queue-runner/src/state/step_info.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use db::models::BuildID;
-use harmonia_store_core::derivation::{BasicDerivation, Derivation, DerivationOutput};
-use harmonia_store_core::derived_path::{OutputName, SingleDerivedPath};
-use harmonia_store_core::store_path::{StoreDir, StorePath};
+use harmonia_store_derivation::derivation::{BasicDerivation, Derivation, DerivationOutput};
+use harmonia_store_derivation::derived_path::{OutputName, SingleDerivedPath};
+use harmonia_store_path::{StoreDir, StorePath};
 
 use super::Step;
 use super::drv::flatten_chain;

--- a/subprojects/hydra-queue-runner/src/state/uploader.rs
+++ b/subprojects/hydra-queue-runner/src/state/uploader.rs
@@ -1,6 +1,6 @@
 use backon::ExponentialBuilder;
 use backon::Retryable as _;
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_path::StorePath;
 use nix_utils::BaseStore as _;
 
 #[allow(clippy::unnecessary_wraps)]

--- a/subprojects/hydra-queue-runner/src/utils.rs
+++ b/subprojects/hydra-queue-runner/src/utils.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use db::models::BuildID;
-use harmonia_store_core::derived_path::OutputName;
-use harmonia_store_core::store_path::StorePath;
+use harmonia_store_derivation::derived_path::OutputName;
+use harmonia_store_path::StorePath;
 use nix_utils::BaseStore as _;
 
 use crate::state::RemoteBuild;


### PR DESCRIPTION
Upstream harmonia split `harmonia-store-core` into finer-grained crates: `harmonia-store-path`, `harmonia-store-content-address`, `harmonia-store-derivation`, and `harmonia-utils-signature`. This updates all workspace dependencies and import paths accordingly.

The `fingerprint_path` function also moved to
`harmonia-store-path-info` and now takes `&NarHash` directly (instead of `&[u8]`), so the `narinfo_fingerprint` wrapper was inlined.