### PR TITLE
hydra-builder: Add delimiter to features CLI arguments

### DIFF
--- a/subprojects/hydra-builder/src/config.rs
+++ b/subprojects/hydra-builder/src/config.rs
@@ -86,15 +86,15 @@ pub struct Cli {
     pub domain_name: Option<String>,
 
     /// List of supported systems, defaults to systems from nix and extra-platforms
-    #[clap(long, default_value = None)]
+    #[clap(long, value_delimiter = ' ', default_value = None)]
     pub systems: Option<Vec<String>>,
 
     /// List of supported features, defaults to configured system features
-    #[clap(long, default_value = None)]
+    #[clap(long, value_delimiter = ' ', default_value = None)]
     pub supported_features: Option<Vec<String>>,
 
     /// List of mandatory features
-    #[clap(long, default_value = None)]
+    #[clap(long, value_delimiter = ' ', default_value = None)]
     pub mandatory_features: Option<Vec<String>>,
 
     /// Use substitution over pulling inputs via queue runner


### PR DESCRIPTION
By default clap does not split arguments on spaces, populating a `Vec<T>` in an args structure requires multiuple instances of the argument. This is sort of inconvenient, so add a delimiter where clap will split.

Using a space here instead of comma as space matches the format in the Nix configuration file.