### PR TITLE
List oldest jobs first on machine status page

### DIFF
--- a/subprojects/hydra/lib/Hydra/Controller/Root.pm
+++ b/subprojects/hydra/lib/Hydra/Controller/Root.pm
@@ -208,7 +208,7 @@ sub machines :Local Args(0) {
         "from BuildSteps s " .
         "join Builds b on s.build = b.id " .
         "join Jobsets jobsets on jobsets.id = b.jobset_id " .
-        "where busy != 0 order by machine, stepnr",
+        "where busy != 0 order by machine, s.starttime asc",
         { Slice => {} });
     $c->stash->{template} = 'machine-status.tt';
     $c->stash->{human_bytes} = sub {

--- a/subprojects/hydra/root/build.tt
+++ b/subprojects/hydra/root/build.tt
@@ -39,7 +39,7 @@ END;
 [% BLOCK renderBuildSteps %]
   <table class="table table-striped table-condensed clickable-rows">
     <thead>
-      <tr><th>Nr</th><th>What</th><th>Duration</th><th>Machine</th><th>Status</th></tr>
+      <tr><th>Nr</th><th>Step</th><th>Duration</th><th>Machine</th><th>Status</th></tr>
     </thead>
     <tbody>
       [% FOREACH step IN steps %]

--- a/subprojects/hydra/root/machine-status.tt
+++ b/subprojects/hydra/root/machine-status.tt
@@ -8,7 +8,6 @@
       <th>Job</th>
       <th>Build</th>
       <th>Step</th>
-      <th>What</th>
       <th>Status</th>
       <th>Since</th>
     </tr>
@@ -77,8 +76,7 @@
           <tr>
             <td><tt>[% INCLUDE renderFullJobName project=step.project jobset=step.jobset job=step.job %]</tt></td>
             <td><a [% HTML.attributes(href => c.uri_for('/build' step.build)) %]>[% HTML.escape(step.build) %]</a></td>
-            <td>[% IF step.busy >= 30 %]<a class="row-link" [% HTML.attributes(href => c.uri_for('/build' step.build 'nixlog' step.stepnr 'tail')) %]>[% HTML.escape(step.stepnr) %]</a>[% ELSE; HTML.escape(step.stepnr); END %]</td>
-            <td><tt>[% step.drvpath.match('-(.*)').0 | html %]</tt></td>
+            <td><tt>[% IF step.busy >= 30 %]<a class="row-link" [% HTML.attributes(href => c.uri_for('/build' step.build 'nixlog' step.stepnr 'tail')) %]>[% step.drvpath.match('-(.*)').0 | html %]</a>[% ELSE; step.drvpath.match('-(.*)').0 | html; END %]</tt></td>
             <td>[% INCLUDE renderBusyStatus %]</td>
             <td style="width: 10em">[% INCLUDE renderDuration duration = curTime - step.starttime %] </td>
           </tr>

--- a/subprojects/hydra/root/steps.tt
+++ b/subprojects/hydra/root/steps.tt
@@ -9,7 +9,7 @@ order of descending finish time.</p>
   <thead>
     <tr>
       <th></th>
-      <th>What</th>
+      <th>Step</th>
       <th>Job</th>
       <th>Build</th>
       <th>Step</th>


### PR DESCRIPTION
Ordering by step numer is local to a build closure and jumps around a lot.

Untested, but I checked that `builds.starttime` is indeed a UNIX timestamp and looks like what we want.