### PR TITLE
binary-cache: read narinfos with harmonia's parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "harmonia-file-core"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1369,7 +1369,7 @@ dependencies = [
 [[package]]
 name = "harmonia-file-nar"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "bstr",
  "bytes",
@@ -1393,7 +1393,7 @@ dependencies = [
 [[package]]
 name = "harmonia-protocol"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "async-stream",
  "bstr",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "harmonia-protocol-derive"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1437,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "bytes",
  "harmonia-store-content-address",
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-build-result"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "harmonia-store-derivation",
  "num_enum",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-content-address"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "derive_more",
  "harmonia-store-path",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-derivation"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-nar-info"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-path",
@@ -1503,12 +1503,13 @@ dependencies = [
  "harmonia-utils-hash",
  "harmonia-utils-signature",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "harmonia-store-path"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "derive_more",
  "harmonia-utils-base-encoding",
@@ -1521,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-path-info"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-path",
@@ -1533,7 +1534,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-remote"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "async-stream",
  "futures-core",
@@ -1553,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1563,13 +1564,14 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "blake3",
  "data-encoding",
  "derive_more",
  "harmonia-utils-base-encoding",
  "md5",
+ "pin-project-lite",
  "serde",
  "sha1 0.11.0",
  "sha2 0.11.0",
@@ -1580,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1593,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-signature"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#12c6742560dd1ba1e66f5cc2f04cabd4e99ae754"
+source = "git+https://github.com/nix-community/harmonia.git#fec973ce0cfb0d9575bd7a466bdac80acccf66b2"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",
@@ -3147,7 +3149,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3486,7 +3488,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5107,15 +5109,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/packaging/cargo-output-hashes.nix
+++ b/packaging/cargo-output-hashes.nix
@@ -1,5 +1,5 @@
 # Shared outputHashes for cargoLock across all Rust crates.
 # Update this file when the harmonia dependency changes.
 {
-  "harmonia-store-derivation-0.0.0-alpha.0" = "sha256-6LJOkuyWuMjENbzZCKDOjEz4qjYipTwH0qRMcwpdLSk=";
+  "harmonia-store-derivation-0.0.0-alpha.0" = "sha256-316CfR32JYa6aD8i3Xwlvgdkk0Lq6K+QzCkuitnYAXk=";
 }

--- a/subprojects/crates/binary-cache/examples/simple_presigned.rs
+++ b/subprojects/crates/binary-cache/examples/simple_presigned.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .await?;
 
                 client
-                    .upload_narinfo_after_presigned_upload(&store, narinfo)
+                    .upload_narinfo_after_presigned_upload(narinfo)
                     .await?;
                 Ok::<(), Box<dyn std::error::Error>>(())
             }

--- a/subprojects/crates/binary-cache/src/cfg.rs
+++ b/subprojects/crates/binary-cache/src/cfg.rs
@@ -1,3 +1,4 @@
+use harmonia_store_path::StoreDir;
 use hashbrown::HashMap;
 use smallvec::SmallVec;
 
@@ -10,6 +11,10 @@ const MAX_PRESIGNED_URL_EXPIRY_SECS: u64 = 24 * 60 * 60;
 #[allow(clippy::struct_excessive_bools)]
 pub struct S3CacheConfig {
     pub client_config: S3ClientConfig,
+
+    /// Store directory the cache's narinfos refer to, from the `store` query
+    /// parameter of the nix S3 URL (defaults to the standard `/nix/store`).
+    pub store_dir: StoreDir,
 
     pub compression: Compression,
     pub write_nar_listing: bool,
@@ -32,6 +37,7 @@ impl S3CacheConfig {
     pub fn new(client_config: S3ClientConfig) -> Self {
         Self {
             client_config,
+            store_dir: StoreDir::default(),
             compression: Compression::Xz,
             write_nar_listing: false,
             write_debug_info: false,
@@ -139,6 +145,14 @@ impl S3CacheConfig {
         self
     }
 
+    #[must_use]
+    pub fn with_store_dir(mut self, store_dir: Option<StoreDir>) -> Self {
+        if let Some(store_dir) = store_dir {
+            self.store_dir = store_dir;
+        }
+        self
+    }
+
     pub fn with_presigned_url_expiry(
         mut self,
         expiry_secs: Option<u64>,
@@ -173,6 +187,8 @@ pub enum UrlParseError {
     UriParseError(#[from] url::ParseError),
     #[error("Int parse error: {0}")]
     IntParseError(#[from] std::num::ParseIntError),
+    #[error("Invalid store directory: {0}")]
+    StoreDir(String),
     #[error(transparent)]
     S3Scheme(#[from] InvalidS3Scheme),
     #[error(transparent)]
@@ -211,6 +227,13 @@ impl std::str::FromStr for S3CacheConfig {
             .with_profile(query.get("profile").map(String::as_str));
 
         Self::new(cfg)
+            .with_store_dir(
+                query
+                    .get("store")
+                    .map(|x| x.parse::<StoreDir>())
+                    .transpose()
+                    .map_err(|e| UrlParseError::StoreDir(e.to_string()))?,
+            )
             .with_compression(
                 query
                     .get("compression")
@@ -447,7 +470,7 @@ mod tests {
 
     use super::{
         Compression, ConfigReadError, S3CacheConfig, S3ClientConfig, S3CredentialsConfig, S3Scheme,
-        UrlParseError, parse_aws_credentials_file,
+        StoreDir, UrlParseError, parse_aws_credentials_file,
     };
     use std::str::FromStr as _;
 
@@ -808,6 +831,17 @@ aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvb123KEY"
         assert_eq!(config.client_config.scheme, S3Scheme::HTTPS);
         assert!(config.client_config.endpoint.is_none());
         assert!(config.client_config.profile.is_none());
+    }
+
+    #[test]
+    fn test_s3_cache_config_from_str_store_dir() {
+        // Defaults to the standard store directory when `store` is absent.
+        let config = S3CacheConfig::from_str("s3://my-bucket").unwrap();
+        assert_eq!(config.store_dir, StoreDir::default());
+
+        // The `store` query param overrides it, matching nix S3 store URLs.
+        let config = S3CacheConfig::from_str("s3://my-bucket?store=/custom/store").unwrap();
+        assert_eq!(config.store_dir.to_string(), "/custom/store");
     }
 
     #[test]

--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -24,7 +24,7 @@ use object_store::{ObjectStore as _, ObjectStoreExt as _, signer::Signer as _};
 use secrecy::ExposeSecret;
 use smallvec::SmallVec;
 
-use harmonia_store_path::{StoreDir, StorePath};
+use harmonia_store_path::StorePath;
 
 // Realisation writing is now done by the caller, not via FFI query.
 
@@ -38,10 +38,9 @@ mod streaming_hash;
 pub use crate::cfg::{S3CacheConfig, S3ClientConfig, S3CredentialsConfig, S3Scheme};
 pub use crate::compression::Compression;
 pub use crate::debug_info::get_debug_info_build_ids;
-use crate::narinfo::NarInfoError;
 pub use crate::narinfo::{
     NarInfo, clear_sigs_and_sign, format_narinfo_txt, get_ls_path, narinfo_from_path_info,
-    narinfo_simple, parse_hash, parse_nar_hash, parse_narinfo,
+    narinfo_simple, parse_hash, parse_nar_hash, parse_narinfo_txt,
 };
 pub use crate::presigned::{
     PresignedUpload, PresignedUploadClient, PresignedUploadMetrics, PresignedUploadResponse,
@@ -153,8 +152,10 @@ pub enum CacheError {
     Serde(#[from] serde_json::Error),
     #[error("Signing error: {0}")]
     Signing(String),
+    #[error("narinfo was not valid utf-8")]
+    NarInfoUtf8(#[from] std::str::Utf8Error),
     #[error(transparent)]
-    NarInfoParseError(#[from] NarInfoError),
+    NarInfoParseError(#[from] harmonia_store_nar_info::NarInfoParseError),
     #[error("daemon error: {0}")]
     DaemonError(#[from] harmonia_protocol::types::DaemonError),
     #[error("cannot add '{0}' to the binary cache because the reference '{1}' is not valid")]
@@ -602,17 +603,13 @@ impl S3BinaryCacheClient {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, store_dir, narinfo), err)]
-    async fn upload_narinfo(
-        &self,
-        store_dir: &StoreDir,
-        narinfo: NarInfo,
-    ) -> Result<String, CacheError> {
+    #[tracing::instrument(skip(self, narinfo), err)]
+    async fn upload_narinfo(&self, narinfo: NarInfo) -> Result<String, CacheError> {
         let base = narinfo.path.hash().to_string();
         let info_key = format!("{base}.narinfo");
         self.upsert_file(
             &info_key,
-            format_narinfo_txt(store_dir, &narinfo),
+            format_narinfo_txt(&self.cfg.store_dir, &narinfo),
             "text/x-nix-narinfo",
         )
         .await?;
@@ -621,23 +618,21 @@ impl S3BinaryCacheClient {
 
     fn narinfo_from_valid_path_info(
         &self,
-        store_dir: &StoreDir,
         vpi: &harmonia_store_path_info::ValidPathInfo,
     ) -> NarInfo {
         narinfo_from_path_info(
             &vpi.path,
             vpi.info.clone(),
             self.cfg.compression,
-            store_dir,
+            &self.cfg.store_dir,
             &self.signing_keys,
         )
     }
 
-    #[tracing::instrument(skip(self, store, store_dir, vpi), fields(%vpi.path), err)]
+    #[tracing::instrument(skip(self, store, vpi), fields(%vpi.path), err)]
     pub async fn copy_path(
         &self,
         store: &harmonia_store_remote::ConnectionPool,
-        store_dir: &StoreDir,
         vpi: &harmonia_store_path_info::ValidPathInfo,
         repair: bool,
     ) -> Result<(), CacheError> {
@@ -646,7 +641,7 @@ impl S3BinaryCacheClient {
         }
 
         tracing::debug!("start copying path: {}", vpi.path);
-        let mut narinfo = self.narinfo_from_valid_path_info(store_dir, vpi);
+        let mut narinfo = self.narinfo_from_valid_path_info(vpi);
         if self.cfg.write_nar_listing {
             let listing = nar_listing(store, &narinfo.path).await?;
             let ls_json = serde_json::json!({
@@ -663,7 +658,7 @@ impl S3BinaryCacheClient {
         if self.cfg.write_debug_info {
             debug_info::process_debug_info(
                 &nar_url,
-                store_dir.as_ref(),
+                self.cfg.store_dir.as_ref(),
                 &narinfo.path,
                 self.clone(),
             )
@@ -699,7 +694,7 @@ impl S3BinaryCacheClient {
         // (e.g. the queue-runner after resolving and building a CA drv),
         // not here during path copy.
 
-        self.upload_narinfo(store.store_dir(), narinfo).await?;
+        self.upload_narinfo(narinfo).await?;
 
         Ok(())
     }
@@ -713,14 +708,10 @@ impl S3BinaryCacheClient {
     ) -> Result<(), CacheError> {
         use futures::stream::StreamExt as _;
 
-        let store_dir = store.store_dir().clone();
         let mut stream = tokio_stream::iter(paths)
-            .map(|vpi| {
-                let store_dir = store_dir.clone();
-                async move {
-                    tracing::debug!("copying path {} to s3 binary cache.", vpi.path);
-                    self.copy_path(store, &store_dir, &vpi, repair).await
-                }
+            .map(|vpi| async move {
+                tracing::debug!("copying path {} to s3 binary cache.", vpi.path);
+                self.copy_path(store, &vpi, repair).await
             })
             .buffered(10);
 
@@ -767,7 +758,7 @@ impl S3BinaryCacheClient {
             .await?
         {
             Some(v) => {
-                let narinfo = parse_narinfo(&v)?;
+                let narinfo = parse_narinfo_txt(&self.cfg.store_dir, std::str::from_utf8(&v)?)?;
                 self.narinfo_cache
                     .insert(store_path.to_owned(), narinfo.clone())
                     .await;
@@ -943,10 +934,9 @@ impl S3BinaryCacheClient {
         })
     }
 
-    #[tracing::instrument(skip(self, store, narinfo), err)]
+    #[tracing::instrument(skip(self, narinfo), err)]
     pub async fn upload_narinfo_after_presigned_upload(
         &self,
-        store: &harmonia_store_remote::ConnectionPool,
         narinfo: NarInfo,
     ) -> Result<String, CacheError> {
         if self.cfg.write_nar_listing {
@@ -962,9 +952,9 @@ impl S3BinaryCacheClient {
             .then_some(())
             .ok_or(CacheError::PathNotFound { path: nar_url })?;
 
-        let narinfo = clear_sigs_and_sign(narinfo, store.store_dir(), &self.signing_keys);
+        let narinfo = clear_sigs_and_sign(narinfo, &self.cfg.store_dir, &self.signing_keys);
         // TODO: we also need to integarte realisation into this!
-        self.upload_narinfo(store.store_dir(), narinfo).await
+        self.upload_narinfo(narinfo).await
     }
 }
 

--- a/subprojects/crates/binary-cache/src/narinfo.rs
+++ b/subprojects/crates/binary-cache/src/narinfo.rs
@@ -1,20 +1,18 @@
-use std::collections::BTreeSet;
-
 use harmonia_store_nar_info::UnkeyedNarInfo;
-use harmonia_store_path::{ParseStorePathError, StoreDir, StorePath};
+use harmonia_store_path::{StoreDir, StorePath};
 use harmonia_store_path_info::fingerprint_path;
 use harmonia_store_path_info::{NarHash, UnkeyedValidPathInfo};
 use harmonia_utils_hash::Hash;
 use harmonia_utils_hash::HashFormat as _;
-use harmonia_utils_signature::{SecretKey, Signature};
+use harmonia_utils_signature::SecretKey;
 use secrecy::ExposeSecret as _;
 
 use crate::Compression;
 
 pub use harmonia_store_nar_info::NarInfo;
 
-/// Re-export the harmonia narinfo formatter.
-pub use harmonia_store_nar_info::format_narinfo_txt;
+/// Re-export the harmonia narinfo formatter and parser.
+pub use harmonia_store_nar_info::{format_narinfo_txt, parse_narinfo_txt};
 
 /// Parse a hash string (in any format: hex, nix32, sri) into a typed `Hash`.
 pub fn parse_hash(raw: &str) -> Option<Hash> {
@@ -121,177 +119,4 @@ pub fn clear_sigs_and_sign(
 #[must_use]
 pub fn get_ls_path(narinfo: &NarInfo) -> String {
     format!("{}.ls", narinfo.path.hash())
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum NarInfoError {
-    #[error("missing required field: {0}")]
-    MissingField(&'static str),
-    #[error("invalid value for {field}: {value}")]
-    InvalidValue {
-        field: String,
-        value: String,
-        #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-    #[error("parse error on line {line}: {reason}")]
-    Line { line: usize, reason: String },
-    #[error("narinfo was not valid utf-8")]
-    FromUtf8(#[from] std::str::Utf8Error),
-}
-
-/// Parse a narinfo text into a [`NarInfo`].
-///
-/// `FromStr` cannot be implemented directly on the re-exported type due to
-/// Rust's orphan rules, so this free function is provided instead.
-// TODO: harmonia should grow its own narinfo parser so we can use that instead
-#[tracing::instrument(skip(raw), err)]
-#[allow(clippy::too_many_lines)]
-pub fn parse_narinfo(raw: &[u8]) -> Result<NarInfo, NarInfoError> {
-    let input = str::from_utf8(raw)?;
-
-    let mut store_path_opt: Option<StorePath> = None;
-    let mut url_opt: Option<String> = None;
-    let mut compression_opt: Option<String> = None;
-    let mut file_hash: Option<Hash> = None;
-    let mut file_size: Option<u64> = None;
-    let mut nar_hash_opt: Option<NarHash> = None;
-    let mut nar_size: u64 = 0;
-    let mut have_nar_size = false;
-    let mut references: BTreeSet<StorePath> = BTreeSet::new();
-    let mut deriver: Option<StorePath> = None;
-    let mut ca_str: Option<String> = None;
-    let mut sigs: BTreeSet<Signature> = BTreeSet::new();
-
-    for (idx, raw_line) in input.lines().enumerate() {
-        let line_no = idx + 1;
-        let line = raw_line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
-        let Some((k, v)) = line.split_once(':') else {
-            return Err(NarInfoError::Line {
-                line: line_no,
-                reason: "expected `Key: value`".into(),
-            });
-        };
-        let key = k.trim();
-        let val = v
-            .strip_prefix(' ')
-            .map_or(v, |stripped| stripped)
-            .trim_end();
-
-        match key {
-            "StorePath" => {
-                store_path_opt = Some(val.parse().map_err(|e: ParseStorePathError| {
-                    NarInfoError::InvalidValue {
-                        field: key.to_owned(),
-                        value: val.to_owned(),
-                        source: e.into(),
-                    }
-                })?);
-            }
-            "URL" => {
-                url_opt = Some(val.to_string());
-            }
-            "Compression" => {
-                compression_opt = Some(val.to_string());
-            }
-            "FileHash" => {
-                file_hash = parse_hash(val);
-            }
-            "FileSize" => {
-                file_size = Some(val.parse::<u64>().map_err(|e| NarInfoError::InvalidValue {
-                    field: key.to_owned(),
-                    value: val.to_owned(),
-                    source: e.into(),
-                })?);
-            }
-            "NarHash" => {
-                nar_hash_opt = parse_nar_hash(val);
-            }
-            "NarSize" => {
-                nar_size = val.parse::<u64>().map_err(|e| NarInfoError::InvalidValue {
-                    field: key.to_owned(),
-                    value: val.to_owned(),
-                    source: e.into(),
-                })?;
-                have_nar_size = true;
-            }
-            "References" => {
-                references = val
-                    .split_whitespace()
-                    .filter(|s| !s.is_empty())
-                    .map(|s| {
-                        s.parse()
-                            .map_err(|e: ParseStorePathError| NarInfoError::InvalidValue {
-                                field: key.to_owned(),
-                                value: s.to_owned(),
-                                source: e.into(),
-                            })
-                    })
-                    .collect::<Result<_, _>>()?;
-            }
-            "Deriver" => {
-                deriver = if val.is_empty() {
-                    None
-                } else {
-                    Some(val.parse().map_err(|e: ParseStorePathError| {
-                        NarInfoError::InvalidValue {
-                            field: key.to_owned(),
-                            value: val.to_owned(),
-                            source: e.into(),
-                        }
-                    })?)
-                };
-            }
-            "CA" => {
-                ca_str = if val.is_empty() {
-                    None
-                } else {
-                    Some(val.to_string())
-                };
-            }
-            "Sig" => {
-                if !val.is_empty()
-                    && let Ok(sig) = val.parse()
-                {
-                    sigs.insert(sig);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    let store_path = store_path_opt.ok_or(NarInfoError::MissingField("StorePath"))?;
-    let url = url_opt.ok_or(NarInfoError::MissingField("URL"))?;
-    let compression = compression_opt.ok_or(NarInfoError::MissingField("Compression"))?;
-    let nar_hash = nar_hash_opt.ok_or(NarInfoError::MissingField("NarHash"))?;
-    if !have_nar_size {
-        return Err(NarInfoError::MissingField("NarSize"));
-    }
-
-    let ca = ca_str.as_deref().and_then(|s| s.parse().ok());
-
-    Ok(NarInfo {
-        path: store_path,
-        info: UnkeyedNarInfo {
-            info: UnkeyedValidPathInfo {
-                deriver,
-                nar_hash,
-                references,
-                registration_time: None,
-                nar_size,
-                ultimate: false,
-                signatures: sigs,
-                ca,
-                store_dir: StoreDir::default(),
-            },
-            url: Some(url),
-            compression: Some(compression),
-            download_hash: file_hash,
-            download_size: file_size,
-        },
-    })
 }

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -751,6 +751,11 @@ impl RunnerService for Server {
             )));
         }
 
+        // The cache signs and formats narinfos with its own configured store
+        // dir; for those signatures to match the uploaded paths it must agree
+        // with the local store (the narinfo was just checked against it above).
+        debug_assert_eq!(&remote_store.cfg.store_dir, self.state.pool.store_dir());
+
         let store_path = narinfo.path.clone();
 
         // Override compression from server config
@@ -760,7 +765,7 @@ impl RunnerService for Server {
         let size = narinfo.info.download_size;
 
         let narinfo_url = remote_store
-            .upload_narinfo_after_presigned_upload(&self.state.pool, narinfo)
+            .upload_narinfo_after_presigned_upload(narinfo)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to upload narinfo for {}: {e}", store_path);


### PR DESCRIPTION
The `StorePath` field of a narinfo holds the full path
(`/nix/store/<hash>-<name>`); cache.nixos.org serves it that way and
`harmonia_store_nar_info`, used for our own uploads, writes it that way.
Our hand-rolled `parse_narinfo` fed the value into `StorePath::from_str`,
which only accepts the base name, so every spec-conforming narinfo failed
to parse.

The queue runner therefore could not read back narinfos from its own
binary cache: `has_narinfo` failed for every path, uploads were repeated
endlessly and `copy_paths` errors failed the affected builds. Observed on
a 120-build nixos-small evaluation against an S3 cache populated by the
runner itself: 2067 `invalid value for StorePath` errors and all 120
builds failing with status 2.

harmonia has since grown its own `parse_narinfo_txt` (mirroring nix's
`nar-info.cc`), so delegate to it instead of maintaining our own. It takes
the store directory explicitly, so carry it on `S3CacheConfig`, read from
the `store` query parameter of the cache URL (the nix S3 convention,
defaulting to `/nix/store`); both the upload and download paths now use
`self.cfg.store_dir` rather than threading it in. Besides reading
`StorePath` as a full path, this also fixes two ways our parser diverged
from nix: `Deriver: unknown-deriver` and an optional `Compression` field.

