### PR TITLE
chore: cleanup clippy lints

### DIFF
--- a/subprojects/hydra-queue-runner/src/config.rs
+++ b/subprojects/hydra-queue-runner/src/config.rs
@@ -330,16 +330,13 @@ impl TryFrom<AppConfig> for PreparedApp {
             std::env::var("LOGNAME").map_err(|_| ConfigError::MissingEnvVar("LOGNAME"))?;
         let nix_remote =
             daemon_client_utils::parse_nix_remote().map_err(ConfigError::ParseNixStore)?;
-        let roots_dir = val.roots_dir.map_or_else(
-            || {
-                nix_remote
-                    .state_dir
-                    .join("gcroots/per-user")
-                    .join(logname)
-                    .join("hydra-roots")
-            },
-            |roots_dir| roots_dir,
-        );
+        let roots_dir = val.roots_dir.unwrap_or_else(|| {
+            nix_remote
+                .state_dir
+                .join("gcroots/per-user")
+                .join(logname)
+                .join("hydra-roots")
+        });
         fs_err::create_dir_all(&roots_dir)?;
 
         let hydra_log_dir = val.hydra_data_dir.join("build-logs");

--- a/subprojects/hydra-queue-runner/src/io/machine.rs
+++ b/subprojects/hydra-queue-runner/src/io/machine.rs
@@ -85,16 +85,18 @@ impl MachineStats {
             avg_step_import_time_ms,
             avg_step_build_time_ms,
             avg_step_upload_time_ms,
-        ) = if nr_steps_done > 0 {
-            (
-                total_step_time_ms / nr_steps_done,
-                total_step_import_time_ms / nr_steps_done,
-                total_step_build_time_ms / nr_steps_done,
-                total_step_upload_time_ms / nr_steps_done,
-            )
-        } else {
-            (0, 0, 0, 0)
-        };
+        ) = (
+            total_step_time_ms.checked_div(nr_steps_done).unwrap_or(0),
+            total_step_import_time_ms
+                .checked_div(nr_steps_done)
+                .unwrap_or(0),
+            total_step_build_time_ms
+                .checked_div(nr_steps_done)
+                .unwrap_or(0),
+            total_step_upload_time_ms
+                .checked_div(nr_steps_done)
+                .unwrap_or(0),
+        );
 
         Self {
             current_jobs: item.get_current_jobs(),

--- a/subprojects/hydra-queue-runner/src/state/fod_checker.rs
+++ b/subprojects/hydra-queue-runner/src/state/fod_checker.rs
@@ -156,7 +156,7 @@ impl FodChecker {
         loop {
             tokio::select! {
                 () = self.notify_traverse.notified() => {},
-                () = tokio::time::sleep(tokio::time::Duration::from_secs(60)) => {},
+                () = tokio::time::sleep(tokio::time::Duration::from_mins(1)) => {},
             };
             self.traverse(&self.pool).await;
             if let Some(tx) = &self.traverse_done_notifier {

--- a/subprojects/hydra-queue-runner/src/state/jobset.rs
+++ b/subprojects/hydra-queue-runner/src/state/jobset.rs
@@ -98,10 +98,7 @@ impl Jobset {
         let now = jiff::Timestamp::now().as_second();
         let mut steps = self.steps.write();
 
-        loop {
-            let Some(first) = steps.first_entry() else {
-                break;
-            };
+        while let Some(first) = steps.first_entry() {
             let start_time = *first.key();
 
             if start_time > now - SCHEDULING_WINDOW {

--- a/subprojects/hydra-queue-runner/src/state/metrics.rs
+++ b/subprojects/hydra-queue-runner/src/state/metrics.rs
@@ -850,12 +850,23 @@ impl PromMetrics {
 
     pub async fn refresh_dynamic_metrics(&self, state: &Arc<super::State>) {
         let nr_steps_done = self.nr_steps_done.get();
-        if nr_steps_done > 0 {
-            let avg_time = self.total_step_time_ms.get() / nr_steps_done;
-            let avg_import_time = self.total_step_import_time_ms.get() / nr_steps_done;
-            let avg_build_time = self.total_step_build_time_ms.get() / nr_steps_done;
-            let avg_upload_time = self.total_step_upload_time_ms.get() / nr_steps_done;
-
+        if let (
+            Some(avg_time),
+            Some(avg_import_time),
+            Some(avg_build_time),
+            Some(avg_upload_time),
+        ) = (
+            self.total_step_time_ms.get().checked_div(nr_steps_done),
+            self.total_step_import_time_ms
+                .get()
+                .checked_div(nr_steps_done),
+            self.total_step_build_time_ms
+                .get()
+                .checked_div(nr_steps_done),
+            self.total_step_upload_time_ms
+                .get()
+                .checked_div(nr_steps_done),
+        ) {
             if let Ok(v) = i64::try_from(avg_time) {
                 self.avg_step_time_ms.set(v);
             }

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -2587,10 +2587,7 @@ impl State {
 
         conn.check_if_paths_failed(
             self.pool.store_dir(),
-            &drv_outputs
-                .iter()
-                .filter_map(|(_, path)| path.clone())
-                .collect::<Vec<_>>(),
+            &drv_outputs.values().flatten().cloned().collect::<Vec<_>>(),
         )
         .await
         .unwrap_or_default()

--- a/subprojects/hydra-queue-runner/src/state/step.rs
+++ b/subprojects/hydra-queue-runner/src/state/step.rs
@@ -580,14 +580,11 @@ impl Steps {
         let mut is_new = false;
         let mut steps = self.inner.write();
         let step = if let Some(step) = steps.get(drv_path) {
-            step.upgrade().map_or_else(
-                || {
-                    steps.remove(drv_path);
-                    is_new = true;
-                    Step::new(drv_path.to_owned())
-                },
-                |step| step,
-            )
+            step.upgrade().unwrap_or_else(|| {
+                steps.remove(drv_path);
+                is_new = true;
+                Step::new(drv_path.to_owned())
+            })
         } else {
             is_new = true;
             Step::new(drv_path.to_owned())

--- a/subprojects/hydra-queue-runner/src/state/uploader.rs
+++ b/subprojects/hydra-queue-runner/src/state/uploader.rs
@@ -196,7 +196,7 @@ impl Uploader {
         })
         .retry(
             ExponentialBuilder::default()
-                .with_max_delay(std::time::Duration::from_secs(60))
+                .with_max_delay(std::time::Duration::from_mins(1))
                 .with_max_times(5),
         )
         .await?;


### PR DESCRIPTION
Fixes the queue-runner clippy errors that appear with rust 1.95 (`map_or_else` with identity, manual checked division, `Duration` unit constructors, `while let` loop, `iter_kv_map`). No behavior change.