### PR TITLE
queue-runner: fix dynamic derivation scheduling and resolution

### DIFF
--- a/subprojects/hydra-queue-runner/src/state/drv.rs
+++ b/subprojects/hydra-queue-runner/src/state/drv.rs
@@ -22,6 +22,24 @@ impl OutputNameChain {
     }
 }
 
+/// Walk down the nesting of `sdp`, appending each output name onto `chain`.
+/// Descending visits outermost names first, so plain pushes produce
+/// [`OutputNameChain`]'s stack order.
+fn flatten_into(
+    mut sdp: &SingleDerivedPath,
+    mut chain: OutputNameChain,
+) -> (StorePath, OutputNameChain) {
+    loop {
+        match sdp {
+            SingleDerivedPath::Opaque(p) => return (p.clone(), chain),
+            SingleDerivedPath::Built { drv_path, output } => {
+                chain.0.push(output.clone());
+                sdp = drv_path;
+            }
+        }
+    }
+}
+
 /// Flatten a [`SingleDerivedPath`] into `(root_drv_path, chain)`.
 ///
 /// The output chain is in stack order (outermost first) matching
@@ -29,13 +47,10 @@ impl OutputNameChain {
 /// returns `(A, ["foo"])`. For `Opaque(A)`, returns `(A, [])`.
 #[must_use]
 pub fn flatten_path(sdp: &SingleDerivedPath) -> (StorePath, OutputNameChain) {
-    match sdp {
-        SingleDerivedPath::Opaque(p) => (p.clone(), OutputNameChain::default()),
-        SingleDerivedPath::Built { drv_path, output } => flatten_chain(drv_path, output),
-    }
+    flatten_into(sdp, OutputNameChain::default())
 }
 
-/// Like [`flatten_path`] but appends an additional output name.
+/// Like [`flatten_path`] but adds the outermost output name.
 ///
 /// For `Built { Opaque(A), "foo" }` with output `"bar"`,
 /// returns `(A, ["bar", "foo"])`.
@@ -44,9 +59,7 @@ pub fn flatten_chain(
     drv_path: &SingleDerivedPath,
     output_name: &OutputName,
 ) -> (StorePath, OutputNameChain) {
-    let (root, mut chain) = flatten_path(drv_path);
-    chain.0.push(output_name.clone());
-    (root, chain)
+    flatten_into(drv_path, OutputNameChain(vec![output_name.clone()]))
 }
 
 /// Extract `Built` input dependencies from a derivation.

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -1075,9 +1075,10 @@ impl State {
                 // original step's drv path differs from the resolved one, so
                 // completing the resolved step wouldn't clear the dep).
                 for rdep in step_info.step.clone_rdeps() {
-                    if let Some(rdep) = rdep.step.upgrade() {
-                        rdep.remove_dep(&step_info.step);
-                        resolved_step.make_rdep(&rdep);
+                    if let Some(dep_step) = rdep.step.upgrade() {
+                        dep_step.remove_dep(&step_info.step);
+                        // relation must survive the swap or pop_dynamic_rdeps never fires
+                        resolved_step.make_rdep_with_relation(&dep_step, rdep.relation);
                     }
                 }
 

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -999,7 +999,7 @@ impl State {
                 let resolved_step = match self
                     .create_step(
                         build.clone(),
-                        resolved_path,
+                        resolved_path.clone(),
                         referring_build,
                         None,
                         Arc::new(parking_lot::RwLock::new(HashSet::new())),
@@ -1009,9 +1009,41 @@ impl State {
                     .await
                 {
                     CreateStepResult::None => {
-                        return Err(StateError::from(
-                            ResolutionError::ResolvedStepCreationFailed,
-                        ));
+                        // The resolved derivation is already built, so no new
+                        // step will run. Finish the owning builds as cached and
+                        // wake dependents with the resolved outputs.
+                        let output = self.get_build_output_cached(&resolved_path).await?;
+                        let now = i32::try_from(jiff::Timestamp::now().as_second())?;
+                        let mut direct = step_info.step.get_direct_builds();
+                        direct.sort_by_key(|b| b.id);
+                        crate::utils::with_serialization_retry("cached_resolved_step", || async {
+                            let mut db = self.db.get().await?;
+                            let mut tx = db.begin_transaction().await?;
+                            for b in &direct {
+                                tx.mark_succeeded_build(
+                                    get_mark_build_sccuess_data(b, &output),
+                                    true,
+                                    now,
+                                    now,
+                                    self.connector.store_dir(),
+                                )
+                                .await?;
+                                tx.notify_build_finished(b.id, &[]).await?;
+                            }
+                            Ok(tx.commit().await?)
+                        })
+                        .await?;
+                        for b in &direct {
+                            self.metrics.nr_builds_done.inc();
+                            b.set_finished_in_db(true);
+                            self.builds.remove_by_id(b.id);
+                        }
+                        if direct.is_empty() {
+                            self.steps.remove(step_info.step.get_drv_path());
+                        }
+                        self.finish_step_rdeps(&step_info.step, &resolved_path, &output, &direct)
+                            .await?;
+                        return Ok(RealiseStepResult::Resolved);
                     }
                     CreateStepResult::Valid(step) => step,
                     CreateStepResult::PreviousFailure(step) => {
@@ -2081,10 +2113,22 @@ impl State {
             tx.commit().await?;
         }
 
-        // Process dynamic rdeps first, as we must add new step dependencies for dynamically
-        // generated derivations
+        self.finish_step_rdeps(&item.step_info.step, &drv_path, &output, &direct)
+            .await
+    }
+
+    /// Wake a finished step's reverse dependencies. Dynamic rdeps are
+    /// handled first so the generated derivations in `output` get steps
+    /// before `make_rdeps_runnable` runs.
+    async fn finish_step_rdeps(
+        &self,
+        step: &Arc<Step>,
+        drv_path: &StorePath,
+        output: &BuildOutput,
+        direct: &[Arc<Build>],
+    ) -> Result<(), StateError> {
         {
-            for (dep_step, output_name, relation) in item.step_info.step.pop_dynamic_rdeps() {
+            for (dep_step, output_name, relation) in step.pop_dynamic_rdeps() {
                 let Some(dependent_step) = dep_step.upgrade() else {
                     continue;
                 };
@@ -2104,9 +2148,7 @@ impl State {
                 } else {
                     let mut dependents = HashSet::new();
                     let mut visited_steps = HashSet::new();
-                    item.step_info
-                        .step
-                        .get_dependents(&mut dependents, &mut visited_steps);
+                    step.get_dependents(&mut dependents, &mut visited_steps);
                     let Some(b) = dependents.into_iter().next() else {
                         tracing::warn!("Finished step does not have associated build");
                         continue;
@@ -2153,7 +2195,7 @@ impl State {
                 dependent_step.add_dep_if_unfinished(new_step);
             }
         }
-        item.step_info.step.make_rdeps_runnable();
+        step.make_rdeps_runnable();
 
         // always trigger dispatch, as we now might have a free machine again
         self.trigger_dispatch();

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -791,6 +791,9 @@ pub enum ResolutionError {
     #[error("could not create resolved build step")]
     ResolvedStepCreationFailed,
 
+    #[error("no recorded output path for {drv}^{name}")]
+    MissingRecordedOutput { drv: StorePath, name: String },
+
     #[error("output path mismatch for output `{name}` of {drv}: expected {expected}, got {actual}")]
     OutputPathMismatch {
         name: String,
@@ -1019,7 +1022,7 @@ impl State {
                 let resolved_step = match self
                     .create_step(
                         build.clone(),
-                        resolved_path,
+                        resolved_path.clone(),
                         referring_build,
                         None,
                         Arc::new(parking_lot::RwLock::new(HashSet::new())),
@@ -1029,9 +1032,41 @@ impl State {
                     .await
                 {
                     CreateStepResult::None => {
-                        return Err(StateError::from(
-                            ResolutionError::ResolvedStepCreationFailed,
-                        ));
+                        // The resolved derivation is already built, so no new
+                        // step will run. Finish the owning builds as cached and
+                        // wake dependents with the resolved outputs.
+                        let output = self.get_build_output_cached(&resolved_path).await?;
+                        let now = i32::try_from(jiff::Timestamp::now().as_second())?;
+                        let mut direct = step_info.step.get_direct_builds();
+                        direct.sort_by_key(|b| b.id);
+                        crate::utils::with_serialization_retry("cached_resolved_step", || async {
+                            let mut db = self.db.get().await?;
+                            let mut tx = db.begin_transaction().await?;
+                            for b in &direct {
+                                tx.mark_succeeded_build(
+                                    get_mark_build_sccuess_data(b, &output),
+                                    true,
+                                    now,
+                                    now,
+                                    self.connector.store_dir(),
+                                )
+                                .await?;
+                                tx.notify_build_finished(b.id, &[]).await?;
+                            }
+                            Ok(tx.commit().await?)
+                        })
+                        .await?;
+                        for b in &direct {
+                            self.metrics.nr_builds_done.inc();
+                            b.set_finished_in_db(true);
+                            self.builds.remove_by_id(b.id);
+                        }
+                        if direct.is_empty() {
+                            self.steps.remove(step_info.step.get_drv_path());
+                        }
+                        self.finish_step_rdeps(&step_info.step, &resolved_path, &output, &direct)
+                            .await?;
+                        return Ok(RealiseStepResult::Resolved);
                     }
                     CreateStepResult::Valid(step) => step,
                     CreateStepResult::PreviousFailure(step) => {
@@ -2132,10 +2167,22 @@ impl State {
             tx.commit().await?;
         }
 
-        // Process dynamic rdeps first, as we must add new step dependencies for dynamically
-        // generated derivations
+        self.finish_step_rdeps(&item.step_info.step, drv_path, &output, &direct)
+            .await
+    }
+
+    /// Wake a finished step's reverse dependencies. Dynamic rdeps are
+    /// handled first so the generated derivations in `output` get steps
+    /// before `make_rdeps_runnable` runs.
+    async fn finish_step_rdeps(
+        &self,
+        step: &Arc<Step>,
+        drv_path: &StorePath,
+        output: &BuildOutput,
+        direct: &[Arc<Build>],
+    ) -> Result<(), StateError> {
         {
-            for (dep_step, output_name, relation) in item.step_info.step.pop_dynamic_rdeps() {
+            for (dep_step, output_name, relation) in step.pop_dynamic_rdeps() {
                 let Some(dependent_step) = dep_step.upgrade() else {
                     continue;
                 };
@@ -2155,9 +2202,7 @@ impl State {
                 } else {
                     let mut dependents = HashSet::new();
                     let mut visited_steps = HashSet::new();
-                    item.step_info
-                        .step
-                        .get_dependents(&mut dependents, &mut visited_steps);
+                    step.get_dependents(&mut dependents, &mut visited_steps);
                     let Some(b) = dependents.into_iter().next() else {
                         tracing::warn!("Finished step does not have associated build");
                         continue;
@@ -2204,7 +2249,7 @@ impl State {
                 dependent_step.add_dep_if_unfinished(new_step);
             }
         }
-        item.step_info.step.make_rdeps_runnable();
+        step.make_rdeps_runnable();
 
         // always trigger dispatch, as we now might have a free machine again
         self.trigger_dispatch();
@@ -3031,21 +3076,28 @@ impl State {
         self.observe_input_drvs(&drv);
 
         let use_substitutes = self.config.get_use_substitutes();
+        let known_outputs = self
+            .query_known_drv_outputs(drv_path)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("Could not query known outputs, continuing: {e}");
+                BTreeMap::new()
+            });
+        // A CA floating output has no path until built; recorded build steps are the only way to find it.
         let output_paths: BTreeMap<OutputName, Option<StorePath>> = drv
             .outputs
             .iter()
             .map(|(name, output)| {
-                (
-                    name.clone(),
-                    output
-                        .path(self.connector.store_dir(), &drv.name, name)
-                        .ok()
-                        .flatten(),
-                )
+                let path = output
+                    .path(self.connector.store_dir(), &drv.name, name)
+                    .ok()
+                    .flatten()
+                    .or_else(|| known_outputs.get(name).cloned());
+                (name.clone(), path)
             })
             .collect();
         let missing_local_outputs = self
-            .missing_local_outputs(build, drv_path, &output_paths, pool)
+            .missing_local_outputs(build, drv_path, &output_paths, &known_outputs, pool)
             .await;
 
         // Handle paths that aren't in the remote store (for pushing).
@@ -3180,15 +3232,9 @@ impl State {
         build: &Arc<Build>,
         drv_path: &StorePath,
         output_paths: &BTreeMap<OutputName, Option<StorePath>>,
+        known_outputs: &BTreeMap<OutputName, StorePath>,
         pool: &Arc<daemon_client_utils::DaemonConnPool>,
     ) -> BTreeMap<OutputName, Option<StorePath>> {
-        let known_outputs = self
-            .query_known_drv_outputs(drv_path)
-            .await
-            .unwrap_or_else(|e| {
-                tracing::warn!("Could not query known outputs, continuing: {e}");
-                BTreeMap::new()
-            });
         let mut conn = pool.acquire().await.ok();
         let mut missing = BTreeMap::new();
         for (name, path) in output_paths {
@@ -3411,19 +3457,33 @@ impl State {
     ) -> Result<BuildOutput, StateError> {
         let drv = self.read_derivation(drv_path).await?;
 
+        let known_outputs = self.query_known_drv_outputs(drv_path).await?;
         let output_paths: BTreeMap<OutputName, Option<StorePath>> = drv
             .outputs
             .iter()
             .map(|(name, output)| {
-                (
-                    name.clone(),
-                    output
-                        .path(self.connector.store_dir(), &drv.name, name)
-                        .ok()
-                        .flatten(),
-                )
+                let path = output
+                    .path(self.connector.store_dir(), &drv.name, name)
+                    .ok()
+                    .flatten()
+                    .or_else(|| known_outputs.get(name).cloned());
+                (name.clone(), path)
             })
             .collect();
+
+        // Finishing a build as cached writes these paths to buildoutputs, so a
+        // gap there would record NULL rather than fail loudly.
+        if let Some(name) = output_paths
+            .iter()
+            .find_map(|(n, p)| p.is_none().then_some(n))
+        {
+            return Err(ResolutionError::MissingRecordedOutput {
+                drv: drv_path.clone(),
+                name: name.to_string(),
+            }
+            .into());
+        }
+
         {
             let mut db = self.db.get().await?;
             for out_path in output_paths.values() {
@@ -3448,6 +3508,10 @@ impl State {
                     .get_build_metrics_for_build_id(build_id)
                     .await?
                     .into_iter()
+                    .collect();
+                res.outputs = output_paths
+                    .iter()
+                    .filter_map(|(name, path)| Some((name.clone(), path.clone()?)))
                     .collect();
 
                 return Ok(res);

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -1098,9 +1098,10 @@ impl State {
                 // original step's drv path differs from the resolved one, so
                 // completing the resolved step wouldn't clear the dep).
                 for rdep in step_info.step.clone_rdeps() {
-                    if let Some(rdep) = rdep.step.upgrade() {
-                        rdep.remove_dep(&step_info.step);
-                        resolved_step.make_rdep(&rdep);
+                    if let Some(dep_step) = rdep.step.upgrade() {
+                        dep_step.remove_dep(&step_info.step);
+                        // relation must survive the swap or pop_dynamic_rdeps never fires
+                        resolved_step.make_rdep_with_relation(&dep_step, rdep.relation);
                     }
                 }
 

--- a/subprojects/hydra-queue-runner/src/state/step.rs
+++ b/subprojects/hydra-queue-runner/src/state/step.rs
@@ -525,6 +525,20 @@ impl Step {
             .store(state.rdeps.len() as u64, Ordering::Relaxed);
     }
 
+    /// Like [`make_rdep`](Self::make_rdep), but records the given dynamic
+    /// output relation on the reverse dependency instead of an empty chain.
+    pub fn make_rdep_with_relation(self: &Arc<Self>, dep: &Arc<Self>, relation: OutputNameChain) {
+        dep.add_dep(self.clone());
+        let mut state = self.state.write();
+        state.rdeps.push(ReverseDep {
+            step: Arc::downgrade(dep),
+            relation,
+        });
+        self.atomic_state
+            .rdeps_len
+            .store(state.rdeps.len() as u64, Ordering::Relaxed);
+    }
+
     pub fn clone_rdeps(&self) -> Vec<ReverseDep> {
         let state = self.state.read();
         state.rdeps.clone()

--- a/subprojects/hydra-queue-runner/src/state/step.rs
+++ b/subprojects/hydra-queue-runner/src/state/step.rs
@@ -535,6 +535,20 @@ impl Step {
             .store(state.rdeps.len() as u64, Ordering::Relaxed);
     }
 
+    /// Like [`make_rdep`](Self::make_rdep), but records the given dynamic
+    /// output relation on the reverse dependency instead of an empty chain.
+    pub fn make_rdep_with_relation(self: &Arc<Self>, dep: &Arc<Self>, relation: OutputNameChain) {
+        dep.add_dep(self.clone());
+        let mut state = self.state.write();
+        state.rdeps.push(ReverseDep {
+            step: Arc::downgrade(dep),
+            relation,
+        });
+        self.atomic_state
+            .rdeps_len
+            .store(state.rdeps.len() as u64, Ordering::Relaxed);
+    }
+
     pub fn clone_rdeps(&self) -> Vec<ReverseDep> {
         let state = self.state.read();
         state.rdeps.clone()

--- a/subprojects/hydra-queue-runner/src/state/step_info.rs
+++ b/subprojects/hydra-queue-runner/src/state/step_info.rs
@@ -125,9 +125,15 @@ impl StepInfo {
                                         None
                                     })
                                     .or_else(|| resolve_from_drv_file(store_dir, &key.0, &key.1));
-                                memo.insert(key, r.clone());
+                                memo.insert(key.clone(), r.clone());
                                 r
                             };
+                            tracing::debug!(
+                                "chain hop: {current} -> {}!{} => {:?}",
+                                key.0,
+                                key.1,
+                                result.as_ref().map(ToString::to_string),
+                            );
                             current = result?;
                         }
                         Some(current)

--- a/subprojects/hydra-queue-runner/src/state/step_info.rs
+++ b/subprojects/hydra-queue-runner/src/state/step_info.rs
@@ -130,7 +130,7 @@ impl StepInfo {
                         result.or_else(|| {
                             let mut current = (*root).clone();
                             for output_name in outputs {
-                                current = rt
+                                let resolved = rt
                                     .block_on(conn.resolve_drv_output(
                                         store_dir,
                                         &current,
@@ -142,7 +142,12 @@ impl StepInfo {
                                     })
                                     .or_else(|| {
                                         resolve_from_drv_file(store_dir, &current, output_name)
-                                    })?;
+                                    });
+                                tracing::debug!(
+                                    "chain hop: {current}!{output_name} => {:?}",
+                                    resolved.as_ref().map(ToString::to_string),
+                                );
+                                current = resolved?;
                             }
                             Some(current)
                         })

--- a/subprojects/hydra-tests/content-addressed/early-cutoff-sequential.t
+++ b/subprojects/hydra-tests/content-addressed/early-cutoff-sequential.t
@@ -1,0 +1,47 @@
+use feature 'unicode_strings';
+use strict;
+use warnings;
+use Setup;
+
+my %ctx = test_init(
+    nix_config => qq|
+    experimental-features = ca-derivations
+    |,
+);
+
+use Test2::V0;
+
+my $db = $ctx{context}->db();
+
+my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+
+my $jobset = createBaseJobset($db, "content-addressed-early-cutoff", "content-addressed-early-cutoff.nix", $ctx{jobsdir});
+
+ok(evalSucceeds($ctx{context}, $jobset), "Evaluating early cutoff jobs should exit with return code 0");
+is(nrQueuedBuildsForJobset($jobset), 4, "Should queue 4 early cutoff builds");
+
+my %builds = map { $_->job => $_ } queuedBuildsForJobset($jobset);
+
+ok(runBuilds($ctx{context}, $builds{earlyCutoffUpstream1}, $builds{earlyCutoffDownstream1}),
+    "Building the first upstream/downstream pair should exit with code 0");
+ok(runBuilds($ctx{context}, $builds{earlyCutoffUpstream2}, $builds{earlyCutoffDownstream2}),
+    "Building the second upstream/downstream pair should exit with code 0");
+
+for my $job (sort keys %builds) {
+    my $build = $db->resultset('Builds')->find($builds{$job}->id);
+    is($build->finished, 1, "Build '$job' should be finished.");
+    is($build->buildstatus, 0, "Build '$job' should have buildstatus 0.");
+}
+
+my $downstream1 = $db->resultset('Builds')->find($builds{earlyCutoffDownstream1}->id);
+my $downstream2 = $db->resultset('Builds')->find($builds{earlyCutoffDownstream2}->id);
+
+my $downstream1_out = $downstream1->buildoutputs->find({ name => "out" });
+my $downstream2_out = $downstream2->buildoutputs->find({ name => "out" });
+is($downstream1_out->path, $downstream2_out->path,
+    "Both downstream builds should create the same content-addressed output path");
+
+ok(!$downstream1->iscachedbuild, "The first downstream build should not be cached");
+ok($downstream2->iscachedbuild, "The second downstream build should be cached");
+
+done_testing;


### PR DESCRIPTION
When trying to run nix-ninja jobs with dynamic derivation through the queue runner, I hit three bugs in the two-phase CA dance. Regular CA builds only ever produce depth-1 chains, so none of these paths had really been exercised before it seems.

- When a step resolves to a different drv path, the rdep migration used `make_rdep`, which records an empty `OutputNameChain`. As such, dynamic rdeps lost their relation, so `pop_dynamic_rdeps` found nothing when the resolved step finished and the generated derivation was never scheduled.
- `flatten_chain` pushed the outermost output name onto the pop end of the chain, so an input like `drv^out^hello` resolved outermost-first and asked the outer derivation for the inner one's output.
- A step whose resolved drv was already built errored with `ResolvedStepCreationFailed` and retried forever instead of finishing the build as cached. This is the early cutoff case the included test located at `early-cutoff-sequential.t` covers.


With these three bugs fixed, nix-ninja's example jobs build green end to end for me locally. The outer derivation runs nix-ninja inside the sandbox, the generated derivations get scheduled as real steps, and dependents resolve through the two-level chain!