### PR TITLE
Update SQL readme to reflect laxer old schema snapshot rules

### DIFF
--- a/subprojects/hydra/sql/README.md
+++ b/subprojects/hydra/sql/README.md
@@ -8,17 +8,21 @@
 
 - `schemas/hydra-<n>.sql` — historical snapshot of `hydra.sql` at version N
 
+  This should include every historical schema but need not include the current one.
+
 - `schemas/commit-<n>.txt` — the git commit each snapshot was extracted from
+
+  This allows us to make sure the snapshots match the actual git history of `hydra.sql`.
 
 - `check-migrations.nix` — Nix derivations that test each migration step
 
 ## Making a schema change
 
-1. Update `hydra.sql` to reflect the desired end state.
+1. Copy the current `hydra.sql` to `schemas/hydra-<n-1>.sql`.
 
-2. Create `migrations/upgrade-<n>.sql` with the migration SQL.
+2. Update `hydra.sql` to reflect the desired end state.
 
-3. Copy `hydra.sql` to `schemas/hydra-<n>.sql`.
+3. Create `migrations/upgrade-<n>.sql` with the migration SQL.
 
 4. Run the migration check to verify:
 


### PR DESCRIPTION
Since db5596835b4b97ae328645c5aab1b7fefdb8ab8a, we don't need to snapshot the *current* schema, since we already have it. We just need to snapshot historical schemas. This makes the process of writing a new migration slightly less onerous: there is no need to keep a just-changed file and a copy in sync, whereas vendoring the old schema version is low-effort because by definition it should not be changing!