### PR TITLE
hydra-tests: Add basic test for logging

### DIFF
--- a/subprojects/hydra-tests/jobs/logging-failure.sh
+++ b/subprojects/hydra-tests/jobs/logging-failure.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+echo "should appear in failure"
+
+exit 1

--- a/subprojects/hydra-tests/jobs/logging-success.sh
+++ b/subprojects/hydra-tests/jobs/logging-success.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+echo "should appear in success"
+mkdir $out
+echo "is output" > $out/file

--- a/subprojects/hydra-tests/jobs/logging.nix
+++ b/subprojects/hydra-tests/jobs/logging.nix
@@ -1,0 +1,12 @@
+with import ./config.nix;
+{
+  success = mkDerivation {
+    name = "logging-success";
+    builder = ./logging-success.sh;
+  };
+
+  failure = mkDerivation {
+    name = "logging-failure";
+    builder = ./logging-failure.sh;
+  };
+}

--- a/subprojects/hydra-tests/queue-runner/logging.t
+++ b/subprojects/hydra-tests/queue-runner/logging.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Setup;
+use Test2::V0;
+use File::Slurper qw(read_text);
+require Hydra::Helper::Nix;
+
+my $ctx = test_context();
+setup_catalyst_test($ctx);
+
+my $builds = $ctx->makeAndEvaluateJobset(
+    expression => "logging.nix",
+    build => 1
+);
+
+subtest "success" => sub {
+    my $build = $builds->{"success"};
+    is($build->finished, 1, "Build should be finished.");
+    is($build->buildstatus, 0, "Build should have succeeded.");
+
+    # getDrvLogPath wants HYDRA_DATA
+    local $ENV{HYDRA_DATA} = $ctx->{central}{hydra_data} . "/data";
+    my $logPath = Hydra::Helper::Nix::getDrvLogPath($build->drvpath) or die "Log file did not exist";
+    my $logContent = read_text($logPath) or die "Could not read log file";
+    ok(index($logContent, "should appear in success") != -1, "Log should contain correct content");
+};
+
+subtest "failure" => sub {
+    my $build = $builds->{"failure"};
+    is($build->finished, 1, "Build should be finished.");
+    is($build->buildstatus, 1, "Build should have failed.");
+
+    # getDrvLogPath wants HYDRA_DATA
+    local $ENV{HYDRA_DATA} = $ctx->{central}{hydra_data} . "/data";
+    my $logPath = Hydra::Helper::Nix::getDrvLogPath($build->drvpath) or die "Log file did not exist";
+    my $logContent = read_text($logPath) or die "Could not read log file";
+    ok(index($logContent, "should appear in failure") != -1, "Log should contain correct content");
+};
+
+done_testing;


### PR DESCRIPTION
Only makes sure that logs exist at the end of the build, not that they appear during builds.

Success and failure are the two most basic cases, though it may be a good idea to add others (e.g. CA) in the future.

Fixes #1754 