### PR TITLE
Use `u32` for scheduling shares

### DIFF
--- a/subprojects/crates/db/src/connection.rs
+++ b/subprojects/crates/db/src/connection.rs
@@ -133,6 +133,9 @@ impl Connection {
         .await
     }
 
+    // TODO Currently unused. In the old C++ queue-runner, this was called
+    // in queue-monitor.cc to mark GC'ed builds as aborted. The Rust
+    // queue runner apparently doesn't handle that case yet.
     #[tracing::instrument(skip(self), err)]
     pub async fn abort_build(&mut self, build_id: i32) -> sqlx::Result<()> {
         #[allow(clippy::cast_possible_truncation)]

--- a/subprojects/crates/db/src/connection.rs
+++ b/subprojects/crates/db/src/connection.rs
@@ -99,14 +99,15 @@ impl Connection {
     pub async fn get_jobset_scheduling_shares(
         &mut self,
         jobset_id: i32,
-    ) -> sqlx::Result<Option<i32>> {
+    ) -> anyhow::Result<Option<u32>> {
         Ok(sqlx::query!(
             "SELECT schedulingshares FROM jobsets WHERE id = $1",
             jobset_id,
         )
         .fetch_optional(&mut *self.conn)
         .await?
-        .map(|v| v.schedulingshares))
+        .map(|v| u32::try_from(v.schedulingshares))
+        .transpose()?)
     }
 
     #[tracing::instrument(skip(self), err)]

--- a/subprojects/hydra-queue-runner/src/state/jobset.rs
+++ b/subprojects/hydra-queue-runner/src/state/jobset.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
 
+use anyhow::Context;
 use hashbrown::HashMap;
 
 pub type JobsetID = i32;
@@ -61,10 +62,8 @@ impl Jobset {
         ((seconds as f64) / f64::from(shares))
     }
 
-    pub fn set_shares(&self, shares: i32) -> anyhow::Result<()> {
-        debug_assert!(shares > 0);
-        self.shares.store(shares.try_into()?, Ordering::Relaxed);
-        Ok(())
+    pub fn set_shares(&self, shares: u32) {
+        self.shares.store(shares, Ordering::Relaxed);
     }
 
     pub fn get_shares(&self) -> u32 {
@@ -176,7 +175,7 @@ impl Jobsets {
             .await?
             .ok_or_else(|| anyhow::anyhow!("Scheduling Shares not found for jobset not found."))?;
         let jobset = Jobset::new(jobset_id, project_name, jobset_name);
-        jobset.set_shares(shares)?;
+        jobset.set_shares(shares);
 
         for step in conn
             .get_jobset_build_steps(jobset_id, SCHEDULING_WINDOW)
@@ -206,15 +205,10 @@ impl Jobsets {
 
         let jobsets = self.inner.read();
         for row in curr_jobsets_in_db {
-            if let Some(i) = jobsets.get(&(row.project.clone(), row.name.clone()))
-                && let Err(e) = i.set_shares(row.schedulingshares)
-            {
-                tracing::error!(
-                    "Failed to update jobset scheduling shares. project_name={} jobset_name={} e={}",
-                    row.project,
-                    row.name,
-                    e,
-                );
+            if let Some(i) = jobsets.get(&(row.project.clone(), row.name.clone())) {
+                let shares = u32::try_from(row.schedulingshares)
+                    .context("scheduling shares out of range")?;
+                i.set_shares(shares);
             }
         }
         Ok(())


### PR DESCRIPTION
The DB has a `CHECK (schedulingShares > 0)` constraint, so these values are always positive. Represent that invariant in the Rust types by using `u32` instead of `i32`, converting at the DB boundary.

This makes `set_shares` infallible and removes the `tracing::error` that logged negative-share conversion failures in `handle_change`, replacing it with a hard error via `.context()` since out-of-range values indicate a bug.