### PR TITLE
Replace `HYDRA_DBI` with `HYDRA_DATABASE_URL` everywhere

### DIFF
--- a/foreman/common.sh
+++ b/foreman/common.sh
@@ -14,7 +14,7 @@ HYDRA_HOME=$(pwd)/subprojects/hydra
 HYDRA_PG_SOCKET_DIR=$HYDRA_DATA/postgres
 
 # Connection strings
-HYDRA_DBI="dbi:Pg:dbname=hydra;host=localhost;port=$HYDRA_PG_PORT"
+HYDRA_DATABASE_URL="postgres://localhost:$HYDRA_PG_PORT/hydra"
 
 # Cargo target dir picked from the meson build type set in the dev shell.
 if [ "${mesonBuildType:-}" = "debug" ]; then

--- a/foreman/start-evaluator.sh
+++ b/foreman/start-evaluator.sh
@@ -2,7 +2,7 @@
 
 . ./foreman/common.sh
 
-export HYDRA_DBI
+export HYDRA_DATABASE_URL
 export HYDRA_DATA
 
 wait_for_postgres

--- a/foreman/start-hydra.sh
+++ b/foreman/start-hydra.sh
@@ -4,7 +4,7 @@
 
 export HYDRA_HOME
 export HYDRA_DATA
-export HYDRA_DBI
+export HYDRA_DATABASE_URL
 
 wait_for_postgres
 

--- a/foreman/start-notify.sh
+++ b/foreman/start-notify.sh
@@ -4,7 +4,7 @@
 
 export HYDRA_HOME
 export HYDRA_DATA
-export HYDRA_DBI
+export HYDRA_DATABASE_URL
 
 wait_for_postgres
 wait_for_hydra_db

--- a/nixos-modules/postgresql.nix
+++ b/nixos-modules/postgresql.nix
@@ -11,9 +11,9 @@ let
 
   baseDir = "/var/lib/hydra";
 
-  localDB = "dbi:Pg:dbname=hydra;user=hydra;";
+  localDBUrl = "postgres://hydra@%2Frun%2Fpostgresql:5432/hydra";
 
-  haveLocalDB = cfg.dbi == localDB;
+  haveLocalDB = cfg.dbUrl == localDBUrl;
 
 in
 
@@ -50,7 +50,9 @@ in
         "postgresql.service"
       ];
       environment = {
-        HYDRA_DBI = "${cfg.dbi};application_name=hydra-init";
+        HYDRA_DATABASE_URL = "${cfg.dbUrl}${
+          if lib.hasInfix "?" cfg.dbUrl then "&" else "?"
+        }application_name=hydra-init";
         HYDRA_CONFIG = "${baseDir}/hydra.conf";
         HYDRA_DATA = baseDir;
         PGPASSFILE = "${baseDir}/pgpass";

--- a/nixos-modules/web-app.nix
+++ b/nixos-modules/web-app.nix
@@ -16,10 +16,15 @@ let
   hydraConf = pkgs.writeScript "hydra.conf" cfg.extraConfig;
 
   hydraEnv = {
-    HYDRA_DBI = cfg.dbi;
+    HYDRA_DATABASE_URL = cfg.dbUrl;
     HYDRA_CONFIG = "${baseDir}/hydra.conf";
     HYDRA_DATA = "${baseDir}";
   };
+
+  # The database URL with an `application_name` query parameter added, to
+  # distinguish where queries come from in Postgres statistics.
+  dbUrlWithAppName =
+    name: "${cfg.dbUrl}${if hasInfix "?" cfg.dbUrl then "&" else "?"}application_name=${name}";
 
   env = {
     NIX_REMOTE = "daemon";
@@ -41,9 +46,9 @@ let
     }
     // (optionalAttrs cfg.debugServer { DBIC_TRACE = "1"; });
 
-  localDB = "dbi:Pg:dbname=hydra;user=hydra;";
+  localDBUrl = "postgres://hydra@%2Frun%2Fpostgresql:5432/hydra";
 
-  haveLocalDB = cfg.dbi == localDB;
+  haveLocalDB = cfg.dbUrl == localDBUrl;
 
 in
 
@@ -52,6 +57,9 @@ in
     ./postgresql.nix
     (mkRemovedOptionModule [ "services" "hydra-dev" "buildMachinesFiles" ]
       "The queue runner no longer reads Nix build machines files. Builders now connect to the queue runner via gRPC."
+    )
+    (mkRemovedOptionModule [ "services" "hydra-dev" "dbi" ]
+      "Hydra services are now configured with a postgres:// URL via `services.hydra-dev.dbUrl` instead of a Perl DBI string."
     )
   ];
   ###### interface
@@ -67,17 +75,18 @@ in
         '';
       };
 
-      dbi = mkOption {
+      dbUrl = mkOption {
         type = types.str;
-        default = localDB;
-        example = "dbi:Pg:dbname=hydra;host=postgres.example.org;user=foo;";
+        default = localDBUrl;
+        example = "postgres://foo@postgres.example.org/hydra";
         description = ''
-          The DBI string for Hydra database connection.
+          The `postgres://` URL for the Hydra database connection, used
+          by all Hydra services (Perl services convert it to a DBI string
+          internally).
 
-          NOTE: Attempts to set `application_name` will be overridden by
-          `hydra-TYPE` (where TYPE is e.g. `evaluator`, `queue-runner`,
-          etc.) in all hydra services to more easily distinguish where
-          queries are coming from.
+          NOTE: an `application_name` query parameter is appended per
+          service (e.g. `hydra-evaluator`) to more easily distinguish
+          where queries are coming from, so do not set one here.
         '';
       };
 
@@ -256,7 +265,7 @@ in
         "hydra-server.socket"
       ];
       environment = serverEnv // {
-        HYDRA_DBI = "${serverEnv.HYDRA_DBI};application_name=hydra-server";
+        HYDRA_DATABASE_URL = dbUrlWithAppName "hydra-server";
       };
       restartTriggers = [ hydraConf ];
       serviceConfig = {
@@ -303,7 +312,7 @@ in
         cfg.package
       ];
       environment = env // {
-        HYDRA_DBI = "${env.HYDRA_DBI};application_name=hydra-evaluator";
+        HYDRA_DATABASE_URL = dbUrlWithAppName "hydra-evaluator";
       };
       serviceConfig = {
         ExecStart = escapeShellArgs [
@@ -324,7 +333,7 @@ in
       requires = [ "hydra-init.service" ];
       after = [ "hydra-init.service" ];
       environment = env // {
-        HYDRA_DBI = "${env.HYDRA_DBI};application_name=hydra-update-gc-roots";
+        HYDRA_DATABASE_URL = dbUrlWithAppName "hydra-update-gc-roots";
       };
       serviceConfig = {
         ExecStart = escapeShellArgs [
@@ -340,7 +349,7 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "hydra-init.service" ];
       environment = env // {
-        HYDRA_DBI = "${env.HYDRA_DBI};application_name=hydra-send-stats";
+        HYDRA_DATABASE_URL = dbUrlWithAppName "hydra-send-stats";
       };
       serviceConfig = {
         ExecStart = escapeShellArgs [
@@ -359,7 +368,7 @@ in
       path = [ pkgs.zstd ];
       environment = env // {
         PGPASSFILE = "${baseDir}/pgpass-notify";
-        HYDRA_DBI = "${env.HYDRA_DBI};application_name=hydra-notify";
+        HYDRA_DATABASE_URL = dbUrlWithAppName "hydra-notify";
       };
       serviceConfig = {
         ExecStart = escapeShellArgs [

--- a/subprojects/hydra-manual/dev-notes.txt
+++ b/subprojects/hydra-manual/dev-notes.txt
@@ -93,7 +93,7 @@
 
 * Using PostgreSQL (version 9.2 or newer is required): 
 
-  $ HYDRA_DBI="dbi:Pg:dbname=hydra;" hydra-server
+  $ HYDRA_DATABASE_URL="postgres:///hydra" hydra-server
 
 
 * Find the builds with the highest number of build steps:

--- a/subprojects/hydra-manual/src/installation.md
+++ b/subprojects/hydra-manual/src/installation.md
@@ -66,7 +66,7 @@ Hydra uses an environment variable to know which database should be used, and a 
 To set these variables for a PostgreSQL database, add the following to the file `~/.profile` of the user running the Hydra services.
 
 ```console
-export HYDRA_DBI="dbi:Pg:dbname=hydra;host=dbserver.example.org;user=hydra;"
+export HYDRA_DATABASE_URL="postgres://hydra@dbserver.example.org/hydra"
 export HYDRA_DATA=/var/lib/hydra
 ```
 

--- a/subprojects/hydra-tests/lib/HydraTestContext.pm
+++ b/subprojects/hydra-tests/lib/HydraTestContext.pm
@@ -95,7 +95,6 @@ sub new {
     my $pgsql = Test::PostgreSQL->new(
         extra_initdb_args => "--locale C.UTF-8"
     );
-    $central->{hydra_dbi} = $pgsql->dsn;
     $central->{hydra_database_url} = $pgsql->uri;
 
     my $jobsdir = "$dir/jobs";
@@ -128,7 +127,6 @@ sub new {
         central_env => {
             'HYDRA_DATA'         => $central->{hydra_data},
             'HYDRA_CONFIG'       => $central->{hydra_config_file},
-            'HYDRA_DBI'          => $central->{hydra_dbi},
             'HYDRA_DATABASE_URL' => $central->{hydra_database_url},
             'NIX_CONF_DIR'       => $central->{nix_conf_dir},
             'NIX_REMOTE'         => $central->{nix_store_uri},
@@ -166,7 +164,7 @@ sub db {
 
     if (!defined $self->{_db}) {
         require Hydra::Schema;
-        $self->{_db} = Hydra::Schema->connect($self->{central}{hydra_dbi});
+        $self->{_db} = Hydra::Schema->connect($self->{db_handle}->dsn);
 
         if (!(defined $setup && $setup == 0)) {
             $self->{_db}->resultset('Users')->create({

--- a/subprojects/hydra/hydra-evaluator/hydra-evaluator.cc
+++ b/subprojects/hydra/hydra-evaluator/hydra-evaluator.cc
@@ -19,21 +19,8 @@ using namespace nix;
 
 struct Connection : pqxx::connection
 {
-    Connection() : pqxx::connection(getFlags()) { };
-
-    std::string getFlags()
-    {
-        auto s = getEnv("HYDRA_DBI").value_or("dbi:Pg:dbname=hydra;");
-
-        std::string lower_prefix = "dbi:Pg:";
-        std::string upper_prefix = "DBI:Pg:";
-
-        if (hasPrefix(s, lower_prefix) || hasPrefix(s, upper_prefix)) {
-            return concatStringsSep(" ", tokenizeString<Strings>(std::string(s, lower_prefix.size()), ";"));
-        }
-
-        throw Error("$HYDRA_DBI does not denote a PostgreSQL database");
-    }
+    // libpq accepts a postgres:// URL directly as the connection string.
+    Connection() : pqxx::connection(getEnv("HYDRA_DATABASE_URL").value_or("postgres:///hydra")) { };
 };
 
 

--- a/subprojects/hydra/lib/Hydra/Model/DB.pm
+++ b/subprojects/hydra/lib/Hydra/Model/DB.pm
@@ -3,6 +3,7 @@ package Hydra::Model::DB;
 use strict;
 use warnings;
 use base 'Catalyst::Model::DBIC::Schema';
+use URI::db;
 
 sub getHydraPath {
     my $dir = $ENV{"HYDRA_DATA"} || "/var/lib/hydra";
@@ -10,14 +11,27 @@ sub getHydraPath {
     return $dir;
 }
 
-sub getHydraDBPath {
-    return $ENV{"HYDRA_DBI"} || "dbi:Pg:dbname=hydra;";
+# Connection info derived from the HYDRA_DATABASE_URL environment
+# variable, a `postgres://` URL as understood by libpq (and by the Rust
+# services, which read the same variable). Converted to a DBI DSN with
+# URI::db; user and password are not part of the DSN and must be passed
+# as separate connect arguments.
+sub getHydraConnectInfo {
+    my $url = $ENV{"HYDRA_DATABASE_URL"} || "postgres:///hydra";
+    my $uri = URI::db->new("db:$url");
+    die "\$HYDRA_DATABASE_URL does not denote a PostgreSQL database\n"
+        unless ($uri->canonical_engine // "") eq "pg";
+    return (
+        dsn => $uri->dbi_dsn,
+        user => scalar $uri->user,
+        password => scalar $uri->password,
+    );
 }
 
 __PACKAGE__->config(
     schema_class => 'Hydra::Schema',
     connect_info => {
-        dsn => getHydraDBPath
+        getHydraConnectInfo()
     },
 );
 

--- a/subprojects/hydra/package.nix
+++ b/subprojects/hydra/package.nix
@@ -124,6 +124,7 @@ let
         TestPostgreSQL
         TextDiff
         TextTable
+        URIdb
         UUID4Tiny
         YAML
         XMLSimple


### PR DESCRIPTION
Hydra grew a second database-connection convention when the Rust queue runner arrived: it takes a standard `postgres://` URL (`db_url` / `HYDRA_DATABASE_URL`), while the Perl and C++ services read `HYDRA_DBI`, a Perl DBI string. Converge on the URL as the single convention before more Rust services appear, rather than teaching each of them the legacy DBI syntax.

The two formats are equally expressive — the PostgreSQL URI scheme accepts every libpq keyword as a query parameter — so nothing is lost, and each consumer needs only a small change:

- Perl: `Hydra::Model::DB` converts the URL to a DBI DSN with `URI::db` (new dependency). See the comment there for the user/password caveat.

- C++ (`hydra-evaluator`): libpq accepts a `postgres://` URL verbatim, so the DBI-to-conninfo translation code is deleted outright.

- NixOS module: the `dbi` option is replaced by `dbUrl`, and all services now get `HYDRA_DATABASE_URL` with a per-service `application_name` query parameter. Neither hydra.nixos.org nor staging ever set `dbi`, so the option's removal breaks no known deployment.

- The foreman dev scripts, test harness, and manual switch accordingly. The test harness already exported both variables; the `HYDRA_DBI` half is now dropped.

The Perl and C++ in-code default becomes `postgres:///hydra`, which is byte-for-byte equivalent to the old `dbi:Pg:dbname=hydra;` (local socket, OS-user auth). The NixOS module default matches the queue runner's explicit `postgres://hydra@%2Frun%2Fpostgresql:5432/hydra`.