### PR TITLE
hydra.nixos.org: Fix NOTIFY db errors caused by overlarge queued items

### DIFF
--- a/subprojects/crates/db/src/connection.rs
+++ b/subprojects/crates/db/src/connection.rs
@@ -1239,10 +1239,26 @@ impl Transaction<'_> {
         build_id: i32,
         dependent_ids: &[i32],
     ) -> crate::Result<()> {
-        let mut q = vec![build_id.to_string()];
-        q.extend(dependent_ids.iter().map(ToString::to_string));
+        // Postgres limits NOTIFY payloads to slightly less than 8000 bytes.
+        // A cached build can finish thousands of dependent builds at once,
+        // so split the dependents over multiple notifications that each
+        // repeat the finished build id as the first field.
+        const MAX_PAYLOAD_LEN: usize = 7000;
 
-        self.notify_any("build_finished", &q.join("\t")).await?;
+        let head = build_id.to_string();
+        let mut payload = head.clone();
+
+        for dep in dependent_ids {
+            let dep = dep.to_string();
+            if payload.len() + 1 + dep.len() > MAX_PAYLOAD_LEN {
+                self.notify_any("build_finished", &payload).await?;
+                payload = head.clone();
+            }
+            payload.push('\t');
+            payload.push_str(&dep);
+        }
+
+        self.notify_any("build_finished", &payload).await?;
         Ok(())
     }
 
@@ -1794,5 +1810,34 @@ mod tests {
             victim.is_retryable_serialization_failure(),
             "deadlock error should be retryable: {victim:?}"
         );
+    }
+
+    /// Regression test: a dependent list too large for a single NOTIFY
+    /// payload is delivered completely across multiple notifications.
+    #[tokio::test]
+    async fn notify_build_finished_chunks_large_dependent_lists() {
+        let (_pg, pool) = test_utils::TestPg::new().await;
+
+        let mut listener = sqlx::postgres::PgListener::connect_with(&pool)
+            .await
+            .unwrap();
+        listener.listen("build_finished").await.unwrap();
+
+        let dependent_ids: Vec<i32> = (1_000_000..1_005_000).collect();
+        let mut conn = Connection::new(pool.acquire().await.unwrap());
+        let mut tx = conn.begin_transaction().await.unwrap();
+        tx.notify_build_finished(42, &dependent_ids).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let mut received = std::collections::HashSet::new();
+        while received.len() < dependent_ids.len() {
+            let notification = listener.recv().await.unwrap();
+            let payload = notification.payload();
+            assert!(payload.len() <= 8000, "payload too long: {}", payload.len());
+            let mut fields = payload.split('\t');
+            assert_eq!(fields.next(), Some("42"));
+            received.extend(fields.map(|f| f.parse::<i32>().unwrap()));
+        }
+        assert!(dependent_ids.iter().all(|id| received.contains(id)));
     }
 }

--- a/subprojects/crates/db/src/lib.rs
+++ b/subprojects/crates/db/src/lib.rs
@@ -22,6 +22,7 @@ use std::str::FromStr as _;
 pub use connection::{Connection, Transaction};
 pub use error::{DataError, Error, Result};
 pub use harmonia_store_path::StoreDir;
+pub use sqlx::postgres::PgNotification as Notification;
 
 /// Error that a serialization-failure retry can recognise.
 pub trait RetryableError {

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -1508,16 +1508,28 @@ impl State {
             ])
             .await?;
 
+        let mut consecutive_failures = 0u32;
         loop {
             let before_work = Instant::now();
             // no cache in daemon protocol
             let early_exit = match self.get_queued_builds().await {
                 Ok(early_exit) => early_exit,
                 Err(e) => {
-                    tracing::error!("get_queue_builds failed inside queue monitor loop: {e}");
+                    // Back off instead of retrying immediately: a persistent
+                    // failure would otherwise busy-loop, re-reading the whole
+                    // queue at full speed.
+                    consecutive_failures += 1;
+                    let backoff = std::time::Duration::from_secs(
+                        2u64.saturating_pow(consecutive_failures.min(6)),
+                    );
+                    tracing::error!(
+                        "get_queued_builds failed inside queue monitor loop (retrying in {backoff:?}): {e:?}"
+                    );
+                    tokio::time::sleep(backoff).await;
                     continue;
                 }
             };
+            consecutive_failures = 0;
 
             #[allow(clippy::cast_possible_truncation)]
             self.metrics

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -1471,6 +1471,29 @@ impl State {
         task.abort_handle()
     }
 
+    async fn wait_for_queue_notification<E: std::fmt::Display>(
+        listener: &mut (impl futures::Stream<Item = Result<db::Notification, E>> + Unpin),
+        timeout: Option<std::time::Duration>,
+    ) -> Option<String> {
+        let next = listener.try_next();
+        let result = if let Some(timeout) = timeout {
+            tokio::select! {
+                () = tokio::time::sleep(timeout) => return Some("timer_reached".into()),
+                v = next => v,
+            }
+        } else {
+            next.await
+        };
+        match result {
+            Ok(Some(v)) => Some(v.channel().to_owned()),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!("PgListener failed with e={e}");
+                None
+            }
+        }
+    }
+
     #[tracing::instrument(skip(self), err)]
     async fn queue_monitor_loop(&self) -> Result<(), StateError> {
         let mut listener = self
@@ -1502,42 +1525,16 @@ impl State {
                 .inc_by(before_work.elapsed().as_micros() as u64);
 
             let before_sleep = Instant::now();
-            let queue_trigger_timer = self.config.get_queue_trigger_timer();
-            let notification = if early_exit {
+            let timeout = if early_exit {
                 // Short poll: process maybe pending notifications, then re-run immediately.
-                let short_poll = std::time::Duration::from_millis(100);
-                tokio::select! {
-                    () = tokio::time::sleep(short_poll) => {"timer_reached".into()},
-                    v = listener.try_next() => match v {
-                        Ok(Some(v)) => v.channel().to_owned(),
-                        Ok(None) => continue,
-                        Err(e) => {
-                            tracing::warn!("PgListener failed with e={e}");
-                            continue;
-                        }
-                    },
-                }
-            } else if let Some(timer) = queue_trigger_timer {
-                tokio::select! {
-                    () = tokio::time::sleep(timer) => {"timer_reached".into()},
-                    v = listener.try_next() => match v {
-                        Ok(Some(v)) => v.channel().to_owned(),
-                        Ok(None) => continue,
-                        Err(e) => {
-                            tracing::warn!("PgListener failed with e={e}");
-                            continue;
-                        }
-                    },
-                }
+                Some(std::time::Duration::from_millis(100))
             } else {
-                match listener.try_next().await {
-                    Ok(Some(v)) => v.channel().to_owned(),
-                    Ok(None) => continue,
-                    Err(e) => {
-                        tracing::warn!("PgListener failed with e={e}");
-                        continue;
-                    }
-                }
+                self.config.get_queue_trigger_timer()
+            };
+            let Some(notification) =
+                Self::wait_for_queue_notification(&mut listener, timeout).await
+            else {
+                continue;
             };
             self.metrics.nr_queue_wakeups.inc();
             tracing::trace!("New notification from PgListener. notification={notification:?}");


### PR DESCRIPTION
Jul 16 00:43:54 mimas postgres[640893]: user=hydra,db=hydra,app=[unknown],client=[local] ERROR:  payload string too long