### PR TITLE
Split content-addressed `basic.t` into `basic.t` and `early-cutoff.t`

### DIFF
--- a/subprojects/hydra-tests/content-addressed/basic.t
+++ b/subprojects/hydra-tests/content-addressed/basic.t
@@ -24,7 +24,7 @@ my $project = $db->resultset('Projects')->create({name => "tests", displayname =
 my $jobset = createBaseJobset($db, "content-addressed", "content-addressed.nix", $ctx{jobsdir});
 
 ok(evalSucceeds($ctx{context}, $jobset), "Evaluating jobs/content-addressed.nix should exit with return code 0");
-is(nrQueuedBuildsForJobset($jobset), 14, "Evaluating jobs/content-addressed.nix should result in 14 builds");
+is(nrQueuedBuildsForJobset($jobset), 10, "Evaluating jobs/content-addressed.nix should result in 10 builds");
 
 my @builds = queuedBuildsForJobset($jobset);
 ok(runBuilds($ctx{context}, @builds), "Building all jobs from jobs/content-addressed.nix should exit with code 0");
@@ -58,40 +58,4 @@ for my $build (@builds) {
 # XXX: This test seems to not do what it seems to be doing. See documentation: https://metacpan.org/pod/Test2::V0#isnt($got,-$do_not_want,-$name)
 isnt(<$ctx{deststoredir}/realisations/*>, "", "The destination store should have the realisations of the built derivations registered");
 
-# Early cutoff: earlyCutoffUpstream1 and earlyCutoffUpstream2 have
-# different derivations but produce the same content-addressed output.
-# After building earlyCutoffDownstream1, earlyCutoffDownstream2 should
-# be cached because its resolved input is identical.
-my $upstream1 = $db->resultset('Builds')->find({
-    jobset_id => $jobset->id,
-    job => "earlyCutoffUpstream1",
-});
-my $upstream2 = $db->resultset('Builds')->find({
-    jobset_id => $jobset->id,
-    job => "earlyCutoffUpstream2",
-});
-
-my $upstream1_out = $upstream1->buildoutputs->find({ name => "out" });
-my $upstream2_out = $upstream2->buildoutputs->find({ name => "out" });
-is($upstream1_out->path, $upstream2_out->path,
-    "Both upstream builds should resolve to the same content-addressed output path");
-
-my $downstream1 = $db->resultset('Builds')->find({
-    jobset_id => $jobset->id,
-    job => "earlyCutoffDownstream1",
-});
-my $downstream2 = $db->resultset('Builds')->find({
-    jobset_id => $jobset->id,
-    job => "earlyCutoffDownstream2",
-});
-
-my $downstream1_out = $downstream1->buildoutputs->find({ name => "out" });
-my $downstream2_out = $downstream2->buildoutputs->find({ name => "out" });
-is($downstream1_out->path, $downstream2_out->path,
-    "Both downstream builds should create the same content-addressed output path");
-
-ok($downstream1->iscachedbuild || $downstream2->iscachedbuild,
-    "One downstream build should be cached");
-
 done_testing;
-

--- a/subprojects/hydra-tests/content-addressed/early-cutoff.t
+++ b/subprojects/hydra-tests/content-addressed/early-cutoff.t
@@ -1,0 +1,67 @@
+use feature 'unicode_strings';
+use strict;
+use warnings;
+use Setup;
+
+my %ctx = test_init(
+    nix_config => qq|
+    experimental-features = ca-derivations
+    |,
+);
+
+use Test2::V0;
+
+my $db = $ctx{context}->db();
+
+my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+
+my $jobset = createBaseJobset($db, "content-addressed-early-cutoff", "content-addressed-early-cutoff.nix", $ctx{jobsdir});
+
+ok(evalSucceeds($ctx{context}, $jobset), "Evaluating early cutoff jobs should exit with return code 0");
+is(nrQueuedBuildsForJobset($jobset), 4, "Should queue 4 early cutoff builds");
+
+my @builds = queuedBuildsForJobset($jobset);
+ok(runBuilds($ctx{context}, @builds), "Building all early cutoff jobs should exit with code 0");
+
+for my $build (@builds) {
+    my $newbuild = $db->resultset('Builds')->find($build->id);
+    is($newbuild->finished, 1, "Build '".$build->job."' should be finished.");
+    is($newbuild->buildstatus, 0, "Build '".$build->job."' should have buildstatus 0.");
+}
+
+# Early cutoff: earlyCutoffUpstream1 and earlyCutoffUpstream2 have
+# different derivations but produce the same content-addressed output.
+# After building earlyCutoffDownstream1, earlyCutoffDownstream2 should
+# be cached because its resolved input is identical.
+my $upstream1 = $db->resultset('Builds')->find({
+    jobset_id => $jobset->id,
+    job => "earlyCutoffUpstream1",
+});
+my $upstream2 = $db->resultset('Builds')->find({
+    jobset_id => $jobset->id,
+    job => "earlyCutoffUpstream2",
+});
+
+my $upstream1_out = $upstream1->buildoutputs->find({ name => "out" });
+my $upstream2_out = $upstream2->buildoutputs->find({ name => "out" });
+is($upstream1_out->path, $upstream2_out->path,
+    "Both upstream builds should resolve to the same content-addressed output path");
+
+my $downstream1 = $db->resultset('Builds')->find({
+    jobset_id => $jobset->id,
+    job => "earlyCutoffDownstream1",
+});
+my $downstream2 = $db->resultset('Builds')->find({
+    jobset_id => $jobset->id,
+    job => "earlyCutoffDownstream2",
+});
+
+my $downstream1_out = $downstream1->buildoutputs->find({ name => "out" });
+my $downstream2_out = $downstream2->buildoutputs->find({ name => "out" });
+is($downstream1_out->path, $downstream2_out->path,
+    "Both downstream builds should create the same content-addressed output path");
+
+ok($downstream1->iscachedbuild || $downstream2->iscachedbuild,
+    "One downstream build should be cached");
+
+done_testing;

--- a/subprojects/hydra-tests/jobs/content-addressed-early-cutoff.nix
+++ b/subprojects/hydra-tests/jobs/content-addressed-early-cutoff.nix
@@ -1,0 +1,33 @@
+let
+  cfg = import ./config.nix;
+in
+rec {
+  # Early-cutoff test: two upstream derivations that differ in a dummy
+  # attribute but produce the same output (an empty directory).  Because
+  # they are content-addressed, they resolve to the same output path.
+  # Both downstreams depend on a different upstream, but since the
+  # resolved input is identical, the second downstream should be cached.
+  earlyCutoffUpstream1 = cfg.mkContentAddressedDerivation {
+    name = "early-cutoff-upstream";
+    builder = ./empty-dir-builder.sh;
+    dummy = "1";
+  };
+
+  earlyCutoffUpstream2 = cfg.mkContentAddressedDerivation {
+    name = "early-cutoff-upstream";
+    builder = ./empty-dir-builder.sh;
+    dummy = "2";
+  };
+
+  earlyCutoffDownstream1 = cfg.mkContentAddressedDerivation {
+    name = "early-cutoff-downstream";
+    builder = ./dir-with-file-builder.sh;
+    FOO = earlyCutoffUpstream1;
+  };
+
+  earlyCutoffDownstream2 = cfg.mkContentAddressedDerivation {
+    name = "early-cutoff-downstream";
+    builder = ./dir-with-file-builder.sh;
+    FOO = earlyCutoffUpstream2;
+  };
+}

--- a/subprojects/hydra-tests/jobs/content-addressed.nix
+++ b/subprojects/hydra-tests/jobs/content-addressed.nix
@@ -64,33 +64,4 @@ rec {
       "lib"
     ];
   };
-
-  # Early-cutoff test: two upstream derivations that differ in a dummy
-  # attribute but produce the same output (an empty directory).  Because
-  # they are content-addressed, they resolve to the same output path.
-  # Both downstreams depend on a different upstream, but since the
-  # resolved input is identical, the second downstream should be cached.
-  earlyCutoffUpstream1 = cfg.mkContentAddressedDerivation {
-    name = "early-cutoff-upstream";
-    builder = ./empty-dir-builder.sh;
-    dummy = "1";
-  };
-
-  earlyCutoffUpstream2 = cfg.mkContentAddressedDerivation {
-    name = "early-cutoff-upstream";
-    builder = ./empty-dir-builder.sh;
-    dummy = "2";
-  };
-
-  earlyCutoffDownstream1 = cfg.mkContentAddressedDerivation {
-    name = "early-cutoff-downstream";
-    builder = ./dir-with-file-builder.sh;
-    FOO = earlyCutoffUpstream1;
-  };
-
-  earlyCutoffDownstream2 = cfg.mkContentAddressedDerivation {
-    name = "early-cutoff-downstream";
-    builder = ./dir-with-file-builder.sh;
-    FOO = earlyCutoffUpstream2;
-  };
 }


### PR DESCRIPTION
The original test evaluated and built all 14 CA jobs in a single file, making it slow and monolithic. Split it so the 4 early-cutoff jobs (upstream1/2, downstream1/2) get their own test file and nix expression, leaving 10 jobs in `basic.t`.