### PR TITLE
nix-perl: fix eval warning

### DIFF
--- a/subprojects/hydra/package.nix
+++ b/subprojects/hydra/package.nix
@@ -210,7 +210,7 @@ stdenv.mkDerivation (finalAttrs: {
       breezy
       nix-eval-jobs
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       rpm
       dpkg
       cdrkit

--- a/subprojects/nix-perl/package.nix
+++ b/subprojects/nix-perl/package.nix
@@ -50,7 +50,7 @@ perl.pkgs.toPerlModule (
     ];
 
     # `perlPackages.Test2Harness` is marked broken for Darwin
-    doCheck = !stdenv.isDarwin;
+    doCheck = !stdenv.hostPlatform.isDarwin;
 
     nativeCheckInputs = [
       perlPackages.Test2Harness


### PR DESCRIPTION
Fixes a minor evaluation warning that was caused by https://github.com/NixOS/nixpkgs/pull/518407

> stdenv.isDarwin is deprecated, use stdenv.hostPlatform.isDarwin instead
