### PR TITLE
Upgrade to Nix 2.35 and nix-eval-jobs v2.35.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1783369447,
-        "narHash": "sha256-Es+VrLOI5lKgbp3GSIBzKRILc0FZbNFXlKfKxHBolis=",
+        "lastModified": 1783987836,
+        "narHash": "sha256-UkRzz0meYeuSQt5rQodwfiSe1If+5JojDP7Kxk0beXM=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "0969d83cb7f675f3d7cd3426c99fbec86ee9ec35",
+        "rev": "aa2613fa02ca6199fe0ebf61a0f7f6d781d32a47",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "2.34-maintenance",
+        "ref": "2.35-maintenance",
         "repo": "nix",
         "type": "github"
       }
@@ -37,16 +37,16 @@
     "nix-eval-jobs": {
       "flake": false,
       "locked": {
-        "lastModified": 1782247668,
-        "narHash": "sha256-YaVQAgBxWbUBFHXLBLzdUyVvuA/DDw80SEnn9iq0Veo=",
+        "lastModified": 1784200986,
+        "narHash": "sha256-/C5wyGYe4uMKKH26vy3knpwP/hvjOHO/58cySL8ADC4=",
         "owner": "NixOS",
         "repo": "nix-eval-jobs",
-        "rev": "4b56d787e5add67e8f732365a60f590e3efdd5bc",
+        "rev": "a0cd02231c58974a6b5aaa3712069b071047162e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "v2.34.3",
+        "ref": "v2.35.0",
         "repo": "nix-eval-jobs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,13 @@
   inputs.nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
 
   inputs.nix = {
-    url = "github:NixOS/nix/2.34-maintenance";
+    url = "github:NixOS/nix/2.35-maintenance";
     # We want to control the deps precisely
     flake = false;
   };
 
   inputs.nix-eval-jobs = {
-    url = "github:NixOS/nix-eval-jobs/v2.34.3";
+    url = "github:NixOS/nix-eval-jobs/v2.35.0";
     # We want to control the deps precisely
     flake = false;
   };

--- a/subprojects/nix-perl/lib/Nix/Store.xs
+++ b/subprojects/nix-perl/lib/Nix/Store.xs
@@ -10,7 +10,7 @@
 #include "nix/store/realisation.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/store-open.hh"
-#include "nix/util/posix-source-accessor.hh"
+#include "nix/util/source-accessor.hh"
 #include <nlohmann/json.hpp>
 
 using namespace nix;
@@ -146,7 +146,7 @@ SV *
 StoreWrapper::queryRawRealisation(char * outputId)
     PPCODE:
       try {
-        auto realisation = THIS->store->queryRealisation(DrvOutput::parse(outputId));
+        auto realisation = THIS->store->queryRealisation(DrvOutput::parse(*THIS->store, outputId));
         if (realisation)
             XPUSHs(sv_2mortal(newSVpv(static_cast<nlohmann::json>(*realisation).dump().c_str(), 0)));
         else
@@ -235,7 +235,7 @@ StoreWrapper::addToStore(char * srcPath, int recursive, char * algo)
             auto method = recursive ? ContentAddressMethod::Raw::NixArchive : ContentAddressMethod::Raw::Flat;
             auto path = THIS->store->addToStore(
                 std::string(baseNameOf(srcPath)),
-                PosixSourceAccessor::createAtRoot(srcPath),
+                {makeFSSourceAccessor(absPath(srcPath)), CanonPath::root},
                 method, parseHashAlgo(algo));
             XPUSHs(sv_2mortal(newSVpv(THIS->store->printStorePath(path).c_str(), 0)));
         } catch (Error & e) {


### PR DESCRIPTION
Bump the nix input to the 2.35-maintenance branch (2.35.2) and nix-eval-jobs to v2.35.0. Adapt the vendored nix-perl bindings to the 2.35 API:

- `PosixSourceAccessor` was removed; use `makeFSSourceAccessor` with `CanonPath::root` in `addToStore`, matching upstream usage.
- `DrvOutput::parse` now requires a `StoreDirConfig` argument.

All tests pass, and all outputs build.