### PR TITLE
`nix_utils::BaseStore`: return `Result` from all fallible methods 

### DIFF
--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -56,15 +56,16 @@ pub async fn path_to_narinfo(
     store: &nix_utils::LocalStore,
     path: &StorePath,
 ) -> Result<NarInfo, CacheError> {
-    let Some(path_info) = store.query_path_info(path).await else {
-        return Err(CacheError::PathNotFound {
+    let path_info = store
+        .query_path_info(path)
+        .await?
+        .ok_or_else(|| CacheError::PathNotFound {
             path: path.to_string(),
-        });
-    };
+        })?;
     let narinfo = narinfo_simple(path, path_info, Compression::None);
     let queried_references = store
         .query_path_infos(&narinfo.info.info.references.iter().collect::<Vec<_>>())
-        .await;
+        .await?;
     for r in &narinfo.info.info.references {
         if !queried_references.contains_key(r) {
             return Err(CacheError::ReferenceVerifyError(narinfo.path, r.to_owned()));
@@ -549,11 +550,13 @@ impl S3BinaryCacheClient {
         store: &nix_utils::LocalStore,
         path: &StorePath,
     ) -> Result<NarInfo, CacheError> {
-        let Some(path_info) = store.query_path_info(path).await else {
-            return Err(CacheError::PathNotFound {
-                path: path.to_string(),
-            });
-        };
+        let path_info =
+            store
+                .query_path_info(path)
+                .await?
+                .ok_or_else(|| CacheError::PathNotFound {
+                    path: path.to_string(),
+                })?;
         let narinfo = narinfo_from_path_info(
             path,
             path_info,
@@ -563,7 +566,7 @@ impl S3BinaryCacheClient {
         );
         let queried_references = store
             .query_path_infos(&narinfo.info.info.references.iter().collect::<Vec<_>>())
-            .await;
+            .await?;
         for r in &narinfo.info.info.references {
             if !queried_references.contains_key(r) {
                 return Err(CacheError::ReferenceVerifyError(narinfo.path, r.to_owned()));

--- a/subprojects/crates/nix-utils/examples/is_valid_path.rs
+++ b/subprojects/crates/nix-utils/examples/is_valid_path.rs
@@ -1,13 +1,14 @@
 use nix_utils::{self, BaseStore as _};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let store = nix_utils::LocalStore::init();
     let store_dir = nix_utils::get_store_dir();
     println!(
         "storepath={store_dir} valid={}",
         store
             .is_valid_path(&AsRef::<str>::as_ref(&store_dir).parse().unwrap())
-            .await
+            .await?
     );
+    Ok(())
 }

--- a/subprojects/crates/nix-utils/examples/path_infos.rs
+++ b/subprojects/crates/nix-utils/examples/path_infos.rs
@@ -1,7 +1,7 @@
 use nix_utils::BaseStore as _;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let local = nix_utils::LocalStore::init();
 
     let p1 = "ihl4ya67glh9815v1lanyqph0p7hdzfb-hdf5-cpp-1.14.6-bin"
@@ -19,16 +19,17 @@ async fn main() {
     println!("{infos:?}");
     println!(
         "closure_size {p1}: {}",
-        local.compute_closure_size(&p1).await
+        local.compute_closure_size(&p1).await?
     );
     println!(
         "closure_size {p2}: {}",
-        local.compute_closure_size(&p2).await
+        local.compute_closure_size(&p2).await?
     );
     println!(
         "closure_size {p3}: {}",
-        local.compute_closure_size(&p3).await
+        local.compute_closure_size(&p3).await?
     );
 
     println!("stats: {:?}", local.get_store_stats());
+    Ok(())
 }

--- a/subprojects/crates/nix-utils/src/drv.rs
+++ b/subprojects/crates/nix-utils/src/drv.rs
@@ -34,7 +34,7 @@ pub async fn query_drv(
         return Ok(None);
     }
 
-    if !store.is_valid_path(drv).await {
+    if !store.is_valid_path(drv).await? {
         return Ok(None);
     }
 

--- a/subprojects/crates/nix-utils/src/lib.rs
+++ b/subprojects/crates/nix-utils/src/lib.rs
@@ -79,6 +79,7 @@ mod ffi {
 
     #[derive(Debug, Clone)]
     struct InternalPathInfo {
+        found: bool,
         store_dir: String,
         deriver: String,
         nar_hash: Vec<u8>,
@@ -368,6 +369,7 @@ fn to_internal_path_info(
     let nar_hash_bytes: Vec<u8> = AsRef::<[u8]>::as_ref(&info.nar_hash).to_vec();
 
     ffi::InternalPathInfo {
+        found: true,
         store_dir: store_dir.to_str().to_owned(),
         deriver: info
             .deriver
@@ -386,19 +388,18 @@ fn to_internal_path_info(
 }
 
 pub trait BaseStore {
-    #[must_use]
     /// Check whether a path is valid.
-    fn is_valid_path(&self, path: &StorePath) -> impl Future<Output = bool>;
+    fn is_valid_path(&self, path: &StorePath) -> impl Future<Output = Result<bool, Error>>;
 
     fn query_path_info(
         &self,
         path: &StorePath,
-    ) -> impl Future<Output = Option<UnkeyedValidPathInfo>>;
+    ) -> impl Future<Output = Result<Option<UnkeyedValidPathInfo>, Error>>;
     fn query_path_infos(
         &self,
         paths: &[&StorePath],
-    ) -> impl Future<Output = HashMap<StorePath, UnkeyedValidPathInfo>>;
-    fn compute_closure_size(&self, path: &StorePath) -> impl Future<Output = u64>;
+    ) -> impl Future<Output = Result<HashMap<StorePath, UnkeyedValidPathInfo>, Error>>;
+    fn compute_closure_size(&self, path: &StorePath) -> impl Future<Output = Result<u64, Error>>;
 
     fn clear_path_info_cache(&self);
 
@@ -529,33 +530,35 @@ where
 
 impl BaseStore for BaseStoreImpl {
     #[inline]
-    async fn is_valid_path(&self, path: &StorePath) -> bool {
+    async fn is_valid_path(&self, path: &StorePath) -> Result<bool, Error> {
         let store = self.wrapper.clone();
         let path = self.print_store_path(path);
-        asyncify(move || ffi::is_valid_path(store.as_raw(), &path))
-            .await
-            .unwrap_or(false)
+        asyncify(move || ffi::is_valid_path(store.as_raw(), &path)).await
     }
 
     #[inline]
-    async fn query_path_info(&self, path: &StorePath) -> Option<UnkeyedValidPathInfo> {
+    async fn query_path_info(
+        &self,
+        path: &StorePath,
+    ) -> Result<Option<UnkeyedValidPathInfo>, Error> {
         let store = self.wrapper.clone();
         let path = self.print_store_path(path);
         asyncify(move || {
-            Ok(ffi::query_path_info(store.as_raw(), &path)
-                .ok()
-                .map(Into::into))
+            let info = ffi::query_path_info(store.as_raw(), &path)?;
+            if info.found {
+                Ok(Some(info.into()))
+            } else {
+                Ok(None)
+            }
         })
         .await
-        .ok()
-        .flatten()
     }
 
     #[inline]
     async fn query_path_infos(
         &self,
         paths: &[&StorePath],
-    ) -> HashMap<StorePath, UnkeyedValidPathInfo> {
+    ) -> Result<HashMap<StorePath, UnkeyedValidPathInfo>, Error> {
         let paths = paths.iter().map(|v| (*v).to_owned()).collect::<Vec<_>>();
 
         asyncify({
@@ -564,27 +567,22 @@ impl BaseStore for BaseStoreImpl {
                 let mut res = HashMap::with_capacity(paths.len());
                 for p in paths {
                     let full_path = self_.print_store_path(&p);
-                    if let Some(info) = ffi::query_path_info(self_.wrapper.as_raw(), &full_path)
-                        .ok()
-                        .map(Into::into)
-                    {
-                        res.insert(p, info);
+                    let info = ffi::query_path_info(self_.wrapper.as_raw(), &full_path)?;
+                    if info.found {
+                        res.insert(p, info.into());
                     }
                 }
                 Ok(res)
             }
         })
         .await
-        .unwrap_or_default()
     }
 
     #[inline]
-    async fn compute_closure_size(&self, path: &StorePath) -> u64 {
+    async fn compute_closure_size(&self, path: &StorePath) -> Result<u64, Error> {
         let store = self.wrapper.clone();
         let path = self.print_store_path(path);
-        asyncify(move || ffi::compute_closure_size(store.as_raw(), &path))
-            .await
-            .unwrap_or_default()
+        asyncify(move || ffi::compute_closure_size(store.as_raw(), &path)).await
     }
 
     #[inline]
@@ -726,7 +724,7 @@ impl LocalStore {
         tokio_stream::iter(outputs)
             .map(|(name, path)| async move {
                 match path {
-                    Some(p) if self.is_valid_path(&p).await => None,
+                    Some(p) if self.is_valid_path(&p).await.unwrap_or(false) => None,
                     other => Some((name, other)),
                 }
             })
@@ -778,12 +776,15 @@ impl LocalStore {
 
 impl BaseStore for LocalStore {
     #[inline]
-    async fn is_valid_path(&self, path: &StorePath) -> bool {
+    async fn is_valid_path(&self, path: &StorePath) -> Result<bool, Error> {
         self.base.is_valid_path(path).await
     }
 
     #[inline]
-    async fn query_path_info(&self, path: &StorePath) -> Option<UnkeyedValidPathInfo> {
+    async fn query_path_info(
+        &self,
+        path: &StorePath,
+    ) -> Result<Option<UnkeyedValidPathInfo>, Error> {
         self.base.query_path_info(path).await
     }
 
@@ -791,12 +792,12 @@ impl BaseStore for LocalStore {
     async fn query_path_infos(
         &self,
         paths: &[&StorePath],
-    ) -> HashMap<StorePath, UnkeyedValidPathInfo> {
+    ) -> Result<HashMap<StorePath, UnkeyedValidPathInfo>, Error> {
         self.base.query_path_infos(paths).await
     }
 
     #[inline]
-    async fn compute_closure_size(&self, path: &StorePath) -> u64 {
+    async fn compute_closure_size(&self, path: &StorePath) -> Result<u64, Error> {
         self.base.compute_closure_size(path).await
     }
 
@@ -907,7 +908,7 @@ impl RemoteStore {
 
         tokio_stream::iter(paths)
             .map(|p| async move {
-                if self.is_valid_path(&p).await {
+                if self.is_valid_path(&p).await.unwrap_or(false) {
                     None
                 } else {
                     Some(p)
@@ -929,7 +930,7 @@ impl RemoteStore {
         tokio_stream::iter(outputs)
             .map(|(name, path)| async move {
                 match path {
-                    Some(p) if self.is_valid_path(&p).await => None,
+                    Some(p) if self.is_valid_path(&p).await.unwrap_or(false) => None,
                     other => Some((name, other)),
                 }
             })
@@ -942,12 +943,15 @@ impl RemoteStore {
 
 impl BaseStore for RemoteStore {
     #[inline]
-    async fn is_valid_path(&self, path: &StorePath) -> bool {
+    async fn is_valid_path(&self, path: &StorePath) -> Result<bool, Error> {
         self.base.is_valid_path(path).await
     }
 
     #[inline]
-    async fn query_path_info(&self, path: &StorePath) -> Option<UnkeyedValidPathInfo> {
+    async fn query_path_info(
+        &self,
+        path: &StorePath,
+    ) -> Result<Option<UnkeyedValidPathInfo>, Error> {
         self.base.query_path_info(path).await
     }
 
@@ -955,12 +959,12 @@ impl BaseStore for RemoteStore {
     async fn query_path_infos(
         &self,
         paths: &[&StorePath],
-    ) -> HashMap<StorePath, UnkeyedValidPathInfo> {
+    ) -> Result<HashMap<StorePath, UnkeyedValidPathInfo>, Error> {
         self.base.query_path_infos(paths).await
     }
 
     #[inline]
-    async fn compute_closure_size(&self, path: &StorePath) -> u64 {
+    async fn compute_closure_size(&self, path: &StorePath) -> Result<u64, Error> {
         self.base.compute_closure_size(path).await
     }
 

--- a/subprojects/crates/nix-utils/src/nix.cpp
+++ b/subprojects/crates/nix-utils/src/nix.cpp
@@ -113,7 +113,11 @@ bool is_valid_path(const StoreWrapper &wrapper, rust::Str path) {
 
 InternalPathInfo query_path_info(const StoreWrapper &wrapper, rust::Str path) {
   auto store = wrapper._store;
-  auto info = store->queryPathInfo(store->parseStorePath(AS_VIEW(path)));
+  auto storePath = store->parseStorePath(AS_VIEW(path));
+  if (!store->isValidPath(storePath)) {
+    return InternalPathInfo{false, "", "", {}, 0, 0, {}, {}, ""};
+  }
+  auto info = store->queryPathInfo(storePath);
 
   // Return raw SHA256 bytes (32 bytes) — Rust side converts to NarHash directly.
   rust::Vec<uint8_t> narhash_bytes;
@@ -133,6 +137,7 @@ InternalPathInfo query_path_info(const StoreWrapper &wrapper, rust::Str path) {
 
   // TODO(conni2461): Replace "" with option
   return InternalPathInfo{
+      true,
       rust::String(store->storeDir.data(), store->storeDir.size()),
       extract_opt_path(info->deriver),
       narhash_bytes,

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -531,9 +531,15 @@ impl State {
         // successful build.
         let mut output_infos = BTreeMap::new();
         for (name, path) in &outputs {
-            let info = store.query_path_info(path).await.ok_or_else(|| {
-                JobFailure::PostProcessing(anyhow::anyhow!("missing path info for output `{name}`"))
-            })?;
+            let info = store
+                .query_path_info(path)
+                .await
+                .map_err(|e| JobFailure::PostProcessing(e.into()))?
+                .ok_or_else(|| {
+                    JobFailure::PostProcessing(anyhow::anyhow!(
+                        "missing path info for output `{name}`"
+                    ))
+                })?;
             output_infos.insert(
                 name.clone(),
                 harmonia_store_path_info::ValidPathInfo {
@@ -670,12 +676,12 @@ async fn filter_missing(
     store: &nix_utils::LocalStore,
     gcroot: &Gcroot,
     path: StorePath,
-) -> Option<StorePath> {
-    if store.is_valid_path(&path).await {
+) -> anyhow::Result<Option<StorePath>> {
+    if store.is_valid_path(&path).await? {
         nix_utils::add_root(store, &gcroot.root, &path);
-        None
+        Ok(None)
     } else {
-        Some(path)
+        Ok(Some(path))
     }
 }
 
@@ -706,9 +712,13 @@ async fn import_paths(
             filter_missing(&store, gcroot, p)
         })
         .buffered(10)
-        .filter_map(|o| async { o })
         .collect::<Vec<_>>()
         .await
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect()
     } else {
         paths
     };
@@ -716,13 +726,17 @@ async fn import_paths(
         metrics.add_substituting_path(paths.len() as u64);
         let _ = substitute_paths(&store, &paths).await;
         metrics.sub_substituting_path(paths.len() as u64);
-        let paths = futures::StreamExt::map(tokio_stream::iter(paths), |p| {
+        let paths: Vec<_> = futures::StreamExt::map(tokio_stream::iter(paths), |p| {
             filter_missing(&store, gcroot, p)
         })
         .buffered(10)
-        .filter_map(|o| async { o })
         .collect::<Vec<_>>()
-        .await;
+        .await
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect();
         if paths.is_empty() {
             return Ok(());
         }
@@ -772,13 +786,17 @@ async fn import_requisites<T: IntoIterator<Item = StorePath>>(
 ) -> anyhow::Result<()> {
     use futures::stream::StreamExt as _;
 
-    let requisites = futures::StreamExt::map(tokio_stream::iter(requisites), |p| {
+    let requisites: Vec<StorePath> = futures::StreamExt::map(tokio_stream::iter(requisites), |p| {
         filter_missing(&store, gcroot, p)
     })
     .buffered(50)
-    .filter_map(|o| async { o })
     .collect::<Vec<_>>()
-    .await;
+    .await
+    .into_iter()
+    .collect::<anyhow::Result<Vec<_>>>()?
+    .into_iter()
+    .flatten()
+    .collect();
 
     let (input_drvs, input_srcs): (Vec<_>, Vec<_>) =
         requisites.into_iter().partition(StorePath::is_derivation);
@@ -862,7 +880,7 @@ async fn upload_nars_regular(
     let store_clone = store.clone();
     let sender = tokio::task::spawn_blocking(move || {
         let rt = tokio::runtime::Runtime::new()?;
-        let infos = rt.block_on(store_clone.query_path_infos(&nars.iter().collect::<Vec<_>>()));
+        let infos = rt.block_on(store_clone.query_path_infos(&nars.iter().collect::<Vec<_>>()))?;
         store_transfer::export::export(&store_clone, &nars, &infos, &tx);
         Ok::<(), anyhow::Error>(())
     });
@@ -907,7 +925,7 @@ async fn upload_nars_presigned(
         .await
         .unwrap_or_default();
     let paths_to_upload_ref = paths_to_upload.iter().collect::<Vec<_>>();
-    let path_infos = Arc::new(store.query_path_infos(&paths_to_upload_ref).await);
+    let path_infos = Arc::new(store.query_path_infos(&paths_to_upload_ref).await?);
 
     let mut nars = Vec::with_capacity(paths_to_upload.len());
     let mut stream = tokio_stream::iter(paths_to_upload.clone())
@@ -1080,7 +1098,7 @@ async fn new_success_build_result_info(
             name.to_string(),
             OutputInfo {
                 path: Some(ProtoStorePath::from(vpi.path.clone())),
-                closure_size: store.compute_closure_size(&vpi.path).await,
+                closure_size: store.compute_closure_size(&vpi.path).await?,
                 nar_size: vpi.info.nar_size,
                 nar_hash: {
                     let h: harmonia_utils_hash::Hash = vpi.info.nar_hash.into();

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -529,7 +529,11 @@ impl RunnerService for Server {
     ) -> BuilderResult<hydra_proto::HasPathResponse> {
         let path = req.into_inner().0;
         let state = self.state.clone();
-        let has_path = state.store.is_valid_path(&path).await;
+        let has_path = state
+            .store
+            .is_valid_path(&path)
+            .await
+            .map_err(|e| tonic::Status::internal(format!("is_valid_path failed: {e}")))?;
 
         Ok(tonic::Response::new(hydra_proto::HasPathResponse {
             has_path,
@@ -547,7 +551,8 @@ impl RunnerService for Server {
             .state
             .store
             .query_path_infos(&paths.iter().collect::<Vec<_>>())
-            .await;
+            .await
+            .map_err(|e| tonic::Status::internal(format!("query_path_infos failed: {e}")))?;
 
         let (tx, rx) = mpsc::unbounded_channel();
 

--- a/subprojects/hydra-queue-runner/src/state/build.rs
+++ b/subprojects/hydra-queue-runner/src/state/build.rs
@@ -441,7 +441,7 @@ impl BuildOutput {
             .collect();
         let pathinfos = store
             .query_path_infos(&resolved.values().collect::<Vec<_>>())
-            .await;
+            .await?;
         let fs = nix_support::FilesystemOperations {
             real_store_dir: store.get_store_dir().to_path().to_owned(),
         };
@@ -464,7 +464,7 @@ impl BuildOutput {
 
         for (name, path) in resolved {
             if let Some(info) = pathinfos.get(&path) {
-                closure_size += store.compute_closure_size(&path).await;
+                closure_size += store.compute_closure_size(&path).await?;
                 nar_size += info.nar_size;
                 outputs_map.insert(name, path);
             }

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -619,13 +619,13 @@ impl State {
             .await?)
     }
 
-    #[tracing::instrument(skip(self, new_ids, new_builds_by_id, new_builds_by_path))]
+    #[tracing::instrument(skip(self, new_ids, new_builds_by_id, new_builds_by_path), err)]
     async fn process_new_builds(
         &self,
         new_ids: Vec<BuildID>,
         new_builds_by_id: Arc<parking_lot::RwLock<HashMap<BuildID, Arc<Build>>>>,
         new_builds_by_path: HashMap<StorePath, HashSet<BuildID>>,
-    ) {
+    ) -> anyhow::Result<()> {
         let finished_drvs = Arc::new(parking_lot::RwLock::new(HashSet::<StorePath>::new()));
 
         let starttime = jiff::Timestamp::now();
@@ -646,7 +646,7 @@ impl State {
                 finished_drvs.clone(),
                 new_runnable.clone(),
             ))
-            .await;
+            .await?;
 
             // we should never run into this issue
             #[allow(clippy::cast_possible_truncation)]
@@ -689,6 +689,7 @@ impl State {
         if let Some(fod_checker) = &self.fod_checker {
             fod_checker.trigger_traverse();
         }
+        Ok(())
     }
 
     #[tracing::instrument(skip(self), err)]
@@ -781,7 +782,7 @@ impl State {
         }
 
         let new_builds_by_id = Arc::new(parking_lot::RwLock::new(new_builds_by_id));
-        Box::pin(self.process_new_builds(new_ids, new_builds_by_id, new_builds_by_path)).await;
+        Box::pin(self.process_new_builds(new_ids, new_builds_by_id, new_builds_by_path)).await?;
         Ok(())
     }
 
@@ -814,7 +815,7 @@ impl State {
         tracing::debug!("new_builds_by_path: {new_builds_by_path:?}");
 
         let new_builds_by_id = Arc::new(parking_lot::RwLock::new(new_builds_by_id));
-        Box::pin(self.process_new_builds(new_ids, new_builds_by_id, new_builds_by_path)).await;
+        Box::pin(self.process_new_builds(new_ids, new_builds_by_id, new_builds_by_path)).await?;
         Ok(())
     }
 
@@ -1779,7 +1780,7 @@ impl State {
         new_builds_by_path: &HashMap<StorePath, HashSet<BuildID>>,
         finished_drvs: Arc<parking_lot::RwLock<HashSet<StorePath>>>,
         new_runnable: Arc<parking_lot::RwLock<HashSet<Arc<Step>>>>,
-    ) {
+    ) -> anyhow::Result<()> {
         self.metrics.queue_build_loads.inc();
         tracing::info!("loading build {} ({})", build.id, build.full_job_name());
         nr_added.fetch_add(1, Ordering::Relaxed);
@@ -1788,7 +1789,7 @@ impl State {
             new_builds_by_id.remove(&build.id);
         }
 
-        if !self.store.is_valid_path(&build.drv_path).await {
+        if !self.store.is_valid_path(&build.drv_path).await? {
             tracing::error!(
                 "aborting GC'ed build id={} path={}",
                 build.id,
@@ -1811,7 +1812,7 @@ impl State {
 
             build.set_finished_in_db(true);
             self.metrics.nr_builds_done.inc();
-            return;
+            return Ok(());
         }
 
         // Create steps for this derivation and its dependencies.
@@ -1835,7 +1836,7 @@ impl State {
                 if let Err(e) = self.handle_previous_failure(build, step).await {
                     tracing::error!("Failed to handle previous failure: {e}");
                 }
-                return;
+                return Ok(());
             }
         };
 
@@ -1860,7 +1861,7 @@ impl State {
                         if let Some(j) = new_builds_by_id.read().get(&b) {
                             j.clone()
                         } else {
-                            return;
+                            return Ok(());
                         }
                     };
 
@@ -1872,11 +1873,13 @@ impl State {
                         finished_drvs,
                         new_runnable,
                     ))
-                    .await;
+                    .await
                 }
             })
             .buffered(10);
-            while tokio_stream::StreamExt::next(&mut stream).await.is_some() {}
+            while let Some(result) = tokio_stream::StreamExt::next(&mut stream).await {
+                result?;
+            }
         }
 
         if let Some(step) = step {
@@ -1900,6 +1903,7 @@ impl State {
                 tracing::error!("failed to handle cached build: {e}");
             }
         }
+        Ok(())
     }
 
     #[allow(clippy::too_many_lines, clippy::too_many_arguments)]


### PR DESCRIPTION
Previously the trait implementations silently swallowed FFI errors as
"path not found" / empty / zero. This was dubious and could cause
mysterious failures. For example, a daemon connection error would look
like "path is present" to callers, causing paths to be skipped from
import and builds to fail with cryptic errors instead. We don't want
that! Better to have an earlier clear failure.

The C++ `query_path_info` now checks `isValidPath` first and returns
a `found: false` sentinel instead of throwing `InvalidPath` —
eliminating brittle error-message string matching on the Rust side.

All callers updated to propagate errors with `?`.