### PR TITLE
hydra-queue-runner: allow https uris for store

### DIFF
--- a/subprojects/hydra-queue-runner/src/config.rs
+++ b/subprojects/hydra-queue-runner/src/config.rs
@@ -357,6 +357,7 @@ impl TryFrom<AppConfig> for PreparedApp {
             .into_iter()
             .filter(|v| {
                 v.starts_with("file://")
+                    || v.starts_with("https://")
                     || v.starts_with("s3://")
                     || v.starts_with("ssh://")
                     || v.starts_with('/')

--- a/subprojects/hydra-queue-runner/src/config.rs
+++ b/subprojects/hydra-queue-runner/src/config.rs
@@ -329,6 +329,7 @@ impl TryFrom<AppConfig> for PreparedApp {
             .into_iter()
             .filter(|v| {
                 v.starts_with("file://")
+                    || v.starts_with("https://")
                     || v.starts_with("s3://")
                     || v.starts_with("ssh://")
                     || v.starts_with('/')


### PR DESCRIPTION
Otherwise uploads consistently fail because the URI is ignored.