### PR TITLE
binary-cache: remove String::from_utf8_lossy

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -24,6 +24,8 @@ disallowed-methods = [
 
     { path = "std::ffi::OsStr::to_string_lossy", reason = "Handle UTF-8 errors" },
 
+    { path = "std::string::String::from_utf8_lossy", reason = "Handle UTF-8 errors" },
+
     { path = "std::os::unix::fs::symlink", replacement = "fs_err::os::unix::symlink" },
 
     { path = "std::path::Path::try_exists", reason = "Use fs_err::path::PathExt methods" },

--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -43,7 +43,7 @@ pub use crate::debug_info::get_debug_info_build_ids;
 use crate::narinfo::NarInfoError;
 pub use crate::narinfo::{
     NarInfo, clear_sigs_and_sign, format_narinfo_txt, get_ls_path, narinfo_from_path_info,
-    narinfo_simple, parse_hash, parse_nar_hash, parse_narinfo, render_narinfo,
+    narinfo_simple, parse_hash, parse_nar_hash, parse_narinfo,
 };
 pub use crate::presigned::{
     PresignedUpload, PresignedUploadClient, PresignedUploadMetrics, PresignedUploadResponse,
@@ -345,13 +345,13 @@ impl S3BinaryCacheClient {
     }
 
     #[tracing::instrument(skip(self, content, content_type), err)]
-    pub async fn upsert_file(
+    pub async fn upsert_file<T: Into<Bytes>>(
         &self,
         name: &str,
-        content: String,
+        content: T,
         content_type: &str,
     ) -> Result<(), CacheError> {
-        let stream = Box::new(std::io::Cursor::new(Bytes::from(content)));
+        let stream = Box::new(std::io::Cursor::new(content.into()));
         self.upsert_file_stream(name, stream, content_type).await
     }
 
@@ -537,7 +537,7 @@ impl S3BinaryCacheClient {
         let info_key = format!("{base}.narinfo");
         self.upsert_file(
             &info_key,
-            render_narinfo(store_dir, &narinfo),
+            format_narinfo_txt(store_dir, &narinfo),
             "text/x-nix-narinfo",
         )
         .await?;
@@ -709,7 +709,7 @@ impl S3BinaryCacheClient {
             .await?
         {
             Some(v) => {
-                let narinfo = parse_narinfo(&String::from_utf8_lossy(&v))?;
+                let narinfo = parse_narinfo(&v)?;
                 self.narinfo_cache
                     .insert(store_path.to_owned(), narinfo.clone())
                     .await;
@@ -733,11 +733,8 @@ impl S3BinaryCacheClient {
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn download_realisation(&self, id: &DrvOutput) -> Result<Option<String>, CacheError> {
-        (self.get_object(&format!("realisations/{id}.doi")).await?).map_or_else(
-            || Ok(None),
-            |v| Ok(Some(String::from_utf8_lossy(&v).to_string())),
-        )
+    pub async fn download_realisation(&self, id: &DrvOutput) -> Result<Option<Bytes>, CacheError> {
+        self.get_object(&format!("realisations/{id}.doi")).await
     }
 
     #[tracing::instrument(skip(self), err)]

--- a/subprojects/crates/binary-cache/src/narinfo.rs
+++ b/subprojects/crates/binary-cache/src/narinfo.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use harmonia_store_nar_info::{UnkeyedNarInfo, format_narinfo_txt as harmonia_format_narinfo_txt};
+use harmonia_store_nar_info::UnkeyedNarInfo;
 use harmonia_store_path::{ParseStorePathError, StoreDir, StorePath};
 use harmonia_store_path_info::fingerprint_path;
 use harmonia_store_path_info::{NarHash, UnkeyedValidPathInfo};
@@ -123,12 +123,6 @@ pub fn get_ls_path(narinfo: &NarInfo) -> String {
     format!("{}.ls", narinfo.path.hash())
 }
 
-/// Render the narinfo as a text string (for upload).
-#[must_use]
-pub fn render_narinfo(store_dir: &StoreDir, narinfo: &NarInfo) -> String {
-    String::from_utf8_lossy(&harmonia_format_narinfo_txt(store_dir, narinfo)).into_owned()
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum NarInfoError {
     #[error("missing required field: {0}")]
@@ -144,6 +138,8 @@ pub enum NarInfoError {
     },
     #[error("store path parse error: {0}")]
     StorePath(#[from] ParseStorePathError),
+    #[error("narinfo was not valid utf-8")]
+    FromUtf8(#[from] std::str::Utf8Error),
 }
 
 /// Parse a narinfo text into a [`NarInfo`].
@@ -151,9 +147,11 @@ pub enum NarInfoError {
 /// `FromStr` cannot be implemented directly on the re-exported type due to
 /// Rust's orphan rules, so this free function is provided instead.
 // TODO: harmonia should grow its own narinfo parser so we can use that instead
-#[tracing::instrument(skip(input), err)]
+#[tracing::instrument(skip(raw), err)]
 #[allow(clippy::too_many_lines)]
-pub fn parse_narinfo(input: &str) -> Result<NarInfo, NarInfoError> {
+pub fn parse_narinfo(raw: &[u8]) -> Result<NarInfo, NarInfoError> {
+    let input = str::from_utf8(raw)?;
+
     let mut store_path_opt: Option<StorePath> = None;
     let mut url_opt: Option<String> = None;
     let mut compression_opt: Option<String> = None;


### PR DESCRIPTION
from_utf8_lossy is rarely what one wants, as it silently discards errors and can cause corruption when going from raw bytes to string and back.

In #1766 I removed `to_string_lossy` but I forgot about from_utf8_lossy.