### PR TITLE
queue-runner: keep argument parsing out of the library crate

### DIFF
--- a/subprojects/hydra-queue-runner/Cargo.toml
+++ b/subprojects/hydra-queue-runner/Cargo.toml
@@ -20,7 +20,7 @@ toml.workspace        = true
 
 atomic_float.workspace = true
 backon.workspace       = true
-clap                   = { workspace = true, features = [ "derive", "env" ] }
+clap                   = { workspace = true, features = [ "derive" ] }
 color-eyre.workspace   = true
 fs-err                 = { workspace = true, features = [ "tokio" ] }
 thiserror.workspace    = true

--- a/subprojects/hydra-queue-runner/src/cli.rs
+++ b/subprojects/hydra-queue-runner/src/cli.rs
@@ -1,0 +1,86 @@
+//! Binary-only command-line parsing. This is the only module that depends
+//! on `clap`; keeping it out of the library crate means the library (and
+//! its examples) compile without argument parsing pulled in.
+
+use std::net::SocketAddr;
+
+use clap::Parser;
+
+use crate::config::MtlsConfig;
+
+#[derive(Debug, Clone)]
+pub enum BindSocket {
+    Tcp(SocketAddr),
+    Unix(std::path::PathBuf),
+    ListenFd,
+}
+
+impl std::str::FromStr for BindSocket {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<SocketAddr>().map(BindSocket::Tcp).or_else(|_| {
+            if s == "-" {
+                Ok(Self::ListenFd)
+            } else {
+                Ok(Self::Unix(s.into()))
+            }
+        })
+    }
+}
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Cli {
+    /// REST server bind, either a `SocketAddr` or `-` to use `ListenFD` (systemd socket activation)
+    #[clap(short, long, default_value = "[::1]:8080")]
+    pub rest_bind: BindSocket,
+
+    /// GRPC server bind, either a `SocketAddr`, a Path for a Unix Socket or `-` to use `ListenFD` (systemd socket activation)
+    #[clap(short, long, default_value = "[::1]:50051")]
+    pub grpc_bind: BindSocket,
+
+    /// Config path
+    #[clap(short, long, default_value = "config.toml")]
+    pub config_path: String,
+
+    /// Path to Server cert
+    #[clap(long)]
+    pub server_cert_path: Option<std::path::PathBuf>,
+
+    /// Path to Server key
+    #[clap(long)]
+    pub server_key_path: Option<std::path::PathBuf>,
+
+    /// Path to Client ca cert
+    #[clap(long)]
+    pub client_ca_cert_path: Option<std::path::PathBuf>,
+
+    /// Dangerous to disable this, this is only implemented so we can manually trigger only one build
+    #[clap(long, default_value_t = false)]
+    pub disable_queue_monitor_loop: bool,
+}
+
+impl Default for Cli {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Cli {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::parse()
+    }
+
+    /// The mTLS material the library's gRPC server needs, lifted out of the
+    /// parsed arguments.
+    #[must_use]
+    pub fn mtls(&self) -> MtlsConfig {
+        MtlsConfig {
+            server_cert_path: self.server_cert_path.clone(),
+            server_key_path: self.server_key_path.clone(),
+            client_ca_cert_path: self.client_ca_cert_path.clone(),
+        }
+    }
+}

--- a/subprojects/hydra-queue-runner/src/config.rs
+++ b/subprojects/hydra-queue-runner/src/config.rs
@@ -1,6 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
-
-use clap::Parser;
+use std::sync::Arc;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
@@ -27,88 +25,34 @@ pub enum ConfigError {
     Prepare(#[source] Box<ConfigError>),
 }
 
-#[derive(Debug, Clone)]
-pub enum BindSocket {
-    Tcp(SocketAddr),
-    Unix(std::path::PathBuf),
-    ListenFd,
-}
-
-impl std::str::FromStr for BindSocket {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse::<SocketAddr>().map(BindSocket::Tcp).or_else(|_| {
-            if s == "-" {
-                Ok(Self::ListenFd)
-            } else {
-                Ok(Self::Unix(s.into()))
-            }
-        })
-    }
-}
-
-#[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
-pub struct Cli {
-    /// REST server bind, either a `SocketAddr` or `-` to use `ListenFD` (systemd socket activation)
-    #[clap(short, long, default_value = "[::1]:8080")]
-    pub rest_bind: BindSocket,
-
-    /// GRPC server bind, either a `SocketAddr`, a Path for a Unix Socket or `-` to use `ListenFD` (systemd socket activation)
-    #[clap(short, long, default_value = "[::1]:50051")]
-    pub grpc_bind: BindSocket,
-
-    /// Config path
-    #[clap(short, long, default_value = "config.toml")]
-    pub config_path: String,
-
-    /// Path to Server cert
-    #[clap(long)]
+/// mTLS material the gRPC server needs. The binary builds this from its
+/// CLI arguments; keeping it clap-free is what lets the library compile
+/// without depending on argument parsing.
+#[derive(Debug, Clone, Default)]
+pub struct MtlsConfig {
     pub server_cert_path: Option<std::path::PathBuf>,
-
-    /// Path to Server key
-    #[clap(long)]
     pub server_key_path: Option<std::path::PathBuf>,
-
-    /// Path to Client ca cert
-    #[clap(long)]
     pub client_ca_cert_path: Option<std::path::PathBuf>,
-
-    /// Dangerous to disable this, this is only implemented so we can manually trigger only one build
-    #[clap(long, default_value_t = false)]
-    pub disable_queue_monitor_loop: bool,
 }
 
-impl Default for Cli {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Cli {
+impl MtlsConfig {
     #[must_use]
-    pub fn new() -> Self {
-        Self::parse()
-    }
-
-    #[must_use]
-    pub const fn mtls_enabled(&self) -> bool {
+    pub const fn enabled(&self) -> bool {
         self.server_cert_path.is_some()
             && self.server_key_path.is_some()
             && self.client_ca_cert_path.is_some()
     }
 
     #[must_use]
-    pub const fn mtls_configured_correctly(&self) -> bool {
-        self.mtls_enabled()
+    pub const fn configured_correctly(&self) -> bool {
+        self.enabled()
             || (self.server_cert_path.is_none()
                 && self.server_key_path.is_none()
                 && self.client_ca_cert_path.is_none())
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_mtls(
+    pub async fn get(
         &self,
     ) -> Result<(tonic::transport::Certificate, tonic::transport::Identity), ConfigError> {
         let server_cert_path = self

--- a/subprojects/hydra-queue-runner/src/main.rs
+++ b/subprojects/hydra-queue-runner/src/main.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::missing_errors_doc)]
 #![recursion_limit = "256"]
 
+pub mod cli;
 pub mod config;
 pub mod io;
 pub mod lock_file;
@@ -25,6 +26,7 @@ use std::future::Future;
 
 use color_eyre::eyre::{self, WrapErr as _};
 
+use cli::{BindSocket, Cli};
 use state::State;
 
 type GrpcServer =
@@ -34,16 +36,16 @@ type GrpcServer =
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-fn start_task_loops(state: &std::sync::Arc<State>) -> Vec<tokio::task::AbortHandle> {
+fn start_task_loops(state: &std::sync::Arc<State>, cli: &Cli) -> Vec<tokio::task::AbortHandle> {
     tracing::info!("QueueRunner starting task loops");
 
     let mut service_list = vec![
-        spawn_config_reloader(state.clone(), state.config.clone(), &state.cli.config_path),
+        spawn_config_reloader(state.clone(), state.config.clone(), &cli.config_path),
         state.clone().start_dispatch_loop(),
         state.clone().start_uploader_queue(),
         state.clone().start_upload_completion_loop(),
     ];
-    if !state.cli.disable_queue_monitor_loop {
+    if !cli.disable_queue_monitor_loop {
         service_list.push(state.clone().start_queue_monitor_loop());
     }
 
@@ -94,7 +96,9 @@ async fn main() -> color_eyre::Result<()> {
         }));
     }
 
-    let state = Box::pin(State::new()).await?;
+    let cli = Cli::new();
+    let config = config::App::init(&cli.config_path)?;
+    let state = Box::pin(State::new(cli.mtls(), config)).await?;
 
     let lockfile_path = state.config.get_lockfile();
     let _lock = lock_file::LockFile::acquire(&lockfile_path)
@@ -102,14 +106,14 @@ async fn main() -> color_eyre::Result<()> {
 
     state.clear_busy().await?; // clear busy once before starting the queue-runner
 
-    if !state.cli.mtls_configured_correctly() {
+    if !state.mtls.configured_correctly() {
         tracing::error!(
             "mtls configured inproperly, please pass all options: server_cert_path, server_key_path and client_ca_cert_path!"
         );
         return Err(eyre::eyre!("Configuration issue"));
     }
 
-    let task_abort_handles = start_task_loops(&state);
+    let task_abort_handles = start_task_loops(&state, &cli);
 
     // Resolve listeners for both servers. When using socket activation
     // (ListenFd), we use LISTEN_FDNAMES to map names to fd indices.
@@ -120,9 +124,9 @@ async fn main() -> color_eyre::Result<()> {
         .map(String::from)
         .collect();
 
-    let http_listener = match &state.cli.rest_bind {
-        config::BindSocket::Tcp(s) => tokio::net::TcpListener::bind(s).await?,
-        config::BindSocket::ListenFd => {
+    let http_listener = match &cli.rest_bind {
+        BindSocket::Tcp(s) => tokio::net::TcpListener::bind(s).await?,
+        BindSocket::ListenFd => {
             let idx = fd_names.iter().position(|n| n == "rest").unwrap_or(0);
             let std_listener = listenfd
                 .take_tcp_listener(idx)?
@@ -130,14 +134,14 @@ async fn main() -> color_eyre::Result<()> {
             std_listener.set_nonblocking(true)?;
             tokio::net::TcpListener::from_std(std_listener)?
         }
-        config::BindSocket::Unix(_) => {
+        BindSocket::Unix(_) => {
             return Err(eyre::eyre!("HTTP server does not support Unix sockets"));
         }
     };
     let http_addr = http_listener.local_addr()?;
 
-    let (srv1, grpc_info): (GrpcServer, String) = match &state.cli.grpc_bind {
-        config::BindSocket::Tcp(s) => {
+    let (srv1, grpc_info): (GrpcServer, String) = match &cli.grpc_bind {
+        BindSocket::Tcp(s) => {
             let listener = tokio::net::TcpListener::bind(s).await?;
             let addr = listener.local_addr()?;
             let info = addr.to_string();
@@ -146,7 +150,7 @@ async fn main() -> color_eyre::Result<()> {
                 info,
             )
         }
-        config::BindSocket::ListenFd => {
+        BindSocket::ListenFd => {
             let idx = fd_names.iter().position(|n| n == "grpc").unwrap_or(1);
             let std_listener = listenfd
                 .take_tcp_listener(idx)?
@@ -160,7 +164,7 @@ async fn main() -> color_eyre::Result<()> {
                 info,
             )
         }
-        config::BindSocket::Unix(p) => {
+        BindSocket::Unix(p) => {
             let listener = tokio::net::UnixListener::bind(p)?;
             let info = format!("unix:{}", p.display());
             (

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -181,9 +181,9 @@ impl Server {
                 .map_request(hydra_tracing::propagate::accept_trace),
         );
 
-        if state.cli.mtls_enabled() {
+        if state.mtls.enabled() {
             tracing::info!("Using mtls");
-            let (client_ca_cert, server_identity) = state.cli.get_mtls().await?;
+            let (client_ca_cert, server_identity) = state.mtls.get().await?;
 
             let tls = tonic::transport::ServerTlsConfig::new()
                 .identity(server_identity)

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -135,7 +135,7 @@ use harmonia_store_derivation::realisation::{DrvOutput, Realisation, UnkeyedReal
 use inspectable_channel::InspectableChannel;
 use sha2::{Digest as _, Sha256};
 
-use crate::config::{App, Cli};
+use crate::config::{App, MtlsConfig};
 use crate::state::build::get_mark_build_sccuess_data;
 pub use crate::state::fod_checker::FodChecker;
 use crate::state::machine::Machines;
@@ -297,7 +297,7 @@ pub struct State {
     pub store: daemon_client_utils::DaemonStoreReader,
     pub remote_stores: parking_lot::RwLock<Vec<RemoteStoreBackend>>,
     pub config: App,
-    pub cli: Cli,
+    pub mtls: MtlsConfig,
     pub db: db::Database,
 
     pub machines: Machines,
@@ -387,7 +387,7 @@ impl State {
     }
 
     #[tracing::instrument(err)]
-    pub async fn new() -> Result<Arc<Self>, StateError> {
+    pub async fn new(mtls: MtlsConfig, config: App) -> Result<Arc<Self>, StateError> {
         let nix_config = daemon_client_utils::parse_nix_remote()
             .map_err(crate::config::ConfigError::ParseNixStore)?;
         let store_dir = nix_config.store_dir.clone();
@@ -396,9 +396,6 @@ impl State {
 
         tracing::info!("LocalStore dir={store_dir}");
 
-        let cli = Cli::new();
-
-        let config = App::init(&cli.config_path)?;
         let log_dir = config.get_hydra_log_dir();
         let max_db_connections = config.get_max_db_connections();
         let db = db::Database::new(config.get_db_url().expose_secret(), max_db_connections).await?;
@@ -441,7 +438,7 @@ impl State {
             connector,
             store,
             remote_stores: parking_lot::RwLock::new(remote_stores),
-            cli,
+            mtls,
             db,
             machines: Machines::new(),
             resolved_drv_map: parking_lot::RwLock::new(HashMap::new()),


### PR DESCRIPTION
`State` stored the whole clap-derived `Cli`, and `State::new` parsed argv (`Cli::new()`) and read the config file (`App::init`) itself. Because `config.rs` and `State` live in the library crate (consumed by the examples), that pulled `clap` and the entire argv surface into the library's compilation unit, even though the library only ever needs the mTLS material from those arguments.

Split it along what each side actually uses:

- The library keeps a plain, clap-free `MtlsConfig` (the gRPC server's only need from the CLI). `State` holds that instead of `Cli`, and `State::new(mtls, config)` takes both as values rather than reaching out to argv and the filesystem.

- A new binary-only `cli` module owns `Cli`, `BindSocket`, and the `clap::Parser` derive. `main` parses the arguments, loads the config, lifts out `cli.mtls()`, and injects everything into `State::new`. The config-path used by the SIGHUP reloader is threaded through from `main` rather than read back off `State`.

`clap` is now referenced only from `src/cli.rs`, which is not part of the library, so the library (and `examples/collect-fods`) compile without it.