### PR TITLE
NixNAR: cope with compress_num_threads being declared twice

### DIFF
--- a/subprojects/hydra-tests/Hydra/View/NixNAR.t
+++ b/subprojects/hydra-tests/Hydra/View/NixNAR.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Setup;
+
+use Hydra::View::NixNAR;
+
+use Test2::V0;
+
+subtest "numCompressThreads" => sub {
+    is(Hydra::View::NixNAR::numCompressThreads({}), 0,
+        "unset option means no explicit thread count");
+
+    is(Hydra::View::NixNAR::numCompressThreads({ compress_num_threads => 4 }), 4,
+        "a single declaration is used as-is");
+
+    is(Hydra::View::NixNAR::numCompressThreads({ compress_num_threads => [ 0, 4 ] }), 4,
+        "the last declaration wins when the option is declared twice");
+
+    is(Hydra::View::NixNAR::numCompressThreads({ compress_num_threads => "banana" }), 0,
+        "non-numeric values are dropped rather than spliced into the shell command");
+};
+
+done_testing;

--- a/subprojects/hydra/lib/Hydra/View/NixNAR.pm
+++ b/subprojects/hydra/lib/Hydra/View/NixNAR.pm
@@ -5,11 +5,25 @@ use warnings;
 use base qw/Catalyst::View/;
 use Hydra::Helper::CatalystUtils;
 
+# 'compress_num_threads' can be declared more than once in the
+# configuration, e.g. by the NixOS module (which always sets it) and
+# again by the user, in which case Config::General hands us an array
+# ref of all declarations.  Honor the last one.  Anything non-numeric
+# falls back to 0 (pixz decides): the value is spliced into a shell
+# command below, so it must never pass through unchecked.
+sub numCompressThreads {
+    my ($config) = @_;
+    my $numThreads = $config->{'compress_num_threads'} // 0;
+    $numThreads = $numThreads->[-1] if ref($numThreads) eq 'ARRAY';
+    return 0 unless $numThreads =~ /^[0-9]+$/;
+    return int($numThreads);
+}
+
 sub process {
     my ($self, $c) = @_;
 
     my $storePath  = $c->stash->{storePath};
-    my $numThreads = $c->config->{'compress_num_threads'};
+    my $numThreads = numCompressThreads($c->config);
     my $pParam     = ($numThreads > 0) ? "-p$numThreads" : "";
 
     $c->response->content_type('application/x-nix-archive'); # !!! check MIME type


### PR DESCRIPTION
Fixes #1389.

Config::General turns duplicate config keys into an array ref. The NixOS module always sets `compress_num_threads`, so setting it again in `extraConfig` ended up interpolating `ARRAY(0x...)` into the pixz command line and broke `/nar/` serving with a shell syntax error.

This takes the last declared value, and also refuses to pass anything non-numeric into the shell command. Added a small unit test for the new helper.