### PR TITLE
hydra-tests: pump nix daemon logs via `ProcessGroup`

### DIFF
--- a/subprojects/hydra-tests/lib/NixDaemon.pm
+++ b/subprojects/hydra-tests/lib/NixDaemon.pm
@@ -1,0 +1,32 @@
+use warnings;
+use strict;
+
+package NixDaemon;
+use File::Path qw(make_path);
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(start_nix_daemon);
+
+# Start a nix daemon for the given store config and register it in a
+# ProcessGroup so its logs are pumped alongside the other processes.
+sub start_nix_daemon {
+    my ($store, $pg, $label) = @_;
+    make_path($store->{nix_state_dir});
+
+    my $harness = $pg->spawn($label, ["nix-daemon"], env => {
+        NIX_REMOTE              => $store->{nix_store_uri},
+        NIX_STORE_DIR           => $store->{nix_store_dir},
+        NIX_STATE_DIR           => $store->{nix_state_dir},
+        NIX_CONF_DIR            => $store->{nix_conf_dir},
+        NIX_DAEMON_SOCKET_PATH  => $store->{nix_daemon_socket_path},
+        NIX_CONFIG              => "trusted-users = *",
+    });
+    my $socket = $store->{nix_daemon_socket_path};
+    for (1..50) {
+        last if -S $socket;
+        select(undef, undef, undef, 0.1);
+    }
+    -S $socket or die "nix-daemon did not start: $socket\n";
+    return $harness;
+}
+
+1;

--- a/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerBuildOne.pm
@@ -5,6 +5,7 @@ package QueueRunnerBuildOne;
 use JSON::PP;
 use LWP::UserAgent;
 use HTTP::Request;
+use NixDaemon qw(start_nix_daemon);
 use ProcessGroup;
 use QueueRunnerContext;
 our @ISA = qw(Exporter);
@@ -18,9 +19,9 @@ sub runBuilds {
     ref $ctx eq 'HydraTestContext' or die "runBuilds requires a HydraTestContext as first argument\n";
     my @build_ids = map { $_->id } @builds;
 
-    my ($pg, $base_url, $grpc_addr, $qr_daemon) = start_queue_runner($ctx);
+    my ($pg, $base_url, $grpc_addr) = start_queue_runner($ctx);
 
-    my $bl_daemon = QueueRunnerContext::start_nix_daemon($ctx->{builder});
+    start_nix_daemon($ctx->{builder}, $pg, "builder daemon");
 
     $pg->spawn("builder",
         ["hydra-builder", "--gateway-endpoint", "http://$grpc_addr"],
@@ -66,8 +67,6 @@ sub runBuilds {
     alarm 0;
 
     $pg->stop;
-    $bl_daemon->kill_kill(grace => 2);
-    $qr_daemon->kill_kill(grace => 2);
 
     if (!$ok) {
         print STDERR "runBuilds failed: $err" if $err;

--- a/subprojects/hydra-tests/lib/QueueRunnerContext.pm
+++ b/subprojects/hydra-tests/lib/QueueRunnerContext.pm
@@ -2,12 +2,12 @@ use warnings;
 use strict;
 
 package QueueRunnerContext;
-use File::Path qw(make_path);
 use IO::Socket::IP;
 use IPC::Run;
 use LWP::UserAgent;
 use POSIX qw(dup2);
 use Hydra::Config;
+use NixDaemon qw(start_nix_daemon);
 use ProcessGroup;
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
@@ -28,47 +28,21 @@ sub wait_for_url {
     return 0;
 }
 
-# Start a nix daemon for the given store config.
-# Returns the daemon harness.  Caller must kill_kill it when done.
-sub start_nix_daemon {
-    my ($store) = @_;
-    make_path($store->{nix_state_dir});
-
-    my ($in, $out, $err) = ("", "", "");
-    my $harness;
-    {
-        local $ENV{NIX_REMOTE} = $store->{nix_store_uri};
-        local $ENV{NIX_STORE_DIR} = $store->{nix_store_dir};
-        local $ENV{NIX_STATE_DIR} = $store->{nix_state_dir};
-        local $ENV{NIX_CONF_DIR} = $store->{nix_conf_dir};
-        local $ENV{NIX_DAEMON_SOCKET_PATH} = $store->{nix_daemon_socket_path};
-        local $ENV{NIX_CONFIG} = "trusted-users = *";
-        $harness = IPC::Run::start(
-            ["nix-daemon"],
-            \$in, \$out, \$err,
-        );
-    }
-    my $socket = $store->{nix_daemon_socket_path};
-    for (1..50) {
-        last if -S $socket;
-        select(undef, undef, undef, 0.1);
-    }
-    -S $socket or die "nix-daemon did not start: $socket\n";
-    return $harness;
-}
 
 # Start a queue runner process using systemd socket activation.
 # We bind TCP sockets ourselves (port 0 for OS-assigned ports), then
 # pass them to the queue runner via LISTEN_FDS/LISTEN_FDNAMES.
-# Returns ($process_group, $rest_url, $grpc_addr, $daemon_harness).
-# The ProcessGroup has the queue-runner registered as "queue-runner".
-# Caller is responsible for calling $pg->stop and $daemon_harness->kill_kill when done.
+# Returns ($process_group, $rest_url, $grpc_addr).
+# The ProcessGroup has the nix daemon and queue-runner registered.
+# Caller is responsible for calling $pg->stop when done.
 sub start_queue_runner {
     my ($ctx, %opts) = @_;
     ref $ctx eq 'HydraTestContext' or die "start_queue_runner requires a HydraTestContext\n";
 
+    my $pg = ProcessGroup->new;
+
     # Start a nix daemon for the queue runner to use.
-    my $daemon_harness = start_nix_daemon($ctx->{central});
+    start_nix_daemon($ctx->{central}, $pg, "queue-runner daemon");
 
     my $config_dir = $ENV{T2_HARNESS_TEMP_DIR}
         // $ctx->{central}{hydra_data};
@@ -159,13 +133,12 @@ sub start_queue_runner {
     my $rest_url = "http://[::1]:$rest_port";
     my $grpc_addr = "[::1]:$grpc_port";
 
-    my $pg = ProcessGroup->new;
     $pg->{procs}{"queue-runner"} = {
         label => "queue-runner", harness => $qr_harness, out => \$qr_out, err => \$qr_err,
     };
     push @{$pg->{order}}, "queue-runner";
 
-    return ($pg, $rest_url, $grpc_addr, $daemon_harness);
+    return ($pg, $rest_url, $grpc_addr);
 }
 
 # Poll the queue runner REST API until all given build IDs are no longer

--- a/subprojects/hydra-tests/scripts/hydra-send-stats.t
+++ b/subprojects/hydra-tests/scripts/hydra-send-stats.t
@@ -22,7 +22,7 @@ subtest "without queue_runner_endpoint" => sub {
 };
 
 subtest "with queue_runner_endpoint" => sub {
-    my ($pg, $base_url, undef, $daemon_harness) = start_queue_runner($ctx{context});
+    my ($pg, $base_url) = start_queue_runner($ctx{context});
 
     my $ok = eval {
         local $SIG{ALRM} = sub { die "timeout\n" };
@@ -55,7 +55,6 @@ subtest "with queue_runner_endpoint" => sub {
     alarm 0;
 
     $pg->stop;
-    $daemon_harness->kill_kill;
 
     die "with queue_runner_endpoint failed: $err" if !$ok && $err;
 };


### PR DESCRIPTION
The nix daemons (one for the queue-runner, one for the builder) were started with bare `IPC::Run` harnesses whose stdout/stderr were never flushed to test output. When a daemon misbehaved (e.g. connection reset), there was no log to diagnose it.

To fix this have `start_nix_daemon` register the daemon in the caller's `ProcessGroup`. The `ProcessGroup` machinery we made is exactly for this purpose, and we should have had this function use it.

In particular, now that it is part of the process group, `pump_logs` will pick it up. Also, there is no need for the separate `$daemon_harness` return value from `start_queue_runner` — callers no longer need to manually `kill_kill` daemon harnesses since `$pg->stop` handles everything — so that return value is removed too.

Finally, factor out the newly improved `start_nix_daemon` into its own module, since it should not be more strongly associated with either the queue-runner or the daemon.

The queue-runner daemon is labelled `queue-runner daemon` and the builder daemon `builder daemon`, making it easy to tell them apart in test output.

Hopefully this helps us debug the spurious issues we're seeing.