### PR TITLE
Remove instances of to_string_lossy

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -22,6 +22,8 @@ disallowed-methods = [
     { path = "std::fs::File::create_new", replacement = "fs_err::File::create_new" },
     { path = "std::fs::OpenOptions::new", replacement = "fs_err::OpenOptions::new" },
 
+    { path = "std::ffi::OsStr::to_string_lossy", reason = "Handle UTF-8 errors" },
+
     { path = "std::os::unix::fs::symlink", replacement = "fs_err::os::unix::symlink" },
 
     { path = "std::path::Path::try_exists", reason = "Use fs_err::path::PathExt methods" },
@@ -30,6 +32,7 @@ disallowed-methods = [
     { path = "std::path::Path::canonicalize", reason = "Use fs_err::path::PathExt methods" },
     { path = "std::path::Path::read_link", reason = "Use fs_err::path::PathExt methods" },
     { path = "std::path::Path::read_dir", reason = "Use fs_err::path::PathExt methods" },
+    { path = "std::path::Path::to_string_lossy", reason = "Handle UTF-8 errors" },
 
     { path = "tokio::fs::canonicalize", replacement = "fs_err::tokio::canonicalize" },
     { path = "tokio::fs::copy", replacement = "fs_err::tokio::copy" },

--- a/subprojects/crates/binary-cache/src/debug_info.rs
+++ b/subprojects/crates/binary-cache/src/debug_info.rs
@@ -83,12 +83,13 @@ async fn find_debug_files(
         .map_err(CacheError::Io)?;
 
     while let Some(entry) = entries.next_entry().await.map_err(CacheError::Io)? {
-        let s1 = entry.file_name();
-        let s1_str = s1.to_string_lossy();
+        let Ok(s1) = entry.file_name().into_string() else {
+            continue;
+        };
 
         // Check if it's a 2-character hex directory
-        if s1_str.len() != 2
-            || !s1_str.chars().all(|c| c.is_ascii_hexdigit())
+        if s1.len() != 2
+            || !s1.chars().all(|c| c.is_ascii_hexdigit())
             || !entry.file_type().await.map_err(CacheError::Io)?.is_dir()
         {
             continue;
@@ -100,17 +101,18 @@ async fn find_debug_files(
             .map_err(CacheError::Io)?;
 
         while let Some(sub_entry) = subdir_entries.next_entry().await.map_err(CacheError::Io)? {
-            let s2 = sub_entry.file_name();
-            let s2_str = s2.to_string_lossy();
+            let Ok(s2) = sub_entry.file_name().into_string() else {
+                continue;
+            };
 
             // Check if it's a 38-character hex file ending with .debug
-            if s2_str.len() == 44 // 38 chars + .debug (6 chars) = 44
-                    && s2_str.ends_with(".debug")
-                    && s2_str[..38].chars().all(|c| c.is_ascii_hexdigit())
+            if s2.len() == 44 // 38 chars + .debug (6 chars) = 44
+                    && s2.ends_with(".debug")
+                    && s2[..38].chars().all(|c| c.is_ascii_hexdigit())
                     && sub_entry.file_type().await.map_err(CacheError::Io)?.is_file()
             {
-                let build_id = format!("{s1_str}{}", &s2_str[..38]);
-                let debug_path = format!("lib/debug/.build-id/{s1_str}/{s2_str}");
+                let build_id = format!("{s1}{}", &s2[..38]);
+                let debug_path = format!("lib/debug/.build-id/{s1}/{s2}");
                 debug_files.push((build_id, debug_path));
             }
         }

--- a/subprojects/crates/binary-cache/src/debug_info.rs
+++ b/subprojects/crates/binary-cache/src/debug_info.rs
@@ -73,6 +73,7 @@ pub async fn get_debug_info_build_ids(
 }
 
 /// Finds debug files by scanning the build-id directory structure.
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
 async fn find_debug_files(
     build_id_path: &std::path::Path,
 ) -> Result<Vec<(String, String)>, CacheError> {

--- a/subprojects/hydra-queue-runner/src/state/build.rs
+++ b/subprojects/hydra-queue-runner/src/state/build.rs
@@ -189,7 +189,7 @@ pub struct RemoteBuild {
     stop_time: Option<jiff::Timestamp>,
 
     overhead: i32,
-    pub log_file: String,
+    pub log_file: std::path::PathBuf,
 }
 
 impl Default for RemoteBuild {
@@ -212,7 +212,7 @@ impl RemoteBuild {
             start_time: None,
             stop_time: None,
             overhead: 0,
-            log_file: String::new(),
+            log_file: std::path::PathBuf::new(),
         }
     }
 

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -342,8 +342,6 @@ impl State {
 
         self.construct_log_file_path(drv)
             .await?
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("failed to construct log path string."))?
             .clone_into(&mut job.result.log_file);
         let mut db = self.db.get().await?;
         let step_nr = {
@@ -2053,11 +2051,7 @@ impl State {
                     let missing_paths: Vec<StorePath> =
                         missing.values().filter_map(Clone::clone).collect();
                     self.uploader
-                        .schedule_upload(
-                            missing_paths,
-                            format!("log/{drv_path}"),
-                            log_file.to_string_lossy().to_string(),
-                        )
+                        .schedule_upload(missing_paths, format!("log/{drv_path}"), log_file)
                         .await;
                     missing.clear();
                 }

--- a/subprojects/hydra-queue-runner/src/state/uploader.rs
+++ b/subprojects/hydra-queue-runner/src/state/uploader.rs
@@ -17,7 +17,7 @@ struct Message {
     id: uuid::Uuid,
     store_paths: std::sync::Arc<Vec<StorePath>>,
     log_remote_path: std::sync::Arc<String>,
-    log_local_path: std::sync::Arc<String>,
+    log_local_path: std::sync::Arc<std::path::PathBuf>,
 }
 
 #[derive(Debug)]
@@ -80,7 +80,7 @@ impl Uploader {
         &self,
         store_paths: Vec<StorePath>,
         log_remote_path: String,
-        log_local_path: String,
+        log_local_path: std::path::PathBuf,
     ) {
         tracing::info!("Scheduling new path upload: {:?}", store_paths);
         self.queue.send(Message {
@@ -124,7 +124,7 @@ impl Uploader {
 
             // Upload log file with backon retry
             let log_upload_result = (|| async {
-                let file = fs_err::tokio::File::open(msg.log_local_path.as_str()).await?;
+                let file = fs_err::tokio::File::open(msg.log_local_path.as_path()).await?;
                 let reader = Box::new(tokio::io::BufReader::new(file));
 
                 remote_store

--- a/subprojects/hydra-queue-runner/src/utils.rs
+++ b/subprojects/hydra-queue-runner/src/utils.rs
@@ -1,5 +1,6 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, os::unix::ffi::OsStrExt as _};
 
+use anyhow::Context as _;
 use db::models::BuildID;
 use harmonia_store_derivation::derived_path::OutputName;
 use harmonia_store_path::StorePath;
@@ -41,11 +42,15 @@ pub async fn finish_build_step(
         is_non_deterministic: res.get_is_non_deterministic(),
     })
     .await?;
-    debug_assert!(!res.log_file.is_empty());
-    debug_assert!(!res.log_file.contains('\t'));
+    debug_assert!(!res.log_file.as_os_str().is_empty());
+    debug_assert!(!res.log_file.as_os_str().as_bytes().contains(&b'\t'));
 
-    tx.notify_step_finished(build_id, step_nr, &res.log_file)
-        .await?;
+    tx.notify_step_finished(
+        build_id,
+        step_nr,
+        res.log_file.to_str().context("Non UTF-8 log file path")?,
+    )
+    .await?;
 
     if res.step_status == db::models::BuildStatus::Success
         && let Some(output_paths) = output_paths


### PR DESCRIPTION
The `to_string_lossy` function is rarely what one wants, as it silently replaces characters with replacements. Remove all usages by either handling utf-8 errors or replacing strings with  `PathBuf` objects, where paths should be stored.