### PR TITLE
binary-cache: accept more debug ids

### DIFF
--- a/subprojects/crates/binary-cache/src/debug_info.rs
+++ b/subprojects/crates/binary-cache/src/debug_info.rs
@@ -83,39 +83,98 @@ async fn find_debug_files(
         .await
         .map_err(CacheError::Io)?;
 
+    // Debuginfo is always stored in a directory called {aa}/{bb...}.debug,
+    // where {aa} and {bb...} are hexadecimal.
+    // gdb and elfutils assume that the hexadecimal and "debug" are lowercase.
+    // The concatenation of {aa} and {bb...} represent the ID in the ELF's
+    // `.note.gnu.build-id` section, and must be a whole number of bytes.
+    // GNU ld, gold, mold, and lld are capable of using a user-specified ID or
+    // an automatically-generated ID of 8, 16, or 20 bytes.
+    // elfutils assumes all build IDs are 3–64 bytes (inclusive),
+
+    // The elfutils and gdb assumptions are reasonable, so we can limit ourselves
+    // to 3–64 bytes worth of lowercase hexadecimal followed by a lowercase ".debug"
+
     while let Some(entry) = entries.next_entry().await.map_err(CacheError::Io)? {
-        let Ok(s1) = entry.file_name().into_string() else {
+        let Ok(outer_name) = entry.file_name().into_string() else {
+            tracing::warn!(
+                "Skipping build-id entry with a non-UTF-8 name: {}",
+                entry.path().display()
+            );
             continue;
         };
 
         // Check if it's a 2-character hex directory
-        if s1.len() != 2
-            || !s1.chars().all(|c| c.is_ascii_hexdigit())
+        if outer_name.len() != 2
+            || !outer_name
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
             || !entry.file_type().await.map_err(CacheError::Io)?.is_dir()
         {
+            tracing::debug!(
+                "Skipping unexpected entry in .build-id: {}",
+                entry.path().display()
+            );
             continue;
         }
 
-        let subdir_path = build_id_path.join(&s1);
+        let subdir_path = build_id_path.join(&outer_name);
         let mut subdir_entries = fs_err::tokio::read_dir(&subdir_path)
             .await
             .map_err(CacheError::Io)?;
 
         while let Some(sub_entry) = subdir_entries.next_entry().await.map_err(CacheError::Io)? {
-            let Ok(s2) = sub_entry.file_name().into_string() else {
+            let sub_path = sub_entry.path();
+            if sub_path.extension() != Some("debug".as_ref()) {
+                tracing::debug!("Skipping non-debug file: {}", sub_path.display());
+                continue;
+            }
+
+            // `file_stem` only fails to produce a `&str` for a non-UTF-8 name,
+            // which a real build ID should never have.
+            let Some(sub_name) = sub_path.file_stem().and_then(|name| name.to_str()) else {
+                tracing::warn!(
+                    "Skipping debug file with a non-UTF-8 name: {}",
+                    sub_path.display()
+                );
                 continue;
             };
 
-            // Check if it's a 38-character hex file ending with .debug
-            if s2.len() == 44 // 38 chars + .debug (6 chars) = 44
-                    && s2.ends_with(".debug")
-                    && s2[..38].chars().all(|c| c.is_ascii_hexdigit())
-                    && sub_entry.file_type().await.map_err(CacheError::Io)?.is_file()
-            {
-                let build_id = format!("{s1}{}", &s2[..38]);
-                let debug_path = format!("lib/debug/.build-id/{s1}/{s2}");
-                debug_files.push((build_id, debug_path));
+            // The build ID format is `{outer_name}{sub_name}` in hex, and takes two chars per byte.
+            let build_id_hex_chars = outer_name.len() + sub_name.len();
+            let build_id_bytes = build_id_hex_chars / 2;
+            if !(3..=64).contains(&build_id_bytes) {
+                tracing::debug!(
+                    "Skipping debug file with a build ID of {build_id_bytes} bytes, expected 3-64: {}",
+                    sub_path.display()
+                );
+                continue;
             }
+
+            if !sub_name
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+            {
+                tracing::debug!(
+                    "Skipping debug file with a non-hexadecimal build ID: {}",
+                    sub_path.display()
+                );
+                continue;
+            }
+
+            if !sub_entry
+                .file_type()
+                .await
+                .map_err(CacheError::Io)?
+                .is_file()
+            {
+                tracing::debug!("Skipping non-file debug entry: {}", sub_path.display());
+                continue;
+            }
+
+            let build_id = format!("{outer_name}{sub_name}");
+            let debug_path = format!("lib/debug/.build-id/{outer_name}/{sub_name}.debug");
+            debug_files.push((build_id, debug_path));
         }
     }
 
@@ -295,15 +354,6 @@ mod tests {
         fs_err::tokio::write(&valid_dir.join("invalid.txt"), "content")
             .await
             .unwrap();
-        fs_err::tokio::write(&valid_dir.join("cdef.debug"), "content")
-            .await
-            .unwrap();
-        fs_err::tokio::write(
-            &valid_dir.join("cdef12345678901234567890123456789012345.debug"),
-            "content",
-        )
-        .await
-        .unwrap();
         fs_err::tokio::write(
             &valid_dir.join("cdef1234567890123456789012345678901234.txt"),
             "content",
@@ -333,7 +383,7 @@ mod tests {
         let ab_dir = build_id_dir.join("ab");
         fs_err::tokio::create_dir(&ab_dir).await.unwrap();
         fs_err::tokio::write(
-            &ab_dir.join("cdef1234567890123456789012345678901234.debug"),
+            &ab_dir.join("cdef123456789012345678901234567890123456.debug"),
             "valid debug content",
         )
         .await
@@ -365,7 +415,7 @@ mod tests {
         assert_eq!(debug_files.len(), 2);
 
         let build_ids: Vec<String> = debug_files.iter().map(|(id, _)| id.clone()).collect();
-        assert!(build_ids.contains(&"abcdef1234567890123456789012345678901234".to_string()));
+        assert!(build_ids.contains(&"abcdef123456789012345678901234567890123456".to_string()));
         assert!(build_ids.contains(&"cdef567890123456789012345678901234567890".to_string()));
 
         fs_err::tokio::remove_dir_all(&build_id_dir).await.unwrap();


### PR DESCRIPTION
Although 20-byte debug IDs are the most common, a number of lengths are valid.
Instead of ignoring all non-20-byte debug IDs, accept all names that would be used by elfutils (of libelf fame)