### PR TITLE
flake: bump nixpkgs to release-25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,16 +53,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779207331,
-        "narHash": "sha256-+XybZTVZuwYxaqH1os8B8r259q9Av000UDeyudtq9rQ=",
+        "lastModified": 1780067536,
+        "narHash": "sha256-vhO7zdMAD1q7JTuixT6R9dJvUP/FU5+SDhY9/vM3aZk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f58ee5f04eb76292db7ad4b36bd5e30bc8a702c9",
+        "rev": "4a9dbd0960bcbb7196a8f85673afb8b2a0d07a27",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11-small",
+        "ref": "release-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,9 @@
 {
   description = "A Nix-based continuous build system";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11-small";
+  # Temporarily using release-25.11 as it fixes the current CI failures where we're being blocked by
+  # crates.io from fetching dependencies. Once Hydra's caught up we can revert this.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
 
   inputs.nix = {
     url = "github:NixOS/nix/2.34-maintenance";


### PR DESCRIPTION
This fixes the current CI failures where we're being blocked by crates.io from fetching dependencies.

For reference, bumping to release-25.11 gets us https://github.com/NixOS/nixpkgs/pull/524985, which fixes this.