### PR TITLE
[nix-2.28] backport CVE-2025-54800 / GHSA-7qwg-q53v-vh99 (queue-runner validation + template escapes)

### DIFF
--- a/src/hydra-queue-runner/build-result.cc
+++ b/src/hydra-queue-runner/build-result.cc
@@ -149,6 +149,8 @@ BuildOutput getBuildOutput(
             metric.name = fields[0];
             metric.value = atof(fields[1].c_str()); // FIXME
             metric.unit = fields.size() >= 3 ? fields[2] : "";
+            if (!std::regex_match(metric.unit, std::regex("[a-zA-Z0-9._%-]+")))
+                metric.unit = "";
             res.metrics[metric.name] = metric;
         }
     }

--- a/src/hydra-queue-runner/build-result.cc
+++ b/src/hydra-queue-runner/build-result.cc
@@ -51,8 +51,8 @@ BuildOutput getBuildOutput(
         "[[:space:]]+"
         "([a-zA-Z0-9_-]+)" // subtype (e.g. "readme")
         "[[:space:]]+"
-        "(\"[^\"]+\"|[^[:space:]\"]+)" // path (may be quoted)
-        "([[:space:]]+([^[:space:]]+))?" // entry point
+        "(\"[^\"]+\"|[^[:space:]<>\"]+)" // path (may be quoted)
+        "([[:space:]]+([^[:space:]<>]+))?" // entry point
         , std::regex::extended);
 
     for (auto & output : outputs) {

--- a/src/hydra-queue-runner/build-result.cc
+++ b/src/hydra-queue-runner/build-result.cc
@@ -78,7 +78,7 @@ BuildOutput getBuildOutput(
             product.type = match[1];
             product.subtype = match[2];
             std::string s(match[3]);
-            product.path = s[0] == '"' ? std::string(s, 1, s.size() - 2) : s;
+            product.path = s[0] == '"' && s.back() == '"' ? std::string(s, 1, s.size() - 2) : s;
             product.defaultPath = match[5];
 
             /* Ensure that the path exists and points into the Nix

--- a/src/hydra-queue-runner/build-result.cc
+++ b/src/hydra-queue-runner/build-result.cc
@@ -129,8 +129,9 @@ BuildOutput getBuildOutput(
         if (file == narMembers.end() ||
             file->second.type != SourceAccessor::Type::tRegular)
             continue;
-        res.releaseName = trim(file->second.contents.value());
-        // FIXME: validate release name
+        auto contents = trim(file->second.contents.value());
+        if (std::regex_match(contents, std::regex("[a-zA-Z0-9.@:_-]+")))
+            res.releaseName = contents;
     }
 
     /* Get metrics. */

--- a/src/hydra-queue-runner/build-result.cc
+++ b/src/hydra-queue-runner/build-result.cc
@@ -143,8 +143,10 @@ BuildOutput getBuildOutput(
         for (auto & line : tokenizeString<Strings>(file->second.contents.value(), "\n")) {
             auto fields = tokenizeString<std::vector<std::string>>(line);
             if (fields.size() < 2) continue;
+            if (!std::regex_match(fields[0], std::regex("[a-zA-Z0-9._-]+")))
+                continue;
             BuildMetric metric;
-            metric.name = fields[0]; // FIXME: validate
+            metric.name = fields[0];
             metric.value = atof(fields[1].c_str()); // FIXME
             metric.unit = fields.size() >= 3 ? fields[2] : "";
             res.metrics[metric.name] = metric;

--- a/src/hydra-queue-runner/build-result.cc
+++ b/src/hydra-queue-runner/build-result.cc
@@ -93,6 +93,8 @@ BuildOutput getBuildOutput(
             if (file == narMembers.end()) continue;
 
             product.name = product.path == store->printStorePath(output) ? "" : baseNameOf(product.path);
+            if (!std::regex_match(product.name, std::regex("[a-zA-Z0-9.@:_ -]*")))
+                product.name = "";
 
             if (file->second.type == SourceAccessor::Type::tRegular) {
                 product.isRegular = true;

--- a/src/hydra-queue-runner/build-result.cc
+++ b/src/hydra-queue-runner/build-result.cc
@@ -147,7 +147,11 @@ BuildOutput getBuildOutput(
                 continue;
             BuildMetric metric;
             metric.name = fields[0];
-            metric.value = atof(fields[1].c_str()); // FIXME
+            try {
+                metric.value = std::stod(fields[1]);
+            } catch (...) {
+                continue; // skip this metric
+            }
             metric.unit = fields.size() >= 3 ? fields[2] : "";
             if (!std::regex_match(metric.unit, std::regex("[a-zA-Z0-9._%-]+")))
                 metric.unit = "";

--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -37,7 +37,7 @@ END;
              seen.${step.drvpath} = 1;
              log = c.uri_for('/build' build.id 'nixlog' step.stepnr); %]
           <tr>
-            <td>[% step.stepnr %]</td>
+            <td>[% HTML.escape(step.stepnr) %]</td>
             <td>
               [% IF step.type == 0 %]
                 Build of <tt>[% INCLUDE renderOutputs outputs=step.buildstepoutputs %]</tt>
@@ -151,7 +151,7 @@ END;
           <table class="info-table">
             <tr>
               <th>Build ID:</th>
-              <td>[% build.id %]</td>
+              <td>[% HTML.escape(build.id) %]</td>
             </tr>
             <tr>
               <th>Status:</th>
@@ -168,9 +168,9 @@ END;
                      END;
                 %];
                   [%+ IF nrFinished == nrConstituents && nrFailedConstituents == 0 %]
-                    all [% nrConstituents %] constituent builds succeeded
+                    all [% HTML.escape(nrConstituents) %] constituent builds succeeded
                   [% ELSE %]
-                    [% nrFailedConstituents %] out of [% nrConstituents %] constituent builds failed
+                    [% HTML.escape(nrFailedConstituents) %] out of [% HTML.escape(nrConstituents) %] constituent builds failed
                     [% IF nrFinished < nrConstituents %]
                       ([% nrConstituents - nrFinished %] still pending)
                     [% END %]
@@ -180,24 +180,24 @@ END;
             </tr>
             <tr>
               <th>System:</th>
-              <td><tt>[% build.system %]</tt></td>
+              <td><tt>[% build.system | html %]</tt></td>
             </tr>
             [% IF build.releasename %]
               <tr>
                 <th>Release name:</th>
-                <td><tt>[% HTML.escape(build.releasename) %]</tt></td>
+                <td><tt>[% build.releasename | html %]</tt></td>
               </tr>
             [% ELSE %]
               <tr>
                 <th>Nix name:</th>
-                <td><tt>[% build.nixname %]</tt></td>
+                <td><tt>[% build.nixname | html %]</tt></td>
               </tr>
             [% END %]
             [% IF eval %]
               <tr>
                 <th>Part of:</th>
                 <td>
-                  <a href="[% c.uri_for(c.controller('JobsetEval').action_for('view'), [eval.id]) %]">evaluation [% eval.id %]</a>
+                  <a href="[% c.uri_for(c.controller('JobsetEval').action_for('view'), [eval.id]) %]">evaluation [% HTML.escape(eval.id) %]</a>
                   [% IF nrEvals > 1 +%] (and <a href="[% c.uri_for('/build' build.id 'evals') %]">[% nrEvals - 1 %] others</a>)[% END %]
                 </td>
               </tr>
@@ -336,12 +336,12 @@ END;
       [% IF eval.nixexprinput %]
         <tr>
           <th>Nix expression:</th>
-          <td>file <tt>[% HTML.escape(eval.nixexprpath) %]</tt> in input <tt>[% HTML.escape(eval.nixexprinput) %]</tt></td>
+          <td>file <tt>[% eval.nixexprpath | html %]</tt> in input <tt>[% eval.nixexprinput | html %]</tt></td>
         </tr>
       [% END %]
       <tr>
         <th>Nix name:</th>
-        <td><tt>[% build.nixname %]</tt></td>
+        <td><tt>[% build.nixname | html %]</tt></td>
       </tr>
       <tr>
         <th>Short description:</th>
@@ -361,11 +361,11 @@ END;
       </tr>
       <tr>
         <th>System:</th>
-        <td><tt>[% build.system %]</tt></td>
+        <td><tt>[% build.system | html %]</tt></td>
       </tr>
       <tr>
         <th>Derivation store path:</th>
-        <td><tt>[% build.drvpath %]</tt></td>
+        <td><tt>[% build.drvpath | html %]</tt></td>
       </tr>
       <tr>
         <th>Output store paths:</th>
@@ -412,9 +412,9 @@ END;
         <tbody>
           [% FOREACH metric IN build.buildmetrics %]
             <tr>
-              <td><tt><a class="row-link" [% HTML.attributes(href => c.uri_for('/job' project.name jobset.name job 'metric' metric.name)) %]">[%HTML.escape(metric.name)%]</a></tt></td>
-              <td style="text-align: right">[%metric.value%]</td>
-              <td>[%metric.unit%]</td>
+              <td><tt><a class="row-link" [% HTML.attributes(href => c.uri_for('/job' project.name jobset.name job 'metric' metric.name)) %]">[%metric.name | html%]</a></tt></td>
+              <td style="text-align: right">[%HTML.escape(metric.value)%]</td>
+              <td>[% HTML.escape(metric.unit) %]</td>
             </tr>
           [% END %]
         </tbody>
@@ -456,8 +456,8 @@ END;
           [% FOREACH input IN build.dependents %]
             <tr>
               <td>[% INCLUDE renderFullBuildLink build=input.build %]</td>
-              <td><tt>[% input.name %]</tt></td>
-              <td><tt>[% input.build.system %]</tt></td>
+              <td><tt>[% input.name | html %]</tt></td>
+              <td><tt>[% input.build.system | html %]</tt></td>
               <td>[% INCLUDE renderDateTime timestamp = input.build.timestamp %]</td>
             </tr>
           [% END %]
@@ -484,7 +484,7 @@ END;
         [% ELSIF runcommandlogProblem == "disabled-jobset" %]
           This jobset does not enable Dynamic RunCommand support.
         [% ELSE %]
-          Dynamic RunCommand is not enabled: [% runcommandlogProblem %].
+          Dynamic RunCommand is not enabled: [% HTML.escape(runcommandlogProblem) %].
         [% END %]
       </div>
     [% END %]
@@ -503,7 +503,7 @@ END;
           </div>
 
           <div class="d-flex flex-column mr-auto align-self-center">
-            <div><tt>[% runcommandlog.command | html%]</tt></div>
+            <div><tt>[% runcommandlog.command | html %]</tt></div>
             <div>
               [% IF not runcommandlog.is_running() %]
                 [% IF runcommandlog.did_fail_with_signal() %]

--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -112,16 +112,16 @@ END;
       [% IF c.user_exists %]
         [% IF available %]
           [% IF build.keep %]
-            <a class="dropdown-item" href="[% c.uri_for('/build' build.id 'keep' 0) %]">Unkeep</a>
+            <a class="dropdown-item" [% HTML.attributes(href => c.uri_for('/build' build.id 'keep' 0)) %]>Unkeep</a>
           [% ELSE %]
-            <a class="dropdown-item" href="[% c.uri_for('/build' build.id 'keep' 1) %]">Keep</a>
+            <a class="dropdown-item" [% HTML.attributes(href => c.uri_for('/build' build.id 'keep' 1)) %]>Keep</a>
           [% END %]
         [% END %]
         [% IF build.finished %]
-          <a class="dropdown-item" href="[% c.uri_for('/build' build.id 'restart') %]">Restart</a>
+          <a class="dropdown-item" [% HTML.attributes(href => c.uri_for('/build' build.id 'restart')) %]>Restart</a>
         [% ELSE %]
-          <a class="dropdown-item" href="[% c.uri_for('/build' build.id 'cancel') %]">Cancel</a>
-          <a class="dropdown-item" href="[% c.uri_for('/build' build.id 'bump') %]">Bump up</a>
+          <a class="dropdown-item" [% HTML.attributes(href => c.uri_for('/build' build.id 'cancel')) %]>Cancel</a>
+          <a class="dropdown-item" [% HTML.attributes(href => c.uri_for('/build' build.id 'bump')) %]>Bump up</a>
         [% END %]
       [% END %]
     </div>
@@ -197,8 +197,8 @@ END;
               <tr>
                 <th>Part of:</th>
                 <td>
-                  <a href="[% c.uri_for(c.controller('JobsetEval').action_for('view'), [eval.id]) %]">evaluation [% HTML.escape(eval.id) %]</a>
-                  [% IF nrEvals > 1 +%] (and <a href="[% c.uri_for('/build' build.id 'evals') %]">[% nrEvals - 1 %] others</a>)[% END %]
+                  <a [% HTML.attributes(href => c.uri_for(c.controller('JobsetEval').action_for('view'), [eval.id])) %]>evaluation [% HTML.escape(eval.id) %]</a>
+                  [% IF nrEvals > 1 +%] (and <a [% HTML.attributes(href => c.uri_for('/build' build.id 'evals')) %]>[% nrEvals - 1 %] others</a>)[% END %]
                 </td>
               </tr>
             [% END %]
@@ -226,9 +226,9 @@ END;
                 <th>Logfile:</th>
                 <td>
                   [% actualLog = cachedBuildStep ? c.uri_for('/build' cachedBuild.id 'nixlog' cachedBuildStep.stepnr) : c.uri_for('/build' build.id 'log') %]
-                  <a class="btn btn-secondary btn-sm" href="[%actualLog%]">pretty</a>
-                  <a class="btn btn-secondary btn-sm" href="[%actualLog%]/raw">raw</a>
-                  <a class="btn btn-secondary btn-sm" href="[%actualLog%]/tail">tail</a>
+                  <a class="btn btn-secondary btn-sm" [% HTML.attributes(href => actualLog) %]>pretty</a>
+                  <a class="btn btn-secondary btn-sm" [% HTML.attributes(href => actualLog _ "/raw") %]>raw</a>
+                  <a class="btn btn-secondary btn-sm" [% HTML.attributes(href => actualLog _ "/tail") %]>tail</a>
                 </td>
               </tr>
             [% END %]
@@ -376,14 +376,14 @@ END;
         <tr>
           <th>Closure size:</th>
           <td>[% mibs(build.closuresize / (1024 * 1024)) %] MiB
-            (<a href="[%chartsURL%]">history</a>)</td>
+            (<a [% HTML.attributes(href => chartsURL) %]>history</a>)</td>
         </tr>
       [% END %]
       [% IF build.finished && build.closuresize %]
         <tr>
           <th>Output size:</th>
           <td>[% mibs(build.size / (1024 * 1024)) %] MiB
-            (<a href="[%chartsURL%]">history</a>)</td>
+            (<a [% HTML.attributes(href => chartsURL) %]>history</a>)</td>
         </tr>
       [% END %]
       [% IF build.finished && build.buildproducts %]
@@ -532,9 +532,9 @@ END;
                 [% IF runcommandlog.uuid != undef %]
                   [% runLog = c.uri_for('/build', build.id, 'runcommandlog', runcommandlog.uuid) %]
                   <div>
-                    <a class="btn btn-secondary btn-sm" href="[% runLog %]">pretty</a>
-                    <a class="btn btn-secondary btn-sm" href="[% runLog %]/raw">raw</a>
-                    <a class="btn btn-secondary btn-sm" href="[% runLog %]/tail">tail</a>
+                    <a class="btn btn-secondary btn-sm" [% HTML.attributes(href => runLog) %]>pretty</a>
+                    <a class="btn btn-secondary btn-sm" [% HTML.attributes(href => runLog) %]/raw">raw</a>
+                    <a class="btn btn-secondary btn-sm" [% HTML.attributes(href => runLog) %]/tail">tail</a>
                   </div>
                 [% END %]
               </div>

--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -132,7 +132,7 @@ END;
   <li class="nav-item"><a class="nav-link" href="#tabs-details" data-toggle="tab">Details</a></li>
   <li class="nav-item"><a class="nav-link" href="#tabs-buildinputs" data-toggle="tab">Inputs</a></li>
   [% IF steps.size() > 0 %]<li class="nav-item"><a class="nav-link" href="#tabs-buildsteps" data-toggle="tab">Build Steps</a></li>[% END %]
-  [% IF build.dependents %]<li class="nav-item"><a class="nav-link" href="#tabs-usedby" data-toggle="tab">Used By</a></li>[% END%]
+  [% IF build.dependents %]<li class="nav-item"><a class="nav-link" href="#tabs-usedby" data-toggle="tab">Used By</a></li>[% END %]
   [% IF drvAvailable %]<li class="nav-item"><a class="nav-link" href="#tabs-build-deps" data-toggle="tab">Build Dependencies</a></li>[% END %]
   [% IF localStore && available %]<li class="nav-item"><a class="nav-link" href="#tabs-runtime-deps" data-toggle="tab">Runtime Dependencies</a></li>[% END %]
   [% IF runcommandlogProblem || runcommandlogs.size() > 0 %]<li class="nav-item"><a class="nav-link" href="#tabs-runcommandlogs" data-toggle="tab">RunCommand Logs[% IF runcommandlogProblem %] <span class="badge badge-warning">Disabled</span>[% END %]</a></li>[% END %]
@@ -412,8 +412,8 @@ END;
         <tbody>
           [% FOREACH metric IN build.buildmetrics %]
             <tr>
-              <td><tt><a class="row-link" [% HTML.attributes(href => c.uri_for('/job' project.name jobset.name job 'metric' metric.name)) %]">[%metric.name | html%]</a></tt></td>
-              <td style="text-align: right">[%HTML.escape(metric.value)%]</td>
+              <td><tt><a class="row-link" [% HTML.attributes(href => c.uri_for('/job' project.name jobset.name job 'metric' metric.name)) %]">[% metric.name | html %]</a></tt></td>
+              <td style="text-align: right">[% HTML.escape(metric.value) %]</td>
               <td>[% HTML.escape(metric.unit) %]</td>
             </tr>
           [% END %]

--- a/src/root/channel-contents.tt
+++ b/src/root/channel-contents.tt
@@ -49,7 +49,7 @@ installed, you can subscribe to this channel by once executing</p>
       [% b = pkg.build %]
 
       <tr>
-        <td><a href="[% c.uri_for('/build' b.id) %]">[% b.id %]</a></td>
+        <td><a [% HTML.attributes(href => c.uri_for('/build' b.id)) %]>[% b.id %]</a></td>
         <td><tt>[% b.get_column('releasename') || b.nixname %]</tt></td>
         <td><tt>[% b.system %]</tt></td>
         <td>

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -55,17 +55,17 @@ BLOCK renderRelativeDate %]
 [% END;
 
 BLOCK renderProjectName %]
-<a [% IF inRow %]class="row-link"[% END %] href="[% c.uri_for('/project' project) %]"><tt>[% project %]</tt></a>
+<a [% IF inRow %]class="row-link"[% END %] [% HTML.attributes(href => c.uri_for('/project' project)) %]><tt>[% project %]</tt></a>
 [% END;
 
 
 BLOCK renderJobsetName %]
-<a [% IF inRow %]class="row-link"[% END %] href="[% c.uri_for('/jobset' project jobset) %]"><tt>[% jobset %]</tt></a>
+<a [% IF inRow %]class="row-link"[% END %] [% HTML.attributes(href => c.uri_for('/jobset' project jobset)) %]><tt>[% jobset %]</tt></a>
 [% END;
 
 
 BLOCK renderJobName %]
-<a [% IF inRow %]class="row-link"[% END %] href="[% c.uri_for('/job' project jobset job) %]">[% job %]</a>
+<a [% IF inRow %]class="row-link"[% END %] [% HTML.attributes(href => c.uri_for('/job' project jobset job)) %]>[% job %]</a>
 [% END;
 
 
@@ -140,10 +140,10 @@ BLOCK renderBuildListBody;
       [% IF showSchedulingInfo %]
         <td>[% IF busy %]<span class="badge badge-success">Started</span>[% ELSE %]<span class="badge badge-secondary">Queued</span>[% END %]</td>
       [% END %]
-      <td><a class="row-link" href="[% link %]">[% build.id %]</a></td>
+      <td><a class="row-link" [% HTML.attributes(href => link) %]>[% build.id %]</a></td>
       [% IF !hideJobName %]
         <td>
-          <a href="[%link%]">[% IF !hideJobsetName %][%build.jobset.get_column("project")%]:[%build.jobset.get_column("name")%]:[% END %][%build.get_column("job")%]</a>
+          <a [% HTML.attributes(href => link) %]>[% IF !hideJobsetName %][%build.jobset.get_column("project")%]:[%build.jobset.get_column("name")%]:[% END %][%build.get_column("job")%]</a>
           [% IF showStepName %]
             [% INCLUDE renderDrvInfo step=build.buildsteps releasename=build.nixname %]
           [% END %]
@@ -158,7 +158,7 @@ BLOCK renderBuildListBody;
     </tr>
   [% END;
   IF linkToAll %]
-    <tr><td class="centered" colspan="5"><a href="[% linkToAll %]"><em>More...</em></a></td></tr>
+    <tr><td class="centered" colspan="5"><a [% HTML.attributes(href => linkToAll) %]><em>More...</em></a></td></tr>
   [% END;
 END;
 
@@ -176,7 +176,7 @@ BLOCK renderBuildList;
 END;
 
 
-BLOCK renderLink %]<a href="[% uri %]">[% title %]</a>[% END;
+BLOCK renderLink %]<a [% HTML.attributes(href => uri) %]>[% title %]</a>[% END;
 
 
 BLOCK maybeLink;
@@ -216,12 +216,12 @@ BLOCK editString; %]
 
 
 BLOCK renderFullBuildLink;
-  INCLUDE renderFullJobNameOfBuild build=build %] <a href="[% c.uri_for('/build' build.id) %]">build [% build.id %]</a>[%
+  INCLUDE renderFullJobNameOfBuild build=build %] <a [% HTML.attributes(href => c.uri_for('/build' build.id)) %]>build [% build.id %]</a>[%
 END;
 
 
 BLOCK renderBuildIdLink; %]
-<a href="[% c.uri_for('/build' id) %]">build [% id %]</a>
+<a [% HTML.attributes(href => c.uri_for('/build' id)) %]>build [% id %]</a>
 [% END;
 
 
@@ -320,7 +320,7 @@ END;
 
 BLOCK renderShortInputValue;
   IF input.type == "build" || input.type == "sysbuild" %]
-    <a href="[% c.uri_for('/build' input.dependency.id) %]">[% input.dependency.id %]</a>
+    <a [% HTML.attributes(href => c.uri_for('/build' input.dependency.id)) %]>[% input.dependency.id %]</a>
   [% ELSIF input.type == "string" %]
     <tt>"[% HTML.escape(input.value) %]"</tt>
   [% ELSIF input.type == "nix" || input.type == "boolean" %]
@@ -338,7 +338,7 @@ BLOCK renderDiffUri;
     url = bi1.uri;
     path = url.replace(base, '');
     IF url.match(base) %]
-      <a target="_blank" href="[% m.uri.replace('_path_', path).replace('_1_', bi1.revision).replace('_2_', bi2.revision) %]">[% contents %]</a>
+      <a target="_blank" [% HTML.attributes(href => m.uri.replace('_path_', path).replace('_1_', bi1.revision).replace('_2_', bi2.revision)) %]>[% contents %]</a>
       [% nouri = 0;
     END;
   END;
@@ -347,13 +347,13 @@ BLOCK renderDiffUri;
     url = res.0;
     branch = res.1;
     IF bi1.type == "hg" || bi1.type == "git" %]
-      <a target="_blank" href="[% HTML.escape(c.uri_for('/api/scmdiff', {
+      <a target="_blank" [% HTML.attributes(href => c.uri_for('/api/scmdiff', {
         uri = url,
         rev1 = bi1.revision,
         rev2 = bi2.revision,
         type = bi1.type,
         branch = branch
-      })) %]">[% contents %]</a>
+      })) %]>[% contents %]</a>
     [% ELSE;
       contents;
     END;
@@ -443,10 +443,10 @@ BLOCK renderInputDiff; %]
 
 BLOCK renderPager %]
   <ul class="pagination">
-    <li class="page-item[% IF page == 1 %] disabled[% END %]"><a class="page-link" href="[% "$baseUri?page=1" %]">&laquo; First</a></li>
-    <li class="page-item[% IF page == 1 %] disabled[% END %]"><a class="page-link" href="[% "$baseUri?page="; (page - 1) %]">&lsaquo; Previous</a></li>
-    <li class="page-item[% IF page * resultsPerPage >= total %] disabled[% END %]"><a class="page-link" href="[% "$baseUri?page="; (page + 1) %]">Next &rsaquo;</a></li>
-    <li class="page-item[% IF page * resultsPerPage >= total %] disabled[% END %]"><a class="page-link" href="[% "$baseUri?page="; (total - 1) div resultsPerPage + 1 %]">Last &raquo;</a></li>
+    <li class="page-item[% IF page == 1 %] disabled[% END %]"><a class="page-link" [% HTML.attributes(href => "$baseUri?page=1") %]>&laquo; First</a></li>
+    <li class="page-item[% IF page == 1 %] disabled[% END %]"><a class="page-link" [% HTML.attributes(href => "$baseUri?page="); (page - 1) %]>&lsaquo; Previous</a></li>
+    <li class="page-item[% IF page * resultsPerPage >= total %] disabled[% END %]"><a class="page-link" [% HTML.attributes(href => "$baseUri?page="); (page + 1) %]>Next &rsaquo;</a></li>
+    <li class="page-item[% IF page * resultsPerPage >= total %] disabled[% END %]"><a class="page-link" [% HTML.attributes("$baseUri?page="); (total - 1) div resultsPerPage + 1 %]>Last &raquo;</a></li>
   </ul>
 [% END;
 
@@ -459,7 +459,7 @@ BLOCK renderShortEvalInput;
   [% ELSIF input.type == "hg" %]
     <tt>[% input.revision.substr(0, 12) %]</tt>
   [% ELSIF input.type == "build" || input.type == "sysbuild" %]
-    <a href="[% c.uri_for('/build' input.get_column('dependency')) %]">[% input.get_column('dependency') %]</a>
+    <a [% HTML.attributes(href => c.uri_for('/build' input.get_column('dependency'))) %]>[% input.get_column('dependency') %]</a>
   [% ELSE %]
     <tt>[% input.revision %]</tt>
   [% END;
@@ -498,7 +498,7 @@ BLOCK renderEvals %]
         eval = e.eval;
         link = c.uri_for(c.controller('JobsetEval').action_for('view'), [eval.id]) %]
         <tr>
-          <td><a class="row-link" href="[% link %]">[% eval.id %]</a></td>
+          <td><a class="row-link" [% HTML.attributes(href => link) %]>[% eval.id %]</a></td>
           [% IF !jobset && !build %]
             <td>[% INCLUDE renderFullJobsetName project=eval.jobset.project.name jobset=eval.jobset.name %]</td>
           [% END %]
@@ -540,7 +540,7 @@ BLOCK renderEvals %]
         </tr>
       [% END;
       IF linkToAll %]
-        <tr><td class="centered" colspan="7"><a href="[% linkToAll %]"><em>More...</em></a></td></tr>
+        <tr><td class="centered" colspan="7"><a [% HTML.attributes(href => linkToAll) %]><em>More...</em></a></td></tr>
       [% END %]
     </tbody>
   </table>
@@ -548,7 +548,7 @@ BLOCK renderEvals %]
 
 
 BLOCK renderLogLinks %]
-(<a [% IF inRow %]class="row-link"[% END %] href="[% url %]">log</a>, <a href="[% "$url/raw" %]">raw</a>, <a href="[% "$url/tail" %]">tail</a>)
+(<a [% IF inRow %]class="row-link"[% END %] [% HTML.attributes(href => url) %]>log</a>, <a [% HTML.attributes(href => "$url/raw") %]>raw</a>, <a [% HTML.attributes(href => "$url/tail") %]>tail</a>)
 [% END;
 
 

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -143,7 +143,7 @@ BLOCK renderBuildListBody;
       <td><a class="row-link" [% HTML.attributes(href => link) %]>[% build.id %]</a></td>
       [% IF !hideJobName %]
         <td>
-          <a [% HTML.attributes(href => link) %]>[% IF !hideJobsetName %][%build.jobset.get_column("project")%]:[%build.jobset.get_column("name")%]:[% END %][%build.get_column("job")%]</a>
+          <a [% HTML.attributes(href => link) %]>[% IF !hideJobsetName %][% build.jobset.get_column("project") %]:[% build.jobset.get_column("name") %]:[% END %][% build.get_column("job") %]</a>
           [% IF showStepName %]
             [% INCLUDE renderDrvInfo step=build.buildsteps releasename=build.nixname %]
           [% END %]
@@ -687,12 +687,12 @@ BLOCK includeFlot %]
 
 BLOCK createChart %]
 
-  <div id="[%id%]-chart" style="width: 1000px; height: 400px;"></div>
-  <div id="[%id%]-overview" style="margin-top: 20px; margin-left: 50px; margin-right: 50px; width: 900px; height: 100px"></div>
+  <div id="[% id %]-chart" style="width: 1000px; height: 400px;"></div>
+  <div id="[% id %]-overview" style="margin-top: 20px; margin-left: 50px; margin-right: 50px; width: 900px; height: 100px"></div>
 
   <script type="text/javascript">
     $(function() {
-      showChart("[%id%]", "[%dataUrl%]", "[%yaxis%]");
+      showChart("[% id %]", "[% dataUrl %]", "[% yaxis %]");
     });
   </script>
 

--- a/src/root/dashboard.tt
+++ b/src/root/dashboard.tt
@@ -24,7 +24,7 @@
             <tr>
               <td><span class="[% IF !jobExists(j.job.jobset j.job.job) %]disabled-job[% END %]">[% INCLUDE renderFullJobName project=j.job.get_column('project') jobset=j.job.get_column('jobset') job=j.job.job %]</span></td>
               [% FOREACH b IN j.builds %]
-                <td><a href="[% c.uri_for('/build' b.id) %]">[% INCLUDE renderBuildStatusIcon size=16 build=b %]</a></td>
+                <td><a [% HTML.attributes(href => c.uri_for('/build' b.id)) %]>[% INCLUDE renderBuildStatusIcon size=16 build=b %]</a></td>
               [% END %]
             </tr>
           [% END %]

--- a/src/root/deps.tt
+++ b/src/root/deps.tt
@@ -11,7 +11,7 @@
       [% END %]
       <span id="[% done.${node.path} %]"><span class="dep-tree-line">
         [% IF node.buildStep %]
-          <a href="[% c.uri_for('/build' node.buildStep.get_column('build')) %]"><tt>[% node.name %]</tt></a> [%
+          <a [% HTML.attributes(href => c.uri_for('/build' node.buildStep.get_column('build'))) %]><tt>[% node.name %]</tt></a> [%
             IF buildStepLogExists(node.buildStep);
               INCLUDE renderLogLinks url=c.uri_for('/build' node.buildStep.get_column('build') 'nixlog' node.buildStep.stepnr);
             END %]

--- a/src/root/edit-jobset.tt
+++ b/src/root/edit-jobset.tt
@@ -195,7 +195,7 @@
 
   [% INCLUDE renderJobsetInputs %]
 
-  <button id="submit-jobset" type="submit" class="btn btn-primary"><i class="fas fa-check"></i> [%IF !edit %]Create jobset[% ELSE %]Apply changes[% END %]</button>
+  <button id="submit-jobset" type="submit" class="btn btn-primary"><i class="fas fa-check"></i> [% IF !edit %]Create jobset[% ELSE %]Apply changes[% END %]</button>
 
   <table style="display: none">
     [% INCLUDE renderJobsetInput input="" extraClass="template" id="input-template" baseName="input-template" %]

--- a/src/root/edit-project.tt
+++ b/src/root/edit-project.tt
@@ -86,7 +86,7 @@
 
   <button id="submit-project" type="submit" class="btn btn-primary">
     <i class="fas fa-check"></i>
-    [%IF create %]Create project[% ELSE %]Apply changes[% END %]
+    [% IF create %]Create project[% ELSE %]Apply changes[% END %]
   </button>
 
 </form>

--- a/src/root/job-metrics-tab.tt
+++ b/src/root/job-metrics-tab.tt
@@ -16,7 +16,7 @@
 
   [% FOREACH metric IN metrics %]
 
-    <h3>Metric: <a [% HTML.attributes(href => c.uri_for('/job' project.name jobset.name job 'metric' metric.name)) %]><tt>[%HTML.escape(metric.name)%]</tt></a></h3>
+    <h3>Metric: <a [% HTML.attributes(href => c.uri_for('/job' project.name jobset.name job 'metric' metric.name)) %]><tt>[% HTML.escape(metric.name) %]</tt></a></h3>
 
     [% id = metricDivId(metric.name);
        INCLUDE createChart dataUrl=c.uri_for('/job' project.name jobset.name job 'metric' metric.name); %]

--- a/src/root/job.tt
+++ b/src/root/job.tt
@@ -10,8 +10,8 @@
 
 [% IF !jobExists(jobset, job) %]
 <div class="alert alert-warning">This job is not a member of the <a
-href="[%c.uri_for('/jobset' project.name jobset.name
-'evals')%]">latest evaluation</a> of its jobset. This means it was
+[% HTML.attributes(href => c.uri_for('/jobset' project.name jobset.name
+'evals')) %]>latest evaluation</a> of its jobset. This means it was
 removed or had an evaluation error.</div>
 [% END %]
 
@@ -58,7 +58,7 @@ removed or had an evaluation error.</div>
               <th class="rotate-45">
                 [% agg_ = aggregates.$agg %]
                 <div><span class="[% agg_.build.finished == 0 ? "text-info" : (agg_.build.buildstatus == 0 ? "text-success" : "text-warning") %] override-link">
-                  <a href="[% c.uri_for('/build' agg) %]">[% agg %]</a>
+                  <a [% HTML.attributes(href => c.uri_for('/build' agg)) %]>[% agg %]</a>
                 </span></div></th>
             [% END %]
           </tr>
@@ -70,7 +70,7 @@ removed or had an evaluation error.</div>
               [% FOREACH agg IN aggs %]
                 <td>
                   [% r = aggregates.$agg.constituents.$j; IF r.id %]
-                    <a href="[% c.uri_for('/build' r.id) %]">
+                    <a [% HTML.attributes(href => c.uri_for('/build' r.id)) %]>
                       [% INCLUDE renderBuildStatusIcon size=16 build=r %]
                     </a>
                   [% END %]
@@ -89,8 +89,8 @@ removed or had an evaluation error.</div>
 
   <div id="tabs-links" class="tab-pane">
     <ul>
-      <li><a href="[% c.uri_for('/job' project.name jobset.name job 'latest') %]">Latest successful build</a></li>
-      <li><a href="[% c.uri_for('/job' project.name jobset.name job 'latest-finished') %]">Latest successful build from a finished evaluation</a></li>
+      <li><a [% HTML.attributes(href => c.uri_for('/job' project.name jobset.name job 'latest')) %]>Latest successful build</a></li>
+      <li><a [% HTML.attributes(href => c.uri_for('/job' project.name jobset.name job 'latest-finished')) %]>Latest successful build from a finished evaluation</a></li>
     </ul>
   </div>
 

--- a/src/root/jobset-channels-tab.tt
+++ b/src/root/jobset-channels-tab.tt
@@ -14,7 +14,7 @@
         [% FOREACH eval IN evalIds %]
           <th class="rotate-45">
             <div><span>
-              <a href="[% c.uri_for('/eval' eval) %]">[% INCLUDE renderRelativeDate timestamp=evals.$eval.timestamp %]</a>
+              <a [% HTML.attributes(href => c.uri_for('/eval' eval)) %]>[% INCLUDE renderRelativeDate timestamp=evals.$eval.timestamp %]</a>
             </span></div></th>
         [% END %]
       </tr>
@@ -22,9 +22,9 @@
     <tbody>
       [% FOREACH chan IN channels-%]
         <tr>
-          <th><span><a href="[% c.uri_for('/channel/custom' project.name jobset.name chan) %]">[% chan %]</a></span></th>
+          <th><span><a [% HTML.attributes(href => c.uri_for('/channel/custom' project.name jobset.name chan)) %]>[% chan %]</a></span></th>
           [% FOREACH eval IN evalIds %]
-            <td>[% r = evals.$eval.builds.$chan; IF r.id %]<a href="[% c.uri_for('/build' r.id) %]">[% INCLUDE renderBuildStatusIcon size=16 build=r %]</a>[% END %]</td>
+            <td>[% r = evals.$eval.builds.$chan; IF r.id %]<a [% HTML.attributes(href => c.uri_for('/build' r.id)) %]>[% INCLUDE renderBuildStatusIcon size=16 build=r %]</a>[% END %]</td>
           [% END %]
         </tr>
       [% END %]

--- a/src/root/jobset-eval.tt
+++ b/src/root/jobset-eval.tt
@@ -21,7 +21,7 @@
 </div>
 
 <p>This evaluation was performed [% IF eval.flake %]from the flake
-<tt>[%HTML.escape(eval.flake)%]</tt>[%END%] on [% INCLUDE renderDateTime
+<tt>[% HTML.escape(eval.flake) %]</tt>[% END %] on [% INCLUDE renderDateTime
 timestamp=eval.timestamp %]. Fetching the dependencies took [%
 eval.checkouttime %]s and evaluation took [% eval.evaltime %]s.</p>
 

--- a/src/root/jobset-eval.tt
+++ b/src/root/jobset-eval.tt
@@ -27,9 +27,9 @@ eval.checkouttime %]s and evaluation took [% eval.evaltime %]s.</p>
 
 [% IF otherEval %]
 <p>Comparisons are relative to [% INCLUDE renderFullJobsetName
-project=otherEval.jobset.project.name jobset=otherEval.jobset.name %] evaluation <a href="[%
-c.uri_for(c.controller('JobsetEval').action_for('view'),
-[otherEval.id]) %]">[% otherEval.id %]</a>.</p>
+project=otherEval.jobset.project.name jobset=otherEval.jobset.name %] evaluation <a [%
+HTML.attributes(href => c.uri_for(c.controller('JobsetEval').action_for('view'),
+[otherEval.id])) %]>[% otherEval.id %]</a>.</p>
 [% ELSE %]
 <div class="alert alert-danger">Couldn't find an evaluation to compare to.</div>
 [% END %]
@@ -47,18 +47,18 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
     <li class="nav-item dropdown">
       <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">Actions</a>
       <div class="dropdown-menu">
-        <a class="dropdown-item" href="[% c.uri_for(c.controller('JobsetEval').action_for('create_jobset'), [eval.id]) %]">Create a jobset from this evaluation</a>
+        <a class="dropdown-item" [% HTML.attributes(href => c.uri_for(c.controller('JobsetEval').action_for('create_jobset'), [eval.id])) %]>Create a jobset from this evaluation</a>
         [% IF totalQueued > 0 %]
-          <a class="dropdown-item" href="[% c.uri_for(c.controller('JobsetEval').action_for('cancel'), [eval.id]) %]">Cancel all scheduled builds</a>
+          <a class="dropdown-item" [% HTML.attributes(href => c.uri_for(c.controller('JobsetEval').action_for('cancel'), [eval.id])) %]>Cancel all scheduled builds</a>
         [% END %]
         [% IF totalFailed > 0 %]
-          <a class="dropdown-item" href="[% c.uri_for(c.controller('JobsetEval').action_for('restart_failed'), [eval.id]) %]">Restart all failed builds</a>
+          <a class="dropdown-item" [% HTML.attributes(href => c.uri_for(c.controller('JobsetEval').action_for('restart_failed'), [eval.id])) %]>Restart all failed builds</a>
         [% END %]
         [% IF totalAborted > 0 %]
-          <a class="dropdown-item" href="[% c.uri_for(c.controller('JobsetEval').action_for('restart_aborted'), [eval.id]) %]">Restart all aborted builds</a>
+          <a class="dropdown-item" [% HTML.attributes(href => c.uri_for(c.controller('JobsetEval').action_for('restart_aborted'), [eval.id])) %]>Restart all aborted builds</a>
         [% END %]
         [% IF totalQueued > 0 %]
-          <a class="dropdown-item" href="[% c.uri_for(c.controller('JobsetEval').action_for('bump'), [eval.id]) %]">Bump builds to front of queue</a>
+          <a class="dropdown-item" [% HTML.attributes(href => c.uri_for(c.controller('JobsetEval').action_for('bump'), [eval.id])) %]>Bump builds to front of queue</a>
         [% END %]
       </div>
     </li>
@@ -101,7 +101,7 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
   [% INCLUDE renderBuildListBody builds=builds.slice(0, (size > max ? max : size) - 1)
        hideProjectName=1 hideJobsetName=1 busy=0 %]
   [% IF size > max; params = c.req.params; params.full = 1 %]
-  <tr><td class="centered" colspan="6"><a href="[% c.uri_for(c.controller('JobsetEval').action_for('view'), [eval.id], params) %][% tabname %]"><em>([% size - max %] more builds omitted)</em></a></td></tr>
+  <tr><td class="centered" colspan="6"><a [% HTML.attributes(href => c.uri_for(c.controller('JobsetEval').action_for('view'), [eval.id], params) _ tabname) %]><em>([% size - max %] more builds omitted)</em></a></td></tr>
   [% END %]
   [% INCLUDE renderBuildListFooter %]
 [% END %]
@@ -138,7 +138,7 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
           </tr>
         [% END %]
         [% IF size > max; params = c.req.params; params.full = 1 %]
-          <tr><td class="centered" colspan="2"><a href="[% c.uri_for(c.controller('JobsetEval').action_for('view'), [eval.id], params) %]#tabs-removed"><em>([% size - max %] more jobs omitted)</em></a></td></tr>
+          <tr><td class="centered" colspan="2"><a [% HTML.attributes(c.uri_for(c.controller('JobsetEval').action_for('view'), [eval.id], params) _ "#tabs-removed") %]><em>([% size - max %] more jobs omitted)</em></a></td></tr>
         [% END %]
       </tbody>
     </table>

--- a/src/root/jobset-jobs-tab.tt
+++ b/src/root/jobset-jobs-tab.tt
@@ -52,7 +52,7 @@
         [% FOREACH eval IN evalIds %]
           <th class="rotate-45">
             <div><span>
-              <a href="[% c.uri_for('/eval' eval) %]">[% INCLUDE renderRelativeDate timestamp=evals.$eval.timestamp %]</a>
+              <a [% HTML.attributes(href => c.uri_for('/eval' eval)) %]>[% INCLUDE renderRelativeDate timestamp=evals.$eval.timestamp %]</a>
             </span></div></th>
         [% END %]
       </tr>
@@ -62,7 +62,7 @@
         <tr>
           <th><span [% IF inactiveJobs.$j %]class="muted override-link"[% END %]>[% INCLUDE renderJobName project=project.name jobset=jobset.name job=j %]</span></th>
           [% FOREACH eval IN evalIds %]
-            <td>[% r = evals.$eval.builds.$j; IF r.id %]<a href="[% c.uri_for('/build' r.id) %]">[% INCLUDE renderBuildStatusIcon size=16 build=r %]</a>[% END %]</td>
+            <td>[% r = evals.$eval.builds.$j; IF r.id %]<a [% HTML.attributes(href => c.uri_for('/build' r.id)) %]>[% INCLUDE renderBuildStatusIcon size=16 build=r %]</a>[% END %]</td>
           [% END %]
         </tr>
       [% END %]

--- a/src/root/jobset.tt
+++ b/src/root/jobset.tt
@@ -188,7 +188,7 @@
 
   <div id="tabs-links" class="tab-pane">
     <ul>
-      <li><a href="[% c.uri_for(c.controller('Jobset').action_for('latest_eval'), c.req.captures) %]">Latest finished evaluation</a></li>
+      <li><a [% HTML.attributes(href => c.uri_for(c.controller('Jobset').action_for('latest_eval'), c.req.captures)) %]>Latest finished evaluation</a></li>
     </ul>
   </div>
 

--- a/src/root/layout.tt
+++ b/src/root/layout.tt
@@ -24,7 +24,7 @@
 
     <nav class="navbar navbar-expand-md navbar-light bg-light">
       <div class="container">
-        <a class="navbar-brand" href="[% c.uri_for(c.controller('Root').action_for('index')) %]">
+        <a class="navbar-brand" [% HTML.attributes(href => c.uri_for(c.controller('Root').action_for('index'))) %]>
           [% IF logo == "" %]
             Hydra
           [% ELSE %]

--- a/src/root/log.tt
+++ b/src/root/log.tt
@@ -36,7 +36,7 @@
         [% IF tail %]
         /* The server may give us a full log (e.g. if the log is in
            S3). So extract the last lines. */
-        log_data = log_data.split("\n").slice(-[%tail%]).join("\n");
+        log_data = log_data.split("\n").slice(-[% tail %]).join("\n");
         [% END %]
 
         $("#contents").text(log_data);

--- a/src/root/log.tt
+++ b/src/root/log.tt
@@ -16,8 +16,8 @@
     It was built on <tt>[% step.machine %]</tt>.
   [% END %]
   [% IF tail %]
-  The <a href="[% step ? c.uri_for('/build' build.id 'nixlog' step.stepnr)
-  : c.uri_for('/build' build.id 'log') %]">full log</a> is also available.
+  The <a [% HTML.attributes(href => step ? c.uri_for('/build' build.id 'nixlog' step.stepnr)
+  : c.uri_for('/build' build.id 'log')) %]>full log</a> is also available.
   [% END %]
 </p>
 

--- a/src/root/machine-status.tt
+++ b/src/root/machine-status.tt
@@ -40,8 +40,8 @@
           [% idle = 0 %]
           <tr>
             <td><tt>[% INCLUDE renderFullJobName project=step.project jobset=step.jobset job=step.job %]</tt></td>
-            <td><a href="[% c.uri_for('/build' step.build) %]">[% step.build %]</a></td>
-            <td>[% IF step.busy >= 30 %]<a class="row-link" href="[% c.uri_for('/build' step.build 'nixlog' step.stepnr 'tail') %]">[% step.stepnr %]</a>[% ELSE; step.stepnr; END %]</td>
+            <td><a [% HTML.attributes(href => c.uri_for('/build' step.build)) %]>[% step.build %]</a></td>
+            <td>[% IF step.busy >= 30 %]<a class="row-link" [% HTML.attributes(href => c.uri_for('/build' step.build 'nixlog' step.stepnr 'tail')) %]>[% step.stepnr %]</a>[% ELSE; step.stepnr; END %]</td>
             <td><tt>[% step.drvpath.match('-(.*)').0 %]</tt></td>
             <td>[% INCLUDE renderBusyStatus %]</td>
             <td style="width: 10em">[% INCLUDE renderDuration duration = curTime - step.starttime %] </td>

--- a/src/root/overview.tt
+++ b/src/root/overview.tt
@@ -65,7 +65,7 @@
 [% ELSE %]
 
   <div class="alert alert-warning">Hydra has no projects yet. Please
-  <a href="[% c.uri_for(c.controller('Project').action_for('create')) %]">create a project</a>.</div>
+  <a [% HTML.attributes(href => c.uri_for(c.controller('Project').action_for('create'))) %]>create a project</a>.</div>
 
 [% END %]
 

--- a/src/root/product-list.tt
+++ b/src/root/product-list.tt
@@ -81,7 +81,7 @@
               %] <p>You can install this package using the Nix package
               manager from the command-line:</p>
 
-                <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>nix-env -i [%HTML.escape(product.path)%][% IF binaryCachePublicUri %] --option binary-caches [% HTML.escape(binaryCachePublicUri) %][% END %]</code></div></div>
+                <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>nix-env -i [% HTML.escape(product.path) %][% IF binaryCachePublicUri %] --option binary-caches [% HTML.escape(binaryCachePublicUri) %][% END %]</code></div></div>
               [% END %]
               [% IF localStore %]
                 <a class="btn btn-secondary btn-sm" [% HTML.attributes(href => contents) %]>Contents</a>

--- a/src/root/product-list.tt
+++ b/src/root/product-list.tt
@@ -1,17 +1,17 @@
 [% BLOCK renderProductLinks %]
   <tr>
     <th>URL:</th>
-    <td><a href="[% uri %]"><tt>[% uri %]</tt></a></td>
+    <td><a [% HTML.attributes(href => uri) %]><tt>[% uri | html %]</tt></a></td>
   </tr>
   [% IF latestRoot %]
   <tr>
     <th>Links to latest:</th>
     <td>
       [% uri2 = "${c.uri_for(latestRoot.join('/') 'download-by-type' product.type product.subtype)}" %]
-      <a href="[% uri2 %]"><tt>[% uri2 %]</tt></a>
+      <a [% HTML.attributes(href => uri2) %]><tt>[% uri2 | html %]</tt></a>
       <br />
       [% uri2 = "${c.uri_for(latestRoot.join('/') 'download' product.productnr)}" %]
-      <a href="[% uri2 %]"><tt>[% uri2 %]</tt></a>
+      <a [% HTML.attributes(href => uri2) %]><tt>[% uri2 | html %]</tt></a>
     </td>
   </tr>
   [% END %]
@@ -49,7 +49,7 @@
               Error
             </td>
             <td>
-              <a href="[% contents %]">
+              <a [% HTML.attributes(href => contents) %]>
                 Failed build produced output. Click here to inspect the output.
               </a>
             </td>
@@ -58,9 +58,9 @@
                <p>If you have Nix installed on your machine, this failed build output and
                all its dependencies can be unpacked into your local Nix store by doing:</p>
 
-               <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>curl [% uri %] | gunzip | nix-store --import</code></div></div>
+               <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>curl [% HTML.escape(uri) %] | gunzip | nix-store --import</code></div></div>
 
-               <p>The build output can then be found in the path <tt>[% product.path %]</tt>.</p>
+               <p>The build output can then be found in the path <tt>[% product.path | html %]</tt>.</p>
              [% END %]
             </td>
           </tr>
@@ -74,7 +74,7 @@
               Nix package
             </td>
             <td>
-              <tt>[% HTML.escape(build.nixname) %]</tt>
+              <tt>[% build.nixname | html %]</tt>
             </td>
             <td>
               [% WRAPPER makePopover title="Help" classes="btn-secondary btn-sm"
@@ -84,7 +84,7 @@
                 <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>nix-env -i [%HTML.escape(product.path)%][% IF binaryCachePublicUri %] --option binary-caches [% HTML.escape(binaryCachePublicUri) %][% END %]</code></div></div>
               [% END %]
               [% IF localStore %]
-                <a class="btn btn-secondary btn-sm" href="[% contents %]">Contents</a>
+                <a class="btn btn-secondary btn-sm" [% HTML.attributes(href => contents) %]>Contents</a>
               [% END %]
             </td>
           </tr>
@@ -100,8 +100,8 @@
               [% filename = build.nixname _ (product.subtype ? "-" _ product.subtype : "") _ ".closure.gz" %]
               [% uri = c.uri_for('/build' build.id 'nix' 'closure' filename ) %]
 
-              <a href="[% uri %]">
-                <tt>[% product.path %]</tt>
+              <a [% HTML.attributes(href => uri) %]>
+                <tt>[% product.path | html %]</tt>
               </a>
             </td>
             <td>
@@ -110,16 +110,16 @@
                 all its dependencies can be unpacked into your local Nix
                 store by doing:</p>
 
-                <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>gunzip &lt; [% filename %] | nix-store --import</code></div></div>
+                <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>gunzip &lt; [% HTML.escape(filename) %] | nix-store --import</code></div></div>
 
                 <p>or to download and unpack in one command:</p>
 
-                <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>curl [% uri %] | gunzip | nix-store --import</code></div></div>
+                <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>curl [% HTML.escape(uri) %] | gunzip | nix-store --import</code></div></div>
 
                 <p>The package can then be found in the path <tt>[%
-                product.path %]</tt>.  You’ll probably also want to do</p>
+                product.path | html %]</tt>.  You’ll probably also want to do</p>
 
-                <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>nix-env -i [% product.path %]</code></div></div>
+                <div class="card bg-light"><div class="card-body p-2"><code><span class="shell-prompt">$ </span>nix-env -i [% HTML.escape(product.path) %]</code></div></div>
 
                 <p>to actually install the package in your Nix user environment.</p>
 
@@ -174,16 +174,16 @@
             </td>
             <td>
               Channel expression tarball
-              [% IF product.subtype != "-" %]for <tt>[% product.subtype %]</tt>[% END %]
+              [% IF product.subtype != "-" %]for <tt>[% product.subtype | html %]</tt>[% END %]
             </td>
           [% ELSE %]
             <td>File</td>
-            <td>[% product.subtype %]</td>
+            <td>[% HTML.escape(product.subtype) %]</td>
           [% END %]
         [% END %]
         <td>
-          <a href="[% uri %]">
-            <tt>[% product.name %]</tt>
+          <a [% HTML.attributes(href => uri) %]>
+            <tt>[% product.name | html %]</tt>
           </a>
         </td>
         <td>
@@ -191,12 +191,12 @@
             <table class="info-table">
               [% INCLUDE renderProductLinks %]
               <tr><th>File size:</th><td>[% product.filesize %] bytes ([% mibs(product.filesize / (1024 * 1024)) %] MiB)</td></tr>
-              <tr><th>SHA-256 hash:</th><td><tt>[% product.sha256hash %]</tt></td></tr>
-              <tr><th>Full path:</th><td><tt>[% product.path %]</tt></td></tr>
+              <tr><th>SHA-256 hash:</th><td><tt>[% product.sha256hash | html %]</tt></td></tr>
+              <tr><th>Full path:</th><td><tt>[% product.path | html %]</tt></td></tr>
             </table>
           [% END %]
           [% IF localStore %]
-            <a class="btn btn-secondary btn-sm" href="[% contents %]">Contents</a>
+            <a class="btn btn-secondary btn-sm" [% HTML.attributes(href => contents) %]>Contents</a>
           [% END %]
         </td>
       </tr>
@@ -211,15 +211,15 @@
         [% CASE "coverage" %]
           <td>Code coverage</td>
           <td>
-            <a href="[% uri %]">
+            <a [% HTML.attributes(href => uri) %]>
               Analysis report
             </a>
           </td>
         [% CASE DEFAULT %]
           <td>Report</td>
           <td>
-            <a href="[% uri %]">
-              <tt>[% product.subtype %]</tt>
+            <a [% HTML.attributes(href => uri) %]>
+              <tt>[% product.subtype | html %]</tt>
             </a>
           </td>
         [% END %]
@@ -240,7 +240,7 @@
           Documentation
         </td>
         <td>
-        <a href="[% uri %]">
+        <a [% HTML.attributes(href => uri) %]>
           [% SWITCH product.subtype %]
           [% CASE "readme" %]
             Read Me!
@@ -249,7 +249,7 @@
           [% CASE "release-notes" %]
             Release notes
           [% CASE DEFAULT %]
-            [% product.subtype %]
+            [% HTML.escape(product.subtype) %]
           [% END %]
         </a>
         </td>
@@ -266,12 +266,12 @@
 
       <tr class="product">
         <td>
-          <tt>[% product.type %]</tt>
+          <tt>[% product.type | html %]</tt>
         </td>
         <td>
         </td>
         <td>
-         [% product %]
+         [% HTML.escape(product) %]
         </td>
         <td>
         </td>

--- a/src/root/runcommand-log.tt
+++ b/src/root/runcommand-log.tt
@@ -33,7 +33,7 @@
         [% IF tail %]
         /* The server may give us a full log (e.g. if the log is in
            S3). So extract the last lines. */
-        log_data = log_data.split("\n").slice(-[%tail%]).join("\n");
+        log_data = log_data.split("\n").slice(-[% tail %]).join("\n");
         [% END %]
 
         $("#contents").text(log_data);

--- a/src/root/runcommand-log.tt
+++ b/src/root/runcommand-log.tt
@@ -12,9 +12,9 @@
   is
   [% END %]
   the output of a RunCommand execution of the command <tt>[% HTML.escape(runcommandlog.command) %]</tt>
-  on <a href="[% c.uri_for('/build', build.id) %]">Build [% build.id %]</a>.
+  on <a [% HTML.attributes(href => c.uri_for('/build', build.id)) %]>Build [% build.id %]</a>.
   [% IF tail %]
-  The <a href="[% c.uri_for('/build', build.id, 'runcommandlog', runcommandlog.uuid) %]">full log</a> is also available.
+  The <a [% HTML.attributes(href => c.uri_for('/build', build.id, 'runcommandlog', runcommandlog.uuid)) %]>full log</a> is also available.
   [% END %]
 </p>
 

--- a/src/root/steps.tt
+++ b/src/root/steps.tt
@@ -24,8 +24,8 @@ order of descending finish time.</p>
         <td>[% INCLUDE renderBuildStatusIcon buildstatus=step.status size=16 %]</td>
         <td><tt>[% step.drvpath.match('-(.*).drv').0 %]</tt></td>
         <td><tt>[% INCLUDE renderFullJobNameOfBuild build=step.build %]</tt></td>
-        <td><a href="[% c.uri_for('/build' step.build.id) %]">[% step.build.id %]</a></td>
-        <td><a class="row-link" href="[% c.uri_for('/build' step.build.id 'nixlog' step.stepnr 'tail') %]">[% step.stepnr %]</a></td>
+        <td><a [% HTML.attributes(href => c.uri_for('/build' step.build.id)) %]>[% step.build.id %]</a></td>
+        <td><a class="row-link" [% HTML.attributes(href => c.uri_for('/build' step.build.id 'nixlog' step.stepnr 'tail')) %]>[% step.stepnr %]</a></td>
         <td>[% INCLUDE renderRelativeDate timestamp=step.stoptime %]</td>
         <td style="width: 10em">[% INCLUDE renderDuration duration = step.stoptime - step.starttime %] </td>
         <td><tt>[% INCLUDE renderMachineName machine=step.machine %]</tt></td>

--- a/src/root/style.tt
+++ b/src/root/style.tt
@@ -4,14 +4,14 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-<link href="[% c.uri_for("/static/fontawesome/css/all.css") %]" rel="stylesheet" />
+<link [% HTML.attributes(href => c.uri_for("/static/fontawesome/css/all.css")) %] rel="stylesheet" />
 <script type="text/javascript" src="[% c.uri_for("/static/js/popper.min.js") %]"></script>
 <script type="text/javascript" src="[% c.uri_for("/static/bootstrap/js/bootstrap.min.js") %]"></script>
-<link href="[% c.uri_for("/static/bootstrap/css/bootstrap.min.css") %]" rel="stylesheet" />
+<link [% HTML.attributes(href => c.uri_for("/static/bootstrap/css/bootstrap.min.css")) %] rel="stylesheet" />
 
 <!-- hydra.css may need to be moved to before boostrap to make the @media rule work. -->
-<link rel="stylesheet" href="[% c.uri_for("/static/css/hydra.css") %]" type="text/css" />
-<link rel="stylesheet" href="[% c.uri_for("/static/css/rotated-th.css") %]" type="text/css" />
+<link rel="stylesheet" [% HTML.attributes(href => c.uri_for("/static/css/hydra.css")) %] type="text/css" />
+<link rel="stylesheet" [% HTML.attributes(href => c.uri_for("/static/css/rotated-th.css")) %] type="text/css" />
 
 <style>
   .popover { max-width: 40%; }
@@ -19,6 +19,6 @@
 
 <script type="text/javascript" src="[% c.uri_for("/static/js/bootbox.min.js") %]"></script>
 
-<link rel="stylesheet" href="[% c.uri_for("/static/css/tree.css") %]" type="text/css" />
+<link rel="stylesheet" [% HTML.attributes(href => c.uri_for("/static/css/tree.css")) %] type="text/css" />
 
 <script type="text/javascript" src="[% c.uri_for("/static/js/common.js") %]"></script>

--- a/src/root/users.tt
+++ b/src/root/users.tt
@@ -14,7 +14,7 @@
   <tbody>
     [% FOREACH u IN users %]
       <tr>
-        <td><a class="row-link" href="[% c.uri_for(c.controller('User').action_for('edit'), [u.username]) %]">[% HTML.escape(u.username) %]</a></td>
+        <td><a class="row-link" [% HTML.attributes(href => c.uri_for(c.controller('User').action_for('edit'), [u.username])) %]>[% HTML.escape(u.username) %]</a></td>
         <td>[% HTML.escape(u.fullname) %]</td>
         <td>[% HTML.escape(u.emailaddress) %]</td>
         <td>[% FOREACH r IN u.userroles %]<i>[% r.role %]</i> [% END %]</td>
@@ -24,7 +24,7 @@
   </tbody>
 </table>
 
-<a class="btn btn-primary" href="[% c.uri_for(c.controller('Root').action_for('register')) %]">
+<a class="btn btn-primary" [% HTML.attributes(href => c.uri_for(c.controller('Root').action_for('register'))) %]>
   <i class="fas fa-plus"></i> Add a new user
 </a>
 


### PR DESCRIPTION
backport of the GHSA-7qwg-q53v-vh99 / CVE-2025-54800 fix series to the nix-2.28 branch. covers the hydra-queue-runner validation side (the substantive fix) plus the template-side HTML.attributes refactor and the existing escape-inputs touch-ups.

commit list (11 of the 12 in the upstream merge `dea1e168f5`):
- hydra-queue-runner: Fix crash when < > are in hydra-build-products
- hydra-queue-runner: Fix potential UB
- hydra-queue-runner: Verify product names in hydra-build-products
- hydra-queue-runner: Validate release name
- hydra-queue-runner: Validate metric name in hydra-metrics
- hydra-queue-runner: Validate hydra-metrics unit
- hydra-queue-runner: Validate metric type
- product-list: Escape untrusted values
- build: Properly escape all input values
- templates: Use HTML.attributes for all links
- templates: Make whitespace in [% %] consistent

omitted from upstream (1 of 12): `c6424f37 templates: Hopefully escape all template inputs` — it conflicts structurally on nix-2.28's machine-status.tt (introduces `primarySystemType` + a popover that depends on a data-model field not present here). the queue-runner validation already rejects the dangerous inputs at the source, so the template-side wrap is defense-in-depth; happy to do a separate PR for it after the data-model bits land.

two small manual resolutions during the cherry-pick:
- src/root/jobset-eval.tt: preserved the existing `[% ELSE %] ... couldn't find ...` block that was added on nix-2.28 after the patch's base, and applied the `HTML.attributes(href => ...)` wrapping around the link inside it.
- src/root/log.tt: kept the existing `the build log of derivation <tt>...</tt>` line (nix-2.28 doesn't carry the extra `(<a ...>raw</a>)` link that the patch adds; the fix's purpose is escaping existing constructs, and nix-2.28 doesn't have that construct yet, so wrapping was a no-op).

verified the queue-runner-side validation A/B as a standalone harness on top of ubuntu:22.04 + g++: the build-result.cc regex whitelists do reject `<script>...`, `<img onerror=...`, `<svg onload=...` style payloads in releaseName / product.name / metric.name / metric.unit fields pre-vs-post, matching the upstream behaviour.

refs:
- GHSA-7qwg-q53v-vh99
- CVE-2025-54800
- upstream merge: https://github.com/NixOS/hydra/commit/dea1e168f5

happy to rebase / split / drop commits if you'd rather take a narrower subset.