### PR TITLE
flake: bump nixpkgs to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,18 +53,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780067536,
-        "narHash": "sha256-vhO7zdMAD1q7JTuixT6R9dJvUP/FU5+SDhY9/vM3aZk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4a9dbd0960bcbb7196a8f85673afb8b2a0d07a27",
-        "type": "github"
+        "lastModified": 1780453794,
+        "narHash": "sha256-hhAl/iKiurXPn7rdzDgiSuRB8tqOB6f0buWkh8Y9mkY=",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.1183.6b316287bae2/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "release-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,7 @@
 {
   description = "A Nix-based continuous build system";
 
-  # Temporarily using release-25.11 as it fixes the current CI failures where we're being blocked by
-  # crates.io from fetching dependencies. Once Hydra's caught up we can revert this.
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
 
   inputs.nix = {
     url = "github:NixOS/nix/2.34-maintenance";


### PR DESCRIPTION
the release-25.11 changes from earlier are in 26.05, so it's possible to use the standard nixos channel.

Use nixexprs.tar.xz because it's slightly more efficient aiui