### PR TITLE
Add overflow caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "percent-encoding",
+ "quick-xml",
  "reqwest",
  "secrecy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ procfs = "0.18"
 procfs-core = "0.18"
 prometheus = { version = "0.14.0", default-features = false }
 prost = "0.14"
+quick-xml = { version = "0.39", features = [ "serialize" ] }
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = [
     "http2",

--- a/nixos-modules/queue-runner-module.nix
+++ b/nixos-modules/queue-runner-module.nix
@@ -141,6 +141,25 @@ in
               type = lib.types.bool;
               default = false;
             };
+            overflowStore = lib.mkOption {
+              description = "Overflow S3 store. Steps referenced only by the listed jobsets are uploaded there instead of the default store.";
+              default = null;
+              type = lib.types.nullOr (
+                lib.types.submodule {
+                  options = {
+                    store = lib.mkOption {
+                      description = "S3 store URI of the overflow bucket, e.g. `s3://overflow?region=eu-west-1`.";
+                      type = lib.types.singleLineStr;
+                    };
+                    jobsets = lib.mkOption {
+                      description = "Jobsets (`project:jobset`) whose exclusive steps go to the overflow store.";
+                      type = lib.types.listOf lib.types.singleLineStr;
+                      default = [ ];
+                    };
+                  };
+                }
+              );
+            };
             forcedSubstituters = lib.mkOption {
               description = "Force a list of substituters per builder. Builder will no longer be accepted if they don't have `useSubstitutes` with the substituters listed here.";
               type = lib.types.listOf lib.types.singleLineStr;

--- a/nixos-tests/default.nix
+++ b/nixos-tests/default.nix
@@ -32,6 +32,8 @@ in
     }
   );
 
+  s3-overflow = forEachSystem (system: import ./s3-overflow.nix { inherit system nixpkgs common; });
+
   validate-openapi = forEachSystem (
     system:
     let

--- a/nixos-tests/s3-overflow.nix
+++ b/nixos-tests/s3-overflow.nix
@@ -1,0 +1,270 @@
+{
+  system,
+  nixpkgs,
+  common,
+}:
+
+let
+  pkgs = nixpkgs.legacyPackages.${system};
+  inherit (pkgs) lib;
+
+  garagePort = 3900;
+  garageRpcPort = 3901;
+  garageAdminPort = 3902;
+
+  s3StoreUri = "s3://hydra-cache?compression=none&endpoint=http://s3:${toString garagePort}&region=garage&scheme=http&write-nar-listing=1";
+  overflowStoreUri = "s3://hydra-overflow?compression=none&endpoint=http://s3:${toString garagePort}&region=garage&scheme=http&write-nar-listing=1";
+
+  rpcSecret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+  trivialExpr = ''
+    builtins.derivation {
+      name = "trivial";
+      system = "${system}";
+      builder = "''${builtins.storePath "${pkgs.bash}"}/bin/bash";
+      PATH = "''${builtins.storePath "${pkgs.coreutils}"}/bin";
+      allowSubstitutes = false;
+      preferLocalBuild = true;
+      args = [
+        "-c"
+        "mkdir -p $out; echo hello > $out/greeting; exit 0"
+      ];
+    }
+  '';
+
+  jobFile = pkgs.writeText "default.nix" ''
+    {
+      trivial = ${trivialExpr};
+    }
+  '';
+
+  # trivial2 references trivial, which forces a copy from the overflow bucket to the default bucket.
+  jobFile2 = pkgs.writeText "default2.nix" ''
+    let
+      trivial = ${trivialExpr};
+    in {
+      trivial2 = builtins.derivation {
+        name = "trivial2";
+        system = "${system}";
+        builder = "''${builtins.storePath "${pkgs.bash}"}/bin/bash";
+        PATH = "''${builtins.storePath "${pkgs.coreutils}"}/bin";
+        inref = trivial;
+        allowSubstitutes = false;
+        preferLocalBuild = true;
+        args = [
+          "-c"
+          "mkdir -p $out; cp $inref/greeting $out/greeting; echo $inref > $out/ref; exit 0"
+        ];
+      };
+    }
+  '';
+in
+
+(import (nixpkgs + "/nixos/lib/testing-python.nix") { inherit system; }).makeTest {
+  name = "hydra-s3-overflow";
+
+  nodes.s3 =
+    { pkgs, ... }:
+    {
+      services.garage = {
+        enable = true;
+        package = pkgs.garage;
+        settings = {
+          replication_factor = 1;
+          db_engine = "sqlite";
+          rpc_bind_addr = "[::]:${toString garageRpcPort}";
+          rpc_secret = rpcSecret;
+          s3_api = {
+            s3_region = "garage";
+            api_bind_addr = "[::]:${toString garagePort}";
+            root_domain = ".s3.garage";
+          };
+          s3_web = {
+            bind_addr = "[::]:3903";
+            root_domain = ".web.garage";
+          };
+          admin.api_bind_addr = "[::]:${toString garageAdminPort}";
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [
+        garagePort
+        garageAdminPort
+      ];
+    };
+
+  nodes.server =
+    { pkgs, ... }:
+    {
+      imports = [ common.serverConfig ];
+
+      services.hydra-queue-runner-dev = {
+        settings.remoteStoreAddr = [ s3StoreUri ];
+        settings.usePresignedUploads = false;
+        settings.overflowStore = {
+          store = overflowStoreUri;
+          jobsets = [ "test:overflow" ];
+        };
+        awsCredentialsFile = "/var/lib/hydra/queue-runner/.aws-credentials";
+      };
+
+      environment.systemPackages = [ pkgs.jq ];
+    };
+
+  nodes.builder = {
+    imports = [ common.builderConfig ];
+    services.hydra-queue-builder-dev.useSubstitutes = lib.mkForce false;
+    nix.settings.substituters = lib.mkForce [ ];
+  };
+
+  skipLint = true;
+
+  testScript = ''
+    import json
+    import shlex
+
+    s3.start()
+    server.start()
+    builder.start()
+
+    s3.wait_for_unit("garage.service")
+    s3.wait_for_open_port(${toString garagePort})
+    s3.wait_for_open_port(${toString garageAdminPort})
+
+    node_id = s3.succeed("garage node id -q 2>/dev/null").strip()
+    short_id = node_id.split("@")[0][:16] if "@" in node_id else node_id[:16]
+
+    s3.succeed(f"garage layout assign {short_id} -z dc1 -c 1G")
+
+    version = s3.succeed(
+        "garage layout show | grep -oP 'apply --version \\K[0-9]+'"
+    ).strip()
+    s3.succeed(f"garage layout apply --version {version}")
+
+    s3.succeed("garage bucket create hydra-cache")
+    s3.succeed("garage bucket create hydra-overflow")
+
+    key_output = s3.succeed("garage key create hydra-key")
+    key_id = ""
+    key_secret = ""
+    for line in key_output.splitlines():
+        if "Key ID" in line:
+            key_id = line.split()[-1]
+        if "Secret key" in line:
+            key_secret = line.split()[-1]
+
+    for bucket in ("hydra-cache", "hydra-overflow"):
+        s3.succeed(
+            f"garage bucket allow {bucket} --read --write --owner --key {key_id}"
+        )
+
+    def s3_curl(bucket, key, extra=""):
+        return (
+            f"curl -sf http://s3:${toString garagePort}/{bucket}/{key}"
+            f" --aws-sigv4 'aws:amz:garage:s3' -u '{key_id}:{key_secret}' {extra}"
+        )
+
+    creds_path = "/var/lib/hydra/queue-runner/.aws-credentials"
+    server.wait_for_unit("hydra-init.service")
+    server.succeed(
+        f"mkdir -p /var/lib/hydra/queue-runner && "
+        f"printf '[default]\\naws_access_key_id = {key_id}\\naws_secret_access_key = {key_secret}\\n' > {creds_path} && "
+        f"chown hydra-queue-runner:hydra {creds_path} && "
+        f"chmod 600 {creds_path}"
+    )
+    server.succeed("systemctl restart hydra-queue-runner-dev.service")
+    server.wait_for_unit("hydra-queue-runner-dev.service")
+    builder.wait_for_unit("hydra-queue-builder-dev.service")
+
+    server.succeed(
+        'su - hydra -c "hydra-create-user root --email-address root@example.org --password foobar --role admin"'
+    )
+
+    server.wait_for_unit("hydra-server.service")
+    server.wait_for_open_port(3000)
+
+    URL = "http://localhost:3000"
+    cookie_jar = "/tmp/hydra-cookie.txt"
+
+    def mycurl(method, path, data=None):
+        cmd = f"curl --referer {shlex.quote(URL)} -H 'Accept: application/json' -H 'Content-Type: application/json'"
+        cmd += f" -X {method} {shlex.quote(URL + path)}"
+        cmd += f" -b {cookie_jar} -c {cookie_jar}"
+        if data:
+            cmd += f" -d {shlex.quote(json.dumps(data))}"
+        return server.succeed(cmd)
+
+    def make_jobset(name, job_file):
+        src = f"/run/jobset-{name}"
+        server.succeed(
+            f"mkdir -p {src} && cp {job_file} {src}/default.nix && "
+            f"chmod -R 755 {src} && chown -R hydra {src}"
+        )
+        mycurl("PUT", f"/jobset/test/{name}", {
+            "description": name,
+            "checkinterval": "0",
+            "enabled": "1",
+            "visible": "1",
+            "keepnr": "1",
+            "type": 0,
+            "nixexprinput": "src",
+            "nixexprpath": "default.nix",
+            "inputs": {"src": {"value": src, "type": "path"}},
+        })
+        mycurl("POST", f"/api/push?jobsets=test:{name}&force=1")
+
+    def wait_build(build_id):
+        server.wait_until_succeeds(
+            f'curl -sf {URL}/build/{build_id} -H "Accept: application/json"'
+            ' | jq -e ".finished == 1"',
+            timeout=180,
+        )
+        info = json.loads(
+            server.succeed(
+                f'curl -sf {URL}/build/{build_id} -H "Accept: application/json"'
+            )
+        )
+        assert info.get("buildstatus") == 0, f"build {build_id} failed: {info}"
+        return info
+
+    mycurl("POST", "/login", {"username": "root", "password": "foobar"})
+    mycurl("PUT", "/project/test", {
+        "displayname": "Test",
+        "enabled": "1",
+        "visible": "1",
+    })
+
+    # trivial from the overflow jobset must land in the overflow bucket only.
+    make_jobset("overflow", "${jobFile}")
+    build1 = wait_build(1)
+    trivial_hash = build1["buildoutputs"]["out"]["path"].split("/")[-1][:32]
+
+    server.wait_until_succeeds(
+        s3_curl("hydra-overflow", f"{trivial_hash}.narinfo"), timeout=60
+    )
+    server.fail(s3_curl("hydra-cache", f"{trivial_hash}.narinfo"))
+
+    # trivial2 references trivial, forcing a copy to the default bucket.
+    make_jobset("main", "${jobFile2}")
+    build2 = wait_build(2)
+    trivial2_hash = build2["buildoutputs"]["out"]["path"].split("/")[-1][:32]
+
+    server.wait_until_succeeds(
+        s3_curl("hydra-cache", f"{trivial2_hash}.narinfo"), timeout=60
+    )
+
+    # The copy brought trivial's NAR and listing along.
+    narinfo = server.succeed(s3_curl("hydra-cache", f"{trivial_hash}.narinfo"))
+    nar_url = next(
+        l.split(":", 1)[1].strip() for l in narinfo.splitlines() if l.startswith("URL:")
+    )
+    server.succeed(s3_curl("hydra-cache", nar_url, extra="-I"))
+    server.succeed(s3_curl("hydra-cache", f"{trivial_hash}.ls"))
+
+    server.fail(s3_curl("hydra-overflow", f"{trivial2_hash}.narinfo"))
+
+    builder.shutdown()
+    server.shutdown()
+    s3.shutdown()
+  '';
+}

--- a/subprojects/crates/binary-cache/Cargo.toml
+++ b/subprojects/crates/binary-cache/Cargo.toml
@@ -29,6 +29,7 @@ futures.workspace = true
 hashbrown.workspace = true
 object_store = { workspace = true, features = [ "aws" ] }
 parking_lot.workspace = true
+quick-xml.workspace = true
 reqwest.workspace = true
 secrecy.workspace = true
 serde.workspace = true

--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -36,7 +36,7 @@ mod presence_cache;
 mod presigned;
 mod streaming_hash;
 
-pub use crate::cfg::{S3CacheConfig, S3ClientConfig, S3CredentialsConfig, S3Scheme};
+pub use crate::cfg::{S3CacheConfig, S3ClientConfig, S3CredentialsConfig, S3Scheme, UrlParseError};
 pub use crate::compression::Compression;
 pub use crate::debug_info::get_debug_info_build_ids;
 pub use crate::multipart::{

--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -777,6 +777,58 @@ impl S3BinaryCacheClient {
         Ok(())
     }
 
+    /// Server-side copy of one object from `source` into this cache.
+    /// Requires the same endpoint and static credentials with read access to the source bucket.
+    /// Returns `false` if the source object does not exist.
+    #[tracing::instrument(skip(self, source), err)]
+    pub async fn copy_object_from(&self, source: &Self, key: &str) -> Result<bool, CacheError> {
+        let (Some(dst), Some(src)) = (&self.multipart, &source.multipart) else {
+            return Err(CacheError::ConfigurationError {
+                message: "copying between buckets requires static S3 credentials".to_owned(),
+            });
+        };
+        if !dst.same_endpoint(src) {
+            return Err(CacheError::ConfigurationError {
+                message: "copying between buckets requires both behind the same S3 endpoint"
+                    .to_owned(),
+            });
+        }
+
+        // HEAD via get_opts to learn size and content type/encoding without the body.
+        let head = match source
+            .s3
+            .get_opts(
+                &object_store::path::Path::from(key),
+                object_store::GetOptions {
+                    head: true,
+                    ..Default::default()
+                },
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(object_store::Error::NotFound { .. }) => return Ok(false),
+            Err(e) => return Err(CacheError::ObjectStore(e)),
+        };
+        source.s3_stats.head.fetch_add(1, Ordering::Relaxed);
+        let attr = |a: object_store::Attribute| {
+            head.attributes
+                .get(&a)
+                .map(|v| v.as_ref().to_owned())
+                .unwrap_or_default()
+        };
+
+        dst.copy_object_from(
+            src.bucket(),
+            key,
+            head.meta.size,
+            &attr(object_store::Attribute::ContentType),
+            &attr(object_store::Attribute::ContentEncoding),
+        )
+        .await?;
+        Ok(true)
+    }
+
     #[tracing::instrument(skip(self), err)]
     pub async fn download_narinfo(
         &self,

--- a/subprojects/crates/binary-cache/src/multipart.rs
+++ b/subprojects/crates/binary-cache/src/multipart.rs
@@ -354,11 +354,20 @@ impl MultipartPresigner {
             .await
             .map_err(|e| presign_err(key, e))?;
 
-        extract_upload_id(&body).ok_or_else(|| CacheError::PresignedUrlError {
-            path: key.to_owned(),
-            reason: "CreateMultipartUpload response did not contain an UploadId".to_owned(),
-        })
+        let result: InitiateMultipartUploadResult =
+            quick_xml::de::from_str(&body).map_err(|e| CacheError::PresignedUrlError {
+                path: key.to_owned(),
+                reason: format!("invalid CreateMultipartUpload response: {e}"),
+            })?;
+        Ok(result.upload_id)
     }
+}
+
+/// `CreateMultipartUpload` response body.
+#[derive(Debug, serde::Deserialize)]
+struct InitiateMultipartUploadResult {
+    #[serde(rename = "UploadId")]
+    upload_id: String,
 }
 
 fn signable_request<'a>(method: &'a str, url: &'a str) -> Result<SignableRequest<'a>, CacheError> {
@@ -415,14 +424,6 @@ fn complete_multipart_xml(parts: &[CompletedPart]) -> String {
     xml
 }
 
-/// Extract `<UploadId>` from the fixed-shape `CreateMultipartUpload` XML
-/// response, avoiding an XML-parser dependency.
-fn extract_upload_id(xml: &str) -> Option<String> {
-    let start = xml.find("<UploadId>")? + "<UploadId>".len();
-    let end = xml[start..].find("</UploadId>")? + start;
-    Some(xml[start..end].to_owned())
-}
-
 fn resolve_static_credentials(
     cfg: &S3ClientConfig,
 ) -> Result<(String, secrecy::SecretString), CacheError> {
@@ -472,8 +473,10 @@ mod tests {
     #[test]
     fn parses_upload_id() {
         let xml = r#"<?xml version="1.0"?><InitiateMultipartUploadResult><Bucket>b</Bucket><Key>k</Key><UploadId>abc123==</UploadId></InitiateMultipartUploadResult>"#;
-        assert_eq!(extract_upload_id(xml).as_deref(), Some("abc123=="));
-        assert_eq!(extract_upload_id("<nope/>"), None);
+        let result: InitiateMultipartUploadResult =
+            quick_xml::de::from_str(xml).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(result.upload_id, "abc123==");
+        assert!(quick_xml::de::from_str::<InitiateMultipartUploadResult>("<nope/>").is_err());
     }
 
     #[test]

--- a/subprojects/crates/binary-cache/src/multipart.rs
+++ b/subprojects/crates/binary-cache/src/multipart.rs
@@ -14,9 +14,11 @@ use std::time::{Duration, SystemTime};
 
 use aws_credential_types::Credentials;
 use aws_sigv4::http_request::{
-    SignableBody, SignableRequest, SignatureLocation, SigningSettings, sign,
+    PayloadChecksumKind, SignableBody, SignableRequest, SignatureLocation, SigningParams,
+    SigningSettings, sign,
 };
 use aws_sigv4::sign::v4;
+use aws_smithy_runtime_api::client::identity::Identity;
 use secrecy::ExposeSecret as _;
 
 use crate::CacheError;
@@ -24,6 +26,11 @@ use crate::cfg::{S3ClientConfig, S3Scheme};
 
 const MIN_PART_SIZE: u64 = 10 * 1024 * 1024;
 const MAX_PART_SIZE: u64 = 5 * 1024 * 1024 * 1024;
+/// Largest object a single server-side `CopyObject` may cover.
+/// Larger objects are copied with multipart `UploadPartCopy`.
+const MAX_COPY_OBJECT_SIZE: u64 = 5 * 1024 * 1024 * 1024;
+/// Source range covered by one `UploadPartCopy` request.
+const COPY_PART_SIZE: u64 = 1024 * 1024 * 1024;
 /// S3 allows at most 10 000 parts. Aim for 9000 so an incompressible NAR that
 /// zstd grows slightly still fits the presigned part count without a refill.
 const TARGET_MAX_PARTS: u64 = 9000;
@@ -164,6 +171,49 @@ impl MultipartPresigner {
         )
     }
 
+    fn signing_params<'a>(
+        &'a self,
+        identity: &'a Identity,
+        settings: SigningSettings,
+        url: &str,
+    ) -> Result<SigningParams<'a>, CacheError> {
+        Ok(v4::SigningParams::builder()
+            .identity(identity)
+            .region(&self.region)
+            .name("s3")
+            .time(SystemTime::now())
+            .settings(settings)
+            .build()
+            .map_err(|e| presign_err(url, e))?
+            .into())
+    }
+
+    // Returns (URL to sign, URL to send): raw query values for aws-sigv4 to
+    // encode, and the same encoding applied ourselves, so the two match.
+    fn query_urls(&self, key: &str, query: &[(&str, &str)]) -> (String, String) {
+        let object_url = self.object_url(key);
+        if query.is_empty() {
+            return (object_url.clone(), object_url);
+        }
+        let join = |encode: bool| {
+            query
+                .iter()
+                .map(|(k, v)| {
+                    if encode {
+                        format!("{k}={}", sigv4_encode(v))
+                    } else {
+                        format!("{k}={v}")
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("&")
+        };
+        (
+            format!("{object_url}?{}", join(false)),
+            format!("{object_url}?{}", join(true)),
+        )
+    }
+
     // Payload is signed as UNSIGNED-PAYLOAD so bodies can stream / be omitted.
     fn presign(
         &self,
@@ -176,17 +226,8 @@ impl MultipartPresigner {
         settings.signature_location = SignatureLocation::QueryParams;
         settings.expires_in = Some(expires);
 
-        let identity: aws_smithy_runtime_api::client::identity::Identity =
-            self.credentials.clone().into();
-        let signing_params: aws_sigv4::http_request::SigningParams = v4::SigningParams::builder()
-            .identity(&identity)
-            .region(&self.region)
-            .name("s3")
-            .time(SystemTime::now())
-            .settings(settings)
-            .build()
-            .map_err(|e| presign_err(url, e))?
-            .into();
+        let identity: Identity = self.credentials.clone().into();
+        let signing_params = self.signing_params(&identity, settings, url)?;
 
         // Sign with raw operation values; aws-sigv4 percent-encodes them for the
         // canonical request exactly as we do when building the final URL below.
@@ -221,6 +262,151 @@ impl MultipartPresigner {
             .collect::<Vec<_>>()
             .join("&");
         Ok(format!("{url}?{pairs}"))
+    }
+
+    /// Bucket this presigner writes to.
+    #[must_use]
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    /// Whether one signed request can address both buckets,
+    /// i.e. a server-side copy from `source` into this bucket is possible.
+    #[must_use]
+    pub fn same_endpoint(&self, source: &Self) -> bool {
+        self.host == source.host && self.scheme == source.scheme
+    }
+
+    /// Sign a request with header-based `SigV4` auth for the queue runner executes itself.
+    /// Returns extra plus signing headers to apply.
+    fn sign_headers(
+        &self,
+        method: &str,
+        url: &str,
+        extra_headers: &[(&str, String)],
+    ) -> Result<Vec<(String, String)>, CacheError> {
+        let mut settings = SigningSettings::default();
+        // S3 requires the payload checksum header for header-auth requests.
+        settings.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+
+        let identity: Identity = self.credentials.clone().into();
+        let signing_params = self.signing_params(&identity, settings, url)?;
+
+        let signable = SignableRequest::new(
+            method,
+            url,
+            extra_headers.iter().map(|(k, v)| (*k, v.as_str())),
+            SignableBody::UnsignedPayload,
+        )
+        .map_err(|e| presign_err(url, e))?;
+        let (instructions, _signature) = sign(signable, &signing_params)
+            .map_err(|e| presign_err(url, e))?
+            .into_parts();
+        let (signed, _params) = instructions.into_parts();
+
+        Ok(extra_headers
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), v.clone()))
+            .chain(
+                signed
+                    .into_iter()
+                    .map(|h| (h.name().to_owned(), h.value().to_owned())),
+            )
+            .collect())
+    }
+
+    /// Send a directly signed, empty-body S3 request and return the response body.
+    async fn send_signed(
+        &self,
+        method: reqwest::Method,
+        key: &str,
+        query: &[(&str, &str)],
+        extra_headers: &[(&str, String)],
+    ) -> Result<String, CacheError> {
+        let (url_for_signing, url_to_send) = self.query_urls(key, query);
+        let headers = self.sign_headers(method.as_str(), &url_for_signing, extra_headers)?;
+        let mut request = self.http_client.request(method, &url_to_send);
+        for (name, value) in headers {
+            request = request.header(name, value);
+        }
+        let body = request
+            .send()
+            .await
+            .map_err(|e| presign_err(key, e))?
+            .error_for_status()
+            .map_err(|e| presign_err(key, e))?
+            .text()
+            .await
+            .map_err(|e| presign_err(key, e))?;
+        // Copy operations may return 200 OK with an <Error> element in the body.
+        if let Ok(error) = quick_xml::de::from_str::<S3ErrorResponse>(&body) {
+            return Err(CacheError::Other(format!(
+                "S3 request for {key} failed: {} ({})",
+                error.message, error.code
+            )));
+        }
+        Ok(body)
+    }
+
+    /// Server-side copy of `key` from `source_bucket` (same endpoint) into this
+    /// bucket: `CopyObject`, or `UploadPartCopy` above the single-copy limit.
+    #[tracing::instrument(skip(self, content_type, content_encoding), err)]
+    pub async fn copy_object_from(
+        &self,
+        source_bucket: &str,
+        key: &str,
+        size: u64,
+        content_type: &str,
+        content_encoding: &str,
+    ) -> Result<(), CacheError> {
+        let copy_source = format!("/{source_bucket}/{key}");
+
+        if size <= MAX_COPY_OBJECT_SIZE {
+            self.send_signed(
+                reqwest::Method::PUT,
+                key,
+                &[],
+                &[("x-amz-copy-source", copy_source)],
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let upload_id = self
+            .initiate_upload(key, content_type, content_encoding)
+            .await?;
+        let mut parts = Vec::new();
+        let mut start = 0u64;
+        let mut part_number = 1u32;
+        while start < size {
+            let end = start.saturating_add(COPY_PART_SIZE).min(size) - 1;
+            let part_number_str = part_number.to_string();
+            let body = self
+                .send_signed(
+                    reqwest::Method::PUT,
+                    key,
+                    &[
+                        ("partNumber", part_number_str.as_str()),
+                        ("uploadId", upload_id.as_str()),
+                    ],
+                    &[
+                        ("x-amz-copy-source", copy_source.clone()),
+                        ("x-amz-copy-source-range", format!("bytes={start}-{end}")),
+                    ],
+                )
+                .await?;
+            let result: CopyResult = quick_xml::de::from_str(&body).map_err(|e| {
+                CacheError::Other(format!("invalid UploadPartCopy response for {key}: {e}"))
+            })?;
+            parts.push(CompletedPart {
+                part_number,
+                etag: result.etag,
+            });
+            start = end + 1;
+            part_number += 1;
+        }
+        self.complete(key, &upload_id, parts).await?;
+        Ok(())
     }
 
     /// Initiate a multipart upload and presign the part URLs the builder needs.
@@ -370,6 +556,22 @@ struct InitiateMultipartUploadResult {
     upload_id: String,
 }
 
+/// `CopyObjectResult` / `CopyPartResult` response body.
+#[derive(Debug, serde::Deserialize)]
+struct CopyResult {
+    #[serde(rename = "ETag")]
+    etag: String,
+}
+
+/// S3 `<Error>` body, which copy operations may return with a 200 status.
+#[derive(Debug, serde::Deserialize)]
+struct S3ErrorResponse {
+    #[serde(rename = "Code")]
+    code: String,
+    #[serde(rename = "Message", default)]
+    message: String,
+}
+
 fn signable_request<'a>(method: &'a str, url: &'a str) -> Result<SignableRequest<'a>, CacheError> {
     SignableRequest::new(
         method,
@@ -468,6 +670,29 @@ mod tests {
         assert_eq!(sigv4_encode("ab+cd/ef=gh"), "ab%2Bcd%2Fef%3Dgh");
         // Unreserved characters pass through untouched.
         assert_eq!(sigv4_encode("AZaz09-_.~"), "AZaz09-_.~");
+    }
+
+    #[test]
+    fn parses_copy_result() {
+        let xml = r"<CopyObjectResult><LastModified>t</LastModified><ETag>&quot;abc&quot;</ETag></CopyObjectResult>";
+        let result: CopyResult = quick_xml::de::from_str(xml).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(result.etag, "\"abc\"");
+        assert!(quick_xml::de::from_str::<CopyResult>("<nope/>").is_err());
+    }
+
+    #[test]
+    fn parses_error_response() {
+        let xml = r"<Error><Code>AccessDenied</Code><Message>nope</Message></Error>";
+        let error: S3ErrorResponse = quick_xml::de::from_str(xml).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(error.code, "AccessDenied");
+        assert_eq!(error.message, "nope");
+        // Copy results must not be mistaken for errors.
+        assert!(
+            quick_xml::de::from_str::<S3ErrorResponse>(
+                r"<CopyPartResult><ETag>x</ETag></CopyPartResult>"
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -1198,6 +1198,7 @@ struct GrpcMoreParts {
     build_id: String,
     machine_id: String,
     object_key: String,
+    bucket: Option<String>,
 }
 
 impl MorePartsSource for GrpcMoreParts {
@@ -1215,6 +1216,7 @@ impl MorePartsSource for GrpcMoreParts {
                 upload_id: upload_id.to_owned(),
                 start_part_number: start_part,
                 num_parts: count,
+                bucket: self.bucket.clone(),
             };
             let parts = self
                 .client
@@ -1322,6 +1324,7 @@ async fn upload_single_nar_presigned(
         build_id: build_id.to_owned(),
         machine_id: machine_id.to_owned(),
         object_key,
+        bucket: presigned_response.bucket.clone(),
     };
     let (updated_narinfo, completion, nar_already_present) = upload_client
         .process_presigned_request(store.store_dir(), narinfo, presigned_request, &more_parts)
@@ -1338,6 +1341,7 @@ async fn upload_single_nar_presigned(
         let completion_msg = hydra_proto::PresignedUploadComplete {
             build_id: build_id.to_owned(),
             machine_id: machine_id.to_owned(),
+            bucket: presigned_response.bucket.clone(),
             nar_info: Some((&updated_narinfo).into()),
             multipart: completion.map(|c| hydra_proto::MultipartCompletion {
                 object_key: c.key,

--- a/subprojects/hydra-manual/src/configuration.md
+++ b/subprojects/hydra-manual/src/configuration.md
@@ -131,6 +131,27 @@ $ hydra-queue-runner --prometheus-address 127.0.0.1:9198
 $ hydra-queue-runner --prometheus-address [::]:9198
 ```
 
+Overflow binary cache (optional)
+--------------------------------
+
+The queue runner can upload builds of selected jobsets to a separate "overflow"
+S3 bucket, for example to keep large staging rebuilds out of the main cache.
+A step is uploaded to the overflow bucket only when every jobset referencing it
+is listed. Shared steps go to the default bucket.
+
+Both buckets must live on the same S3
+endpoint and use static credentials: when a later build from a regular jobset
+needs outputs that only exist in the overflow bucket, the queue runner copies
+them back to the default bucket server-side instead of rebuilding.
+
+Configured in `queue-runner.toml`:
+
+```toml
+[overflowStore]
+store = "s3://hydra-overflow?region=eu-west-1"
+jobsets = ["nixpkgs:staging-next"]
+```
+
 Using LDAP as authentication backend (optional)
 -----------------------------------------------
 

--- a/subprojects/hydra-queue-runner/src/config.rs
+++ b/subprojects/hydra-queue-runner/src/config.rs
@@ -5,6 +5,9 @@ pub enum ConfigError {
     #[error("missing option: {0}")]
     MissingOption(&'static str),
 
+    #[error("invalid option: {0}")]
+    InvalidOption(&'static str),
+
     #[error("environment variable `{0}` is missing")]
     MissingEnvVar(&'static str),
 
@@ -166,6 +169,28 @@ pub enum StepSortFn {
     WithCriticalPath,
 }
 
+/// Overflow S3 store.
+/// Steps referenced only by the listed jobsets,
+/// upload there instead of the default store.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct OverflowStore {
+    pub store: String,
+    pub jobsets: Vec<String>,
+}
+
+impl OverflowStore {
+    fn validate(&self) -> Result<(), ConfigError> {
+        if !self.store.starts_with("s3://") {
+            return Err(ConfigError::InvalidOption(
+                "overflowStore.store must be an s3:// store URI",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Main configuration of the application
 #[derive(Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -256,6 +281,8 @@ struct AppConfig {
 
     #[serde(default)]
     forced_substituters: Vec<String>,
+
+    overflow_store: Option<OverflowStore>,
 }
 
 /// Prepared configuration of the application
@@ -290,6 +317,7 @@ pub struct PreparedApp {
     pub build_timeout: i32,
     pub max_log_size: u64,
     pub forced_substituters: Vec<String>,
+    pub overflow_store: Option<OverflowStore>,
 }
 
 impl TryFrom<AppConfig> for PreparedApp {
@@ -322,6 +350,10 @@ impl TryFrom<AppConfig> for PreparedApp {
 
         let hydra_log_dir = val.hydra_data_dir.join("build-logs");
         let lockfile = val.hydra_data_dir.join("queue-runner/lock");
+
+        if let Some(overflow) = &val.overflow_store {
+            overflow.validate()?;
+        }
 
         let token_list = val.token_paths.and_then(|l| {
             l.iter()
@@ -390,6 +422,7 @@ impl TryFrom<AppConfig> for PreparedApp {
             build_timeout: val.build_timeout,
             max_log_size: val.max_log_size,
             forced_substituters: val.forced_substituters,
+            overflow_store: val.overflow_store,
         })
     }
 }
@@ -596,6 +629,12 @@ impl App {
     pub fn get_forced_substituters(&self) -> Vec<String> {
         let inner = self.inner.load();
         inner.forced_substituters.clone()
+    }
+
+    #[must_use]
+    pub fn get_overflow_store(&self) -> Option<OverflowStore> {
+        let inner = self.inner.load();
+        inner.overflow_store.clone()
     }
 }
 

--- a/subprojects/hydra-queue-runner/src/main.rs
+++ b/subprojects/hydra-queue-runner/src/main.rs
@@ -43,6 +43,7 @@ fn start_task_loops(state: &std::sync::Arc<State>, cli: &Cli) -> Vec<tokio::task
         spawn_config_reloader(state.clone(), state.config.clone(), &cli.config_path),
         state.clone().start_dispatch_loop(),
         state.clone().start_uploader_queue(),
+        state.clone().start_copier_queue(),
         state.clone().start_upload_completion_loop(),
     ];
     if !cli.disable_queue_monitor_loop {

--- a/subprojects/hydra-queue-runner/src/server/grpc.rs
+++ b/subprojects/hydra-queue-runner/src/server/grpc.rs
@@ -41,6 +41,27 @@ fn multipart_to_proto(mp: binary_cache::PresignedMultipart) -> hydra_proto::Mult
     }
 }
 
+/// Overflow store when `bucket` matches it, default S3 store otherwise.
+fn select_upload_store(
+    state: &State,
+    bucket: Option<&str>,
+) -> Result<Box<binary_cache::S3BinaryCacheClient>, tonic::Status> {
+    if let Some(bucket) = bucket
+        && let Some(overflow) = state.overflow_store.read().clone()
+        && overflow.cfg.client_config.bucket == bucket
+    {
+        return Ok(Box::new((*overflow).clone()));
+    }
+    let remote_stores = state.remote_stores.read();
+    remote_stores
+        .iter()
+        .find_map(|s| match s {
+            crate::state::RemoteStoreBackend::S3(s) => Some(s.clone()),
+            crate::state::RemoteStoreBackend::NixCopy(_) => None,
+        })
+        .ok_or_else(|| tonic::Status::failed_precondition("No remote store configured"))
+}
+
 type BuilderResult<T> = Result<tonic::Response<T>, tonic::Status>;
 type OpenTunnelResponseStream =
     std::pin::Pin<Box<dyn futures::Stream<Item = Result<RunnerRequest, tonic::Status>> + Send>>;
@@ -639,20 +660,25 @@ impl RunnerService for Server {
             .machines
             .get_machine_by_id(machine_id)
             .ok_or_else(|| tonic::Status::not_found("Machine not found"))?;
-        machine
+        let drv_path = machine
             .get_job_drv_for_build_id(build_id)
             .ok_or_else(|| tonic::Status::not_found("Job not found for this build_id"))?;
 
-        let remote_store = {
-            let remote_stores = state.remote_stores.read();
-            remote_stores
-                .iter()
-                .find_map(|s| match s {
-                    crate::state::RemoteStoreBackend::S3(s) => Some(s.clone()),
-                    crate::state::RemoteStoreBackend::NixCopy(_) => None,
-                })
-                .ok_or_else(|| tonic::Status::failed_precondition("No remote store configured"))?
+        // Overflow-only steps upload to the overflow store.
+        let bucket = if state
+            .steps
+            .get(&drv_path)
+            .is_some_and(|s| state.step_wants_overflow(&s))
+        {
+            state
+                .overflow_store
+                .read()
+                .as_ref()
+                .map(|o| o.cfg.client_config.bucket.clone())
+        } else {
+            None
         };
+        let remote_store = select_upload_store(&state, bucket.as_deref())?;
 
         let requests = req
             .request
@@ -700,6 +726,7 @@ impl RunnerService for Server {
                 })?;
 
             responses.push(hydra_proto::PresignedNarResponse {
+                bucket: bucket.clone(),
                 store_path: store_path.to_string(),
                 nar_url: presigned_response.nar_url,
                 nar_upload: Some(hydra_proto::PresignedUpload {
@@ -761,16 +788,7 @@ impl RunnerService for Server {
             ));
         }
 
-        let remote_store = {
-            let remote_stores = self.state.remote_stores.read();
-            remote_stores
-                .iter()
-                .find_map(|s| match s {
-                    crate::state::RemoteStoreBackend::S3(s) => Some(s.clone()),
-                    crate::state::RemoteStoreBackend::NixCopy(_) => None,
-                })
-                .ok_or_else(|| tonic::Status::failed_precondition("No remote store configured"))?
-        };
+        let remote_store = select_upload_store(&self.state, req.bucket.as_deref())?;
 
         let parts = remote_store
             .presign_more_multipart_parts(
@@ -827,16 +845,7 @@ impl RunnerService for Server {
             .get_job_drv_for_build_id(build_id)
             .ok_or_else(|| tonic::Status::not_found("Job not found for this build_id"))?;
 
-        let remote_store = {
-            let remote_stores = state.remote_stores.read();
-            remote_stores
-                .iter()
-                .find_map(|s| match s {
-                    crate::state::RemoteStoreBackend::S3(s) => Some(s.clone()),
-                    crate::state::RemoteStoreBackend::NixCopy(_) => None,
-                })
-                .ok_or_else(|| tonic::Status::failed_precondition("No remote store configured"))?
-        };
+        let remote_store = select_upload_store(&state, req.bucket.as_deref())?;
 
         let proto_nar_info = req
             .nar_info

--- a/subprojects/hydra-queue-runner/src/state/metrics.rs
+++ b/subprojects/hydra-queue-runner/src/state/metrics.rs
@@ -54,6 +54,9 @@ pub struct PromMetrics {
     pub machines_total: prometheus::IntGauge,              // hydraqueuerunner_machines_total
     pub machines_in_use: prometheus::IntGauge,             // hydraqueuerunner_machines_in_use
     pub s3_uploads_pending: prometheus::IntGauge,          // hydraqueuerunner_s3_uploads_pending
+    pub nr_overflow_copies_queued: prometheus::IntCounter, // hydraqueuerunner_overflow_copies_queued
+    pub nr_overflow_copies_succeeded: prometheus::IntCounter, // hydraqueuerunner_overflow_copies_succeeded
+    pub nr_overflow_copies_failed: prometheus::IntCounter, // hydraqueuerunner_overflow_copies_failed
 
     // Per-machine-type metrics
     pub runnable_per_machine_type: prometheus::IntGaugeVec, // hydraqueuerunner_machine_type_runnable
@@ -302,6 +305,19 @@ impl PromMetrics {
         let s3_uploads_pending = prometheus::IntGauge::with_opts(prometheus::Opts::new(
             "hydraqueuerunner_s3_uploads_pending",
             "Pending upload count to all remote stores.",
+        ))?;
+        let nr_overflow_copies_queued = prometheus::IntCounter::with_opts(prometheus::Opts::new(
+            "hydraqueuerunner_overflow_copies_queued_total",
+            "Copies from the overflow store to the default store queued",
+        ))?;
+        let nr_overflow_copies_succeeded =
+            prometheus::IntCounter::with_opts(prometheus::Opts::new(
+                "hydraqueuerunner_overflow_copies_succeeded_total",
+                "Copies from the overflow store to the default store that succeeded",
+            ))?;
+        let nr_overflow_copies_failed = prometheus::IntCounter::with_opts(prometheus::Opts::new(
+            "hydraqueuerunner_overflow_copies_failed_total",
+            "Copies from the overflow store to the default store that failed",
         ))?;
 
         // Per-machine-type metrics
@@ -675,6 +691,9 @@ impl PromMetrics {
         r.register(Box::new(machines_total.clone()))?;
         r.register(Box::new(machines_in_use.clone()))?;
         r.register(Box::new(s3_uploads_pending.clone()))?;
+        r.register(Box::new(nr_overflow_copies_queued.clone()))?;
+        r.register(Box::new(nr_overflow_copies_succeeded.clone()))?;
+        r.register(Box::new(nr_overflow_copies_failed.clone()))?;
 
         // Per-machine-type metrics
         r.register(Box::new(runnable_per_machine_type.clone()))?;
@@ -786,6 +805,9 @@ impl PromMetrics {
             machines_total,
             machines_in_use,
             s3_uploads_pending,
+            nr_overflow_copies_queued,
+            nr_overflow_copies_succeeded,
+            nr_overflow_copies_failed,
 
             // Per-machine-type metrics
             runnable_per_machine_type,

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -193,6 +193,9 @@ enum OutputAvailability {
     /// missing there. The step must not count as finished before the upload
     /// completed.
     PendingUpload(Vec<StorePath>),
+    /// All outputs are in the overflow store but missing from the default
+    /// store. The step must not count as finished before the copy completed.
+    PendingCopy(Vec<StorePath>),
     /// Outputs are missing; the step has to be built.
     Incomplete,
 }
@@ -211,6 +214,8 @@ enum AttachOutcome {
     /// Created but gated: the caller must schedule an upload of these paths
     /// and finish the step via [`complete_step`] once it is done.
     PendingUpload(Vec<StorePath>),
+    /// Created but gated on a copy from the overflow store.
+    PendingCopy(Vec<StorePath>),
     Attached,
 }
 
@@ -246,6 +251,10 @@ fn attach_step(
             // wait for the upload before they may be dispatched.
             step.atomic_state.set_created(true);
             AttachOutcome::PendingUpload(paths)
+        }
+        OutputAvailability::PendingCopy(paths) => {
+            step.atomic_state.set_created(true);
+            AttachOutcome::PendingCopy(paths)
         }
         OutputAvailability::Incomplete => {
             for dep in deps {
@@ -1697,6 +1706,26 @@ impl State {
         task.abort_handle()
     }
 
+    /// Process queued copies from the overflow store to the default store.
+    #[tracing::instrument(skip(self))]
+    pub fn start_copier_queue(self: Arc<Self>) -> tokio::task::AbortHandle {
+        let task = tokio::task::spawn(async move {
+            loop {
+                let overflow = self.overflow_store.read().clone();
+                let (Some(source), Some(dest)) = (overflow, self.first_s3_remote_store()) else {
+                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                    continue;
+                };
+                match self.uploader.copy_once(&source, &dest).await {
+                    Some(true) => self.metrics.nr_overflow_copies_succeeded.inc(),
+                    Some(false) => self.metrics.nr_overflow_copies_failed.inc(),
+                    None => {}
+                }
+            }
+        });
+        task.abort_handle()
+    }
+
     /// Process upload completions for steps gated on
     /// [`OutputAvailability::PendingUpload`]: only once their outputs exist
     /// in the remote binary cache that builders fetch inputs from may the
@@ -2901,6 +2930,35 @@ impl State {
                 ctx.finished_drvs.write().insert(drv_path.clone());
                 CreateStepResult::None
             }
+            AttachOutcome::PendingCopy(paths) => {
+                tracing::info!(
+                    "create_step: {drv_path} outputs in overflow store, awaiting copy to default store"
+                );
+                step.try_mark_upload_scheduled();
+                let realisation_keys = step
+                    .get_output_paths()
+                    .unwrap_or_default()
+                    .into_keys()
+                    .map(|output_name| {
+                        let id = DrvOutput {
+                            drv_path: drv_path.clone(),
+                            output_name,
+                        };
+                        format!("realisations/{id}.doi")
+                    })
+                    .collect();
+                self.metrics.nr_overflow_copies_queued.inc();
+                self.uploader
+                    .schedule_copy(
+                        paths,
+                        format!("log/{drv_path}"),
+                        realisation_keys,
+                        Some(drv_path.clone()),
+                    )
+                    .await;
+                new_steps.write().insert(step.clone());
+                CreateStepResult::Valid(step)
+            }
             AttachOutcome::PendingUpload(paths) => {
                 tracing::info!(
                     "create_step: {drv_path} outputs valid locally, awaiting upload to remote store"
@@ -3013,14 +3071,30 @@ impl State {
 
         // Handle paths that aren't in the remote store (for pushing).
         let mut pending_upload: Option<Vec<StorePath>> = None;
+        let mut pending_copy: Option<Vec<StorePath>> = None;
         let missing_outputs = match self
             .query_missing_remote_outputs(output_paths.clone())
             .await
         {
             Some(mut missing) => {
-                if !missing.is_empty() && missing_local_outputs.is_empty() {
-                    // We have all paths locally, so we can just upload them to
-                    // the remote store.
+                if !missing.is_empty()
+                    && !missing_local_outputs.is_empty()
+                    && let Some(present) = self.outputs_present_in_overflow(&missing).await
+                {
+                    // Only the overflow store has the outputs.
+                    // Overflow jobsets use them as is.
+                    // Anything else waits for a copy to the default store instead of rebuilding.
+                    let overflow_jobsets = self
+                        .config
+                        .get_overflow_store()
+                        .map(|o| o.jobsets)
+                        .unwrap_or_default();
+                    if !overflow_jobsets.contains(&build.jobset.full_name()) {
+                        pending_copy = Some(present);
+                    }
+                    missing.clear();
+                } else if !missing.is_empty() && missing_local_outputs.is_empty() {
+                    // We have all paths locally, so we can just upload them to the remote store.
                     let missing_paths: Vec<StorePath> =
                         missing.values().filter_map(Clone::clone).collect();
                     if self.config.use_presigned_uploads() {
@@ -3089,7 +3163,9 @@ impl State {
             missing_outputs.is_empty()
         };
 
-        let availability = if let Some(paths) = pending_upload {
+        let availability = if let Some(paths) = pending_copy {
+            OutputAvailability::PendingCopy(paths)
+        } else if let Some(paths) = pending_upload {
             OutputAvailability::PendingUpload(paths)
         } else if finished {
             OutputAvailability::Complete
@@ -3254,6 +3330,21 @@ impl State {
         !jobsets.is_empty() && step.wants_overflow(&jobsets)
     }
 
+    /// All of `missing`'s paths if the overflow store has every one of them,
+    /// `None` otherwise.
+    async fn outputs_present_in_overflow(
+        &self,
+        missing: &BTreeMap<OutputName, Option<StorePath>>,
+    ) -> Option<Vec<StorePath>> {
+        let overflow = self.overflow_store.read().clone()?;
+        if missing.values().any(Option::is_none) {
+            return None;
+        }
+        let paths: Vec<StorePath> = missing.values().flatten().cloned().collect();
+        let still_missing = overflow.query_missing_paths(paths.clone()).await;
+        still_missing.is_empty().then_some(paths)
+    }
+
     /// Returns the subset of `output_paths` missing from the binary cache, or
     /// `None` when no S3 store is configured.
     ///
@@ -3391,12 +3482,27 @@ impl State {
         // disk). Fall back to the local store only when no S3 cache is
         // configured.
         let build_output = if let Some(store) = self.first_s3_remote_store() {
-            Box::pin(cached_output::build_output_from_cache(
+            let overflow = self.overflow_store.read().clone();
+            let from_default = Box::pin(cached_output::build_output_from_cache(
                 &store,
                 self.connector.store_dir(),
                 &output_paths,
             ))
-            .await?
+            .await;
+            match (from_default, overflow) {
+                (Ok(v), _) => v,
+                (Err(e), None) => return Err(e.into()),
+                // Outputs of overflow-only builds may exist only in the
+                // overflow store.
+                (Err(_), Some(overflow)) => {
+                    Box::pin(cached_output::build_output_from_cache(
+                        &overflow,
+                        self.connector.store_dir(),
+                        &output_paths,
+                    ))
+                    .await?
+                }
+            }
         } else {
             let default_store: std::path::PathBuf = self.connector.store_dir().to_string().into();
             let real_dir = self.real_store_dir.as_deref().unwrap_or(&default_store);

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -1680,14 +1680,15 @@ impl State {
                             })
                             .collect()
                     };
+                    let overflow_store = self.overflow_store.read().as_deref().cloned();
                     let limit = self.config.get_concurrent_upload_limit();
                     if limit < 2 {
                         self.uploader
-                            .upload_once(store, local_store, s3_stores)
+                            .upload_once(store, local_store, s3_stores, overflow_store)
                             .await;
                     } else {
                         self.uploader
-                            .upload_many(store, local_store, s3_stores, limit)
+                            .upload_many(store, local_store, s3_stores, overflow_store, limit)
                             .await;
                     }
                 }
@@ -2016,6 +2017,7 @@ impl State {
                         outputs_to_upload,
                         format!("log/{}", job.path),
                         job.result.log_file.clone(),
+                        self.step_wants_overflow(&item.step_info.step),
                         None,
                     )
                     .await;
@@ -2033,15 +2035,24 @@ impl State {
         {
             let has_ca_floating = item.step_info.step.has_ca_floating_outputs();
             if has_ca_floating {
-                let s3_stores: Vec<binary_cache::S3BinaryCacheClient> = {
-                    let r = self.remote_stores.read();
-                    r.iter()
-                        .filter_map(|s| match s {
-                            RemoteStoreBackend::S3(s) => Some((**s).clone()),
-                            RemoteStoreBackend::NixCopy(_) => None,
-                        })
-                        .collect()
-                };
+                // Overflow-only steps write their realisations to the overflow store.
+                let s3_stores: Vec<binary_cache::S3BinaryCacheClient> =
+                    if self.step_wants_overflow(&item.step_info.step) {
+                        self.overflow_store
+                            .read()
+                            .as_deref()
+                            .cloned()
+                            .into_iter()
+                            .collect()
+                    } else {
+                        let r = self.remote_stores.read();
+                        r.iter()
+                            .filter_map(|s| match s {
+                                RemoteStoreBackend::S3(s) => Some((**s).clone()),
+                                RemoteStoreBackend::NixCopy(_) => None,
+                            })
+                            .collect()
+                    };
                 for (output_name, out_path) in &output.outputs {
                     let realisation = Realisation {
                         key: DrvOutput {
@@ -2901,6 +2912,7 @@ impl State {
                         paths,
                         format!("log/{drv_path}"),
                         log_file,
+                        self.step_wants_overflow(&step),
                         Some(drv_path.clone()),
                     )
                     .await;
@@ -2938,6 +2950,7 @@ impl State {
                         paths,
                         format!("log/{drv_path}"),
                         log_file,
+                        self.step_wants_overflow(&step),
                         gated.then(|| drv_path.clone()),
                     )
                     .await;
@@ -3020,12 +3033,17 @@ impl State {
                         // Builders import inputs from the queue runner's local
                         // Local validity is enough; the upload only fills
                         // the cache.
+                        let use_overflow = self
+                            .config
+                            .get_overflow_store()
+                            .is_some_and(|o| o.jobsets.contains(&build.jobset.full_name()));
                         let log_file = self.construct_log_file_path(drv_path).await;
                         self.uploader
                             .schedule_upload(
                                 missing_paths,
                                 format!("log/{drv_path}"),
                                 log_file,
+                                use_overflow,
                                 None,
                             )
                             .await;
@@ -3224,6 +3242,16 @@ impl State {
             RemoteStoreBackend::S3(s) => Some((**s).clone()),
             RemoteStoreBackend::NixCopy(_) => None,
         })
+    }
+
+    /// Whether this step's uploads go to the overflow store.
+    pub fn step_wants_overflow(&self, step: &Step) -> bool {
+        let jobsets = self
+            .config
+            .get_overflow_store()
+            .map(|o| o.jobsets)
+            .unwrap_or_default();
+        !jobsets.is_empty() && step.wants_overflow(&jobsets)
     }
 
     /// Returns the subset of `output_paths` missing from the binary cache, or

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -45,6 +45,9 @@ pub enum StateError {
     #[error("binary cache error")]
     Cache(#[from] binary_cache::CacheError),
 
+    #[error("invalid overflow store URI")]
+    OverflowStoreUri(#[from] binary_cache::UrlParseError),
+
     #[error("integer conversion error")]
     IntConversion(#[from] std::num::TryFromIntError),
 
@@ -290,12 +293,34 @@ fn presence_cache_file(uri: &str) -> String {
     format!("narinfo-presence-{digest:x}.db")
 }
 
+/// Build the S3 client for the configured overflow store, if any.
+async fn new_overflow_store(
+    overflow: Option<&crate::config::OverflowStore>,
+    presence_cache_dir: &std::path::Path,
+) -> Result<Option<Arc<binary_cache::S3BinaryCacheClient>>, StateError> {
+    let Some(overflow) = overflow else {
+        return Ok(None);
+    };
+    let cfg = overflow
+        .store
+        .parse::<binary_cache::S3CacheConfig>()?
+        .with_presence_cache(
+            Some(presence_cache_dir.join(presence_cache_file(&overflow.store))),
+            None,
+        );
+    Ok(Some(Arc::new(
+        binary_cache::S3BinaryCacheClient::new(cfg).await?,
+    )))
+}
+
 #[allow(missing_debug_implementations)]
 pub struct State {
     pub connector: daemon_client_utils::DaemonConnector,
     /// Reads store validity and path info through the nix-daemon.
     pub store: daemon_client_utils::DaemonStoreReader,
     pub remote_stores: parking_lot::RwLock<Vec<RemoteStoreBackend>>,
+    /// Overflow S3 store for steps only referenced by the configured jobsets.
+    pub overflow_store: parking_lot::RwLock<Option<Arc<binary_cache::S3BinaryCacheClient>>>,
     pub config: App,
     pub mtls: MtlsConfig,
     pub db: db::Database,
@@ -424,6 +449,9 @@ impl State {
             }
         }
 
+        let overflow_store =
+            new_overflow_store(config.get_overflow_store().as_ref(), &presence_cache_dir).await?;
+
         let fod_checker = if config.get_enable_fod_checker() {
             Some(Arc::new(FodChecker::new(connector.clone(), None)))
         } else {
@@ -438,6 +466,7 @@ impl State {
             connector,
             store,
             remote_stores: parking_lot::RwLock::new(remote_stores),
+            overflow_store: parking_lot::RwLock::new(overflow_store),
             mtls,
             db,
             machines: Machines::new(),
@@ -511,6 +540,12 @@ impl State {
         }
         if curr_remote_stores != new_config.remote_store_addr {
             *self.remote_stores.write() = new_remote_stores;
+        }
+
+        if self.config.get_overflow_store() != new_config.overflow_store {
+            let overflow_store =
+                new_overflow_store(new_config.overflow_store.as_ref(), &presence_cache_dir).await?;
+            *self.overflow_store.write() = overflow_store;
         }
 
         if curr_enable_fod_checker != new_config.enable_fod_checker {

--- a/subprojects/hydra-queue-runner/src/state/step.rs
+++ b/subprojects/hydra-queue-runner/src/state/step.rs
@@ -470,6 +470,16 @@ impl Step {
             .unwrap_or(1e9)
     }
 
+    /// True if all of this step's jobsets (at least one) are in `overflow_jobsets` (`project:jobset` names).
+    pub fn wants_overflow(&self, overflow_jobsets: &[String]) -> bool {
+        let state = self.state.read();
+        !state.jobsets.is_empty()
+            && state
+                .jobsets
+                .iter()
+                .all(|j| overflow_jobsets.contains(&j.full_name()))
+    }
+
     pub fn add_jobset(&self, jobset: Arc<Jobset>) {
         let mut state = self.state.write();
         state.jobsets.insert(jobset);

--- a/subprojects/hydra-queue-runner/src/state/uploader.rs
+++ b/subprojects/hydra-queue-runner/src/state/uploader.rs
@@ -2,7 +2,40 @@ use std::sync::Arc;
 
 use backon::ExponentialBuilder;
 use backon::Retryable as _;
+use harmonia_file_core::{FileSystemObject, FileTree};
 use harmonia_store_path::StorePath;
+
+/// Build ids under `lib/debug/.build-id/<xx>/<rest>.debug` in a NAR listing,
+/// as `<xx><rest>`, matching the `debuginfo/<build-id>` object keys.
+fn listing_debug_build_ids<C>(tree: &FileTree<C>) -> Vec<String> {
+    fn dir<'a, C>(tree: &'a FileTree<C>, name: &str) -> Option<&'a FileTree<C>> {
+        match &tree.0 {
+            FileSystemObject::Directory(d) => d.entries.get(name).map(AsRef::as_ref),
+            _ => None,
+        }
+    }
+    let Some(build_id_dir) = dir(tree, "lib")
+        .and_then(|t| dir(t, "debug"))
+        .and_then(|t| dir(t, ".build-id"))
+    else {
+        return Vec::new();
+    };
+    let FileSystemObject::Directory(prefixes) = &build_id_dir.0 else {
+        return Vec::new();
+    };
+    let mut ids = Vec::new();
+    for (prefix, entry) in &prefixes.entries {
+        let FileSystemObject::Directory(files) = &entry.as_ref().0 else {
+            continue;
+        };
+        for name in files.entries.keys() {
+            if let Some(rest) = name.strip_suffix(".debug") {
+                ids.push(format!("{prefix}{rest}"));
+            }
+        }
+    }
+    ids
+}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum UploaderError {
@@ -38,13 +71,27 @@ struct Message {
     notify_drv: Option<StorePath>,
 }
 
+/// Copy of a closure from the overflow store into the default store.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct CopyMessage {
+    store_paths: Vec<StorePath>,
+    log_remote_path: String,
+    /// Realisation object keys to copy alongside, best effort.
+    realisation_keys: Vec<String>,
+    /// Drv path to report on the completion channel once the copy was
+    /// attempted. Set for steps whose finished flag is gated on the copy.
+    notify_drv: Option<StorePath>,
+}
+
 #[derive(Debug)]
 pub struct Uploader {
     queue: super::InspectableChannel<Message>,
     current_tasks: parking_lot::RwLock<Vec<Message>>,
+    copy_queue: super::InspectableChannel<CopyMessage>,
     completion_tx: tokio::sync::mpsc::UnboundedSender<StorePath>,
 
     state_file_path: std::path::PathBuf,
+    copy_state_file_path: std::path::PathBuf,
 }
 
 impl Uploader {
@@ -52,17 +99,27 @@ impl Uploader {
         state_file_path: std::path::PathBuf,
         completion_tx: tokio::sync::mpsc::UnboundedSender<StorePath>,
     ) -> Self {
+        let copy_state_file_path = state_file_path.with_file_name("copier_state.json");
         let uploader = Self {
             queue: super::InspectableChannel::with_capacity(1000),
             current_tasks: parking_lot::RwLock::new(Vec::with_capacity(10)),
+            copy_queue: super::InspectableChannel::with_capacity(1000),
             completion_tx,
             state_file_path,
+            copy_state_file_path,
         };
 
         if let Err(e) = uploader.load_state().await {
             tracing::warn!(
                 "Failed to load uploader state from {}: {}",
                 uploader.state_file_path.display(),
+                e
+            );
+        }
+        if let Err(e) = uploader.load_copy_state().await {
+            tracing::warn!(
+                "Failed to load copier state from {}: {}",
+                uploader.copy_state_file_path.display(),
                 e
             );
         }
@@ -96,6 +153,130 @@ impl Uploader {
             self.queue.len()
         );
         Ok(())
+    }
+
+    async fn save_copy_state(&self) -> Result<(), UploaderError> {
+        let json = serde_json::to_string(&self.copy_queue.inspect())?;
+        fs_err::tokio::write(&self.copy_state_file_path, json).await?;
+        Ok(())
+    }
+
+    async fn load_copy_state(&self) -> Result<(), UploaderError> {
+        if !self.copy_state_file_path.exists() {
+            return Ok(());
+        }
+        let content = fs_err::tokio::read_to_string(&self.copy_state_file_path).await?;
+        self.copy_queue
+            .load_vec_into(serde_json::from_str(&content)?);
+        tracing::info!(
+            "Loaded {} pending copies from {}",
+            self.copy_queue.len(),
+            self.copy_state_file_path.display()
+        );
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn schedule_copy(
+        &self,
+        store_paths: Vec<StorePath>,
+        log_remote_path: String,
+        realisation_keys: Vec<String>,
+        notify_drv: Option<StorePath>,
+    ) {
+        tracing::info!("Scheduling copy from overflow store: {store_paths:?}");
+        self.copy_queue.send(CopyMessage {
+            store_paths,
+            log_remote_path,
+            realisation_keys,
+            notify_drv,
+        });
+        let _ = self.save_copy_state().await;
+    }
+
+    /// Process one queued overflow→default copy: the closure of its store
+    /// paths, the build log and any realisations. Returns `None` when the
+    /// queue is empty, otherwise whether all objects were copied.
+    pub async fn copy_once(
+        &self,
+        source: &binary_cache::S3BinaryCacheClient,
+        dest: &binary_cache::S3BinaryCacheClient,
+    ) -> Option<bool> {
+        let msg = self.copy_queue.recv().await?;
+        let mut ok = true;
+        let mut queue: Vec<StorePath> = msg.store_paths.clone();
+        let mut seen: hashbrown::HashSet<StorePath> = queue.iter().cloned().collect();
+
+        while let Some(path) = queue.pop() {
+            match self.copy_store_path(source, dest, &path).await {
+                Ok(Some(references)) => {
+                    for r in references {
+                        if seen.insert(r.clone()) {
+                            queue.push(r);
+                        }
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::error!("failed to copy {path} from overflow store: {e:#}");
+                    ok = false;
+                }
+            }
+        }
+
+        for key in std::iter::once(&msg.log_remote_path)
+            .chain(msg.realisation_keys.iter())
+            .map(String::as_str)
+        {
+            if let Err(e) = dest.copy_object_from(source, key).await {
+                tracing::error!("failed to copy {key} from overflow store: {e:#}");
+                ok = false;
+            }
+        }
+
+        if let Some(drv) = &msg.notify_drv {
+            // Reported even on failure: the gated step then finishes anyway
+            // and dependents fall back to substituting or rebuilding.
+            let _ = self.completion_tx.send(drv.clone());
+        }
+        let _ = self.save_copy_state().await;
+        Some(ok)
+    }
+
+    /// Copy one store path's objects (NAR, listing, debug-info links, narinfo
+    /// last). Returns its references for closure traversal, or `None` when the
+    /// destination already has it or the source does not.
+    async fn copy_store_path(
+        &self,
+        source: &binary_cache::S3BinaryCacheClient,
+        dest: &binary_cache::S3BinaryCacheClient,
+        path: &StorePath,
+    ) -> Result<Option<Vec<StorePath>>, UploaderError> {
+        if dest.download_narinfo(path).await?.is_some() {
+            return Ok(None);
+        }
+        let Some(narinfo) = source.download_narinfo(path).await? else {
+            tracing::warn!("{path} is missing from the overflow store, skipping copy");
+            return Ok(None);
+        };
+
+        if let Some(nar_url) = &narinfo.info.url {
+            dest.copy_object_from(source, nar_url).await?;
+        }
+        dest.copy_object_from(source, &binary_cache::get_ls_path(&narinfo))
+            .await?;
+        if dest.cfg.write_debug_info
+            && let Some(listing) = source.download_listing(path).await?
+        {
+            for build_id in listing_debug_build_ids(&listing) {
+                dest.copy_object_from(source, &format!("debuginfo/{build_id}"))
+                    .await?;
+            }
+        }
+        dest.copy_object_from(source, &format!("{}.narinfo", path.hash()))
+            .await?;
+
+        Ok(Some(narinfo.info.info.references.iter().cloned().collect()))
     }
 
     #[tracing::instrument(skip(self))]

--- a/subprojects/hydra-queue-runner/src/state/uploader.rs
+++ b/subprojects/hydra-queue-runner/src/state/uploader.rs
@@ -29,6 +29,9 @@ struct Message {
     store_paths: Arc<Vec<StorePath>>,
     log_remote_path: Arc<String>,
     log_local_path: Arc<std::path::PathBuf>,
+    /// Upload to the overflow store instead of the default stores.
+    #[serde(default)]
+    use_overflow: bool,
     /// Drv path to report on the completion channel once the upload was
     /// attempted. Set for steps whose finished flag is gated on the upload.
     #[serde(default)]
@@ -101,6 +104,7 @@ impl Uploader {
         store_paths: Vec<StorePath>,
         log_remote_path: String,
         log_local_path: std::path::PathBuf,
+        use_overflow: bool,
         notify_drv: Option<StorePath>,
     ) {
         tracing::info!("Scheduling new path upload: {:?}", store_paths);
@@ -109,20 +113,22 @@ impl Uploader {
             store_paths: Arc::new(store_paths),
             log_remote_path: Arc::new(log_remote_path),
             log_local_path: Arc::new(log_local_path),
+            use_overflow,
             notify_drv,
         });
         let _ = self.save_state().await;
     }
 
-    #[tracing::instrument(skip(self, store, local_store, remote_stores))]
+    #[tracing::instrument(skip(self, store, local_store, remote_stores, overflow_store))]
     async fn upload_msg(
         &self,
         store: daemon_client_utils::DaemonStoreReader,
         local_store: daemon_client_utils::DaemonConnector,
         remote_stores: Vec<binary_cache::S3BinaryCacheClient>,
+        overflow_store: Option<binary_cache::S3BinaryCacheClient>,
         msg: Message,
     ) {
-        self.upload_msg_inner(store, local_store, remote_stores, &msg)
+        self.upload_msg_inner(store, local_store, remote_stores, overflow_store, &msg)
             .await;
         if let Some(drv) = &msg.notify_drv {
             // Reported even when the upload failed: the gated step then
@@ -132,17 +138,24 @@ impl Uploader {
         }
     }
 
-    #[tracing::instrument(skip(self, store, local_store, remote_stores))]
+    #[tracing::instrument(skip(self, store, local_store, remote_stores, overflow_store))]
     async fn upload_msg_inner(
         &self,
         store: daemon_client_utils::DaemonStoreReader,
         local_store: daemon_client_utils::DaemonConnector,
         remote_stores: Vec<binary_cache::S3BinaryCacheClient>,
+        overflow_store: Option<binary_cache::S3BinaryCacheClient>,
         msg: &Message,
     ) {
         let span = tracing::info_span!("upload_msg", msg = ?msg);
         let _ = span.enter();
         tracing::info!("Start uploading {} paths", msg.store_paths.len());
+
+        // Overflow-only steps upload to the overflow store.
+        let remote_stores = match overflow_store {
+            Some(overflow) if msg.use_overflow => vec![overflow],
+            _ => remote_stores,
+        };
 
         let closure = match store.query_closure_infos(msg.store_paths.to_vec()).await {
             Ok(c) => c,
@@ -253,12 +266,13 @@ impl Uploader {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, store, local_store, remote_stores))]
+    #[tracing::instrument(skip(self, store, local_store, remote_stores, overflow_store))]
     pub async fn upload_once(
         &self,
         store: daemon_client_utils::DaemonStoreReader,
         local_store: daemon_client_utils::DaemonConnector,
         remote_stores: Vec<binary_cache::S3BinaryCacheClient>,
+        overflow_store: Option<binary_cache::S3BinaryCacheClient>,
     ) {
         let Some(msg) = self.queue.recv().await else {
             return;
@@ -269,7 +283,7 @@ impl Uploader {
             current_tasks.push(msg.clone());
         }
 
-        self.upload_msg(store, local_store, remote_stores, msg)
+        self.upload_msg(store, local_store, remote_stores, overflow_store, msg)
             .await;
 
         {
@@ -279,12 +293,13 @@ impl Uploader {
         let _ = self.save_state().await;
     }
 
-    #[tracing::instrument(skip(self, store, local_store, remote_stores))]
+    #[tracing::instrument(skip(self, store, local_store, remote_stores, overflow_store))]
     pub async fn upload_many(
         self: &Arc<Self>,
         store: daemon_client_utils::DaemonStoreReader,
         local_store: daemon_client_utils::DaemonConnector,
         remote_stores: Vec<binary_cache::S3BinaryCacheClient>,
+        overflow_store: Option<binary_cache::S3BinaryCacheClient>,
         limit: usize,
     ) {
         let messages = self.queue.recv_many(limit).await;
@@ -306,8 +321,9 @@ impl Uploader {
             let store = store.clone();
             let local_store = local_store.clone();
             let remote_stores = remote_stores.clone();
+            let overflow_store = overflow_store.clone();
             jobs.spawn(async move {
-                this.upload_msg(store, local_store, remote_stores, msg)
+                this.upload_msg(store, local_store, remote_stores, overflow_store, msg)
                     .await;
             });
         }

--- a/subprojects/proto/v1/streaming.proto
+++ b/subprojects/proto/v1/streaming.proto
@@ -280,6 +280,8 @@ message MultipartPartsRequest {
   string upload_id = 4;
   uint32 start_part_number = 5;
   uint32 num_parts = 6;
+  // Bucket echoed from PresignedNarResponse.
+  optional string bucket = 7;
 }
 
 message MultipartPartsResponse {
@@ -292,6 +294,9 @@ message PresignedNarResponse {
   PresignedUpload nar_upload = 3;
   optional PresignedUpload ls_upload = 4;
   repeated PresignedUpload debug_info_upload = 5;
+  // Bucket the URLs point at.
+  // Echoed back in follow-up requests.
+  optional string bucket = 6;
 }
 
 message PresignedUrlResponse {
@@ -309,4 +314,6 @@ message PresignedUploadComplete {
   // narinfo's FileHash/FileSize from the stored object rather than from this
   // upload's (discarded) compression.
   bool nar_already_present = 15;
+  // Bucket echoed from PresignedNarResponse.
+  optional string bucket = 16;
 }


### PR DESCRIPTION
The high-level idea is that we can different buckets for staging jobsets and have a different retention policies for those.
So if a derivation is only in staging the output would only be in this bucket and later when the derivation is also in an nixos-unstable jobset, we use bucket side copy to migrate it.

This hopefully reduces the long-term storage consumption since we can throw the staging bucket away as we wish.

I have not tested this outside the NixOS test yet that I added.