### PR TITLE
tests: reset `SIGCHLD` before exec'ing nix-daemon

### DIFF
--- a/subprojects/hydra-tests/lib/QueueRunnerContext.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerContext.pm
@@ -6,7 +6,7 @@ use File::Path qw(make_path);
 use IO::Socket::IP;
 use IPC::Run;
 use LWP::UserAgent;
-use POSIX qw(dup2);
+use POSIX qw(dup2 SIGCHLD SIG_DFL);
 use Hydra::Config;
 use ProcessGroup;
 our @ISA = qw(Exporter);
@@ -46,6 +46,11 @@ sub start_nix_daemon {
         $harness = IPC::Run::start(
             ["nix-daemon"],
             \$in, \$out, \$err,
+            init => sub {
+                # yath inherits SIGCHLD=IGN to children, which breaks nix-daemon's bind() fork+waitpid.
+                $SIG{CHLD} = 'DEFAULT';
+                POSIX::sigaction(SIGCHLD, POSIX::SigAction->new(SIG_DFL));
+            },
         );
     }
     my $socket = $store->{nix_daemon_socket_path};


### PR DESCRIPTION
yath sets `SIGCHLD=IGN`, which the spawned nix-daemon inherits, and its
fork+bind workaround for long socket paths then dies on waitpid (ECHILD).
This commit resets to the default in the `IPC::Run` init callback.