### PR TITLE
Make `BuildSteps.drvPath` NOT NULL

### DIFF
--- a/subprojects/hydra/lib/Hydra/Schema/Result/BuildSteps.pm
+++ b/subprojects/hydra/lib/Hydra/Schema/Result/BuildSteps.pm
@@ -54,7 +54,7 @@ __PACKAGE__->table("buildsteps");
 =head2 drvpath
 
   data_type: 'text'
-  is_nullable: 1
+  is_nullable: 0
 
 =head2 busy
 
@@ -123,7 +123,7 @@ __PACKAGE__->add_columns(
   "type",
   { data_type => "integer", is_nullable => 0 },
   "drvpath",
-  { data_type => "text", is_nullable => 1 },
+  { data_type => "text", is_nullable => 0 },
   "busy",
   { data_type => "integer", is_nullable => 0 },
   "status",
@@ -215,8 +215,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-08-26 12:02:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:GzztRd7OwomaT3Xi7NB2RQ
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2026-07-14 13:37:32
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5DXzz2Gtv1HyerfsgWKhdA
 
 my %hint = (
     columns => [

--- a/subprojects/hydra/sql/check-migrations.nix
+++ b/subprojects/hydra/sql/check-migrations.nix
@@ -23,14 +23,18 @@ let
 
   allVersions = lib.unique (migrationVersions ++ schemaVersions);
 
+  maxMigrationVersion = lib.last (lib.sort lib.lessThan migrationVersions);
+
   # A version N is covered when we have schema N-1, schema N, and upgrade-N.sql.
   # Schema-only versions (like version 1, the base) are also covered.
+  # The highest migration version is special: it uses hydra.sql (the current
+  # schema) as its target, so it doesn't need a vendored schema file.
   isCovered =
     n:
     (
       builtins.elem n migrationVersions
       && builtins.elem (n - 1) schemaVersions
-      && builtins.elem n schemaVersions
+      && (builtins.elem n schemaVersions || n == maxMigrationVersion)
     )
     || (!builtins.elem n migrationVersions && builtins.elem n schemaVersions);
 
@@ -46,7 +50,9 @@ builtins.listToAttrs (
     let
       from = to - 1;
       schemaBefore = ./schemas/hydra-${toString from}.sql;
-      schemaAfter = ./schemas/hydra-${toString to}.sql;
+      # The latest migration tests against the current schema directly,
+      # so we don't need to vendor a copy of it.
+      schemaAfter = if to == maxMigrationVersion then ./hydra.sql else ./schemas/hydra-${toString to}.sql;
       migration = ./migrations/upgrade-${toString to}.sql;
     in
     {

--- a/subprojects/hydra/sql/hydra.sql
+++ b/subprojects/hydra/sql/hydra.sql
@@ -261,7 +261,7 @@ create table BuildSteps (
 
     type          integer not null, -- 0 = build, 1 = substitution
 
-    drvPath       text,
+    drvPath       text not null,
 
     -- 0 = not busy
     -- 1 = building

--- a/subprojects/hydra/sql/migrations/upgrade-86.sql
+++ b/subprojects/hydra/sql/migrations/upgrade-86.sql
@@ -1,0 +1,18 @@
+-- drvPath should always have been NOT NULL, and no current code path
+-- creates a step without one. However, very old deployments (e.g.
+-- hydra.nixos.org) still carry a handful of 2015-era substitution steps
+-- whose drvPath was never recorded. Backfill those with a unique,
+-- obviously-fake placeholder so the constraint can be enforced; the
+-- all-zero hash cannot collide with a real store path, and (build,
+-- stepnr) is the primary key, so the placeholders are unique per row.
+--
+-- Only substitution steps (type = 1) are backfilled: a *build* step
+-- with a NULL drvPath would be genuinely unexpected, so the SET NOT
+-- NULL below should still abort on one, prompting investigation
+-- rather than papering over it.
+UPDATE BuildSteps
+    SET drvPath = format('/nix/store/00000000000000000000000000000000-unknown-build-%s-step-%s.drv', build, stepnr)
+    WHERE drvPath IS NULL
+    AND type = 1;
+
+ALTER TABLE BuildSteps ALTER COLUMN drvPath SET NOT NULL;

--- a/subprojects/hydra/sql/schemas/commit-86.txt
+++ b/subprojects/hydra/sql/schemas/commit-86.txt
@@ -1,0 +1,1 @@
+f3dc914da16fecc933c80e3a9045a3aa2ecbd0f7

--- a/subprojects/hydra/sql/schemas/verify.sh
+++ b/subprojects/hydra/sql/schemas/verify.sh
@@ -19,11 +19,21 @@ for schema_file in hydra-*.sql; do
   fi
 done
 
+# The newest version's schema is hydra.sql itself, so its commit-N.txt has no
+# vendored hydra-N.sql; the snapshot is only vendored once a newer migration
+# supersedes it.
+max_commit=0
+for commit_file in commit-*.txt; do
+  n="${commit_file#commit-}"
+  n="${n%.txt}"
+  (( n > max_commit )) && max_commit=$n
+done
+
 # Check for commits without schemas
 for commit_file in commit-*.txt; do
   n="${commit_file#commit-}"
   n="${n%.txt}"
-  if [ ! -f "hydra-${n}.sql" ]; then
+  if [ ! -f "hydra-${n}.sql" ] && [ "$n" != "$max_commit" ]; then
     echo "ORPHAN COMMIT: $commit_file has no hydra-${n}.sql"
     failures=$((failures + 1))
   fi
@@ -37,7 +47,12 @@ for commit_file in commit-*.txt; do
   schema_file="hydra-${n}.sql"
 
   if [ ! -f "$schema_file" ]; then
-    continue  # already reported above
+    if [ "$n" = "$max_commit" ]; then
+      # Newest version: verify the live hydra.sql against the recorded commit.
+      schema_file="../hydra.sql"
+    else
+      continue  # already reported above
+    fi
   fi
 
   # Find hydra.sql in the commit tree (search from repo root)


### PR DESCRIPTION
`drvPath` was historically nullable, but no current code path creates a
step without one. Making it NOT NULL ensures the `(drvPath, attempt)`
unique constraint (added in the next migration) is enforceable for all
rows.

See the comment in the migration for details, most notably including how
we deal with old data.

I did a dry-run analysis (`BEGIN; EXPLAIN ANALYZE ...; ALTER ...; ROLLBACK;`) in
the backup database.

I got this for the `EXPLAIN ANALYZE`:

```
                                                                      QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------
 Update on buildsteps  (cost=0.70..70981.34 rows=0 width=0) (actual time=6064.217..6064.217 rows=0 loops=1)
   ->  Index Scan using indexbuildstepsondrvpath on buildsteps  (cost=0.70..70981.34 rows=13 width=38) (actual time=0.188..70.271 rows=54014 loops=1)
         Index Cond: (drvpath IS NULL)
         Filter: (type = 1)
 Planning Time: 1.638 ms
 Execution Time: 6065.121 ms
```

There is no `EXPLAIN ANALYZE` for `ALTER ...` but it took 2 minutes
perhaps --- OK for planned downtime.

If we regret anything, we can rollback by finding these drv paths (which
don't overlap with real ones) and setting them back to NULL too.