### PR TITLE
hydra-eval-jobs: use nix-eval-jobs's --select rather --expr

### DIFF
--- a/subprojects/hydra-tests/jobs/config.nix.in
+++ b/subprojects/hydra-tests/jobs/config.nix.in
@@ -2,10 +2,11 @@ rec {
   path = "@testPath@";
   nixBinDir = "@nixBinDir@";
   bash = "@bash@";
+  system = "@system@";
 
   mkDerivation = args:
     derivation ({
-      system = builtins.currentSystem;
+      inherit system;
       PATH = path;
     } // args);
   mkContentAddressedDerivation = args: mkDerivation ({

--- a/subprojects/hydra-tests/lib/HydraTestContext.pm
+++ b/subprojects/hydra-tests/lib/HydraTestContext.pm
@@ -104,10 +104,12 @@ sub new {
     my $coreutils_path = dirname(which 'install');
     my $nix_bin_dir = dirname(which 'nix');
     my $bash_path = which 'bash';
+    chomp(my $system = `nix --extra-experimental-features nix-command config show system`);
     replace_variable_in_file($jobsdir . "/config.nix",
         '@testPath@' => $coreutils_path,
         '@nixBinDir@' => $nix_bin_dir,
-        '@bash@' => $bash_path);
+        '@bash@' => $bash_path,
+        '@system@' => $system);
     replace_variable_in_file($jobsdir . "/declarative/project.json",
         '@jobsPath@' => $jobsdir);
 

--- a/subprojects/hydra/script/hydra-eval-jobset
+++ b/subprojects/hydra/script/hydra-eval-jobset
@@ -358,21 +358,14 @@ sub evalJobs {
     my @cmd;
 
     if (defined $flakeRef) {
-        my $nix_expr =
-            "let " .
-            "flake = builtins.getFlake (toString \"$flakeRef\"); " .
-            "in " .
-            "flake.hydraJobs " .
-            "or flake.checks " .
-            "or (throw \"flake '$flakeRef' does not provide any Hydra jobs or checks\")";
-
         @cmd = ("nix-eval-jobs",
                 # Disable the eval cache to prevent SQLite database contention.
                 # Since Hydra typically evaluates each revision only once,
                 # parallel workers would compete for database locks without
                 # providing any benefit from caching.
                 "--option", "eval-cache", "false",
-                "--expr", $nix_expr);
+                "--flake", $flakeRef,
+                "--select", "flake: flake.outputs.hydraJobs or flake.outputs.checks or (throw \"flake does not provide any Hydra jobs or checks\")");
     } else {
         my $nixExprInput = $inputInfo->{$nixExprInputName}->[0]
             or die "cannot find the input containing the job expression\n";


### PR DESCRIPTION
The current use of builtins.getFlake, mean we don't have pure evaluation.