### PR TITLE
nixos-tests: move `useSubstitutes` under `settings`

### DIFF
--- a/nixos-tests/s3-nar-listing.nix
+++ b/nixos-tests/s3-nar-listing.nix
@@ -174,7 +174,7 @@ in
     imports = [ common.builderConfig ];
     # Presigned uploads require the builder to advertise the forced
     # substituter with substitution enabled, or the queue runner rejects it.
-    services.hydra-queue-builder-dev.useSubstitutes = lib.mkForce presigned;
+    services.hydra-queue-builder-dev.settings.useSubstitutes = lib.mkForce presigned;
     nix.settings.substituters = lib.mkForce (lib.optionals presigned [ s3StoreUri ]);
   };
 

--- a/nixos-tests/s3-overflow.nix
+++ b/nixos-tests/s3-overflow.nix
@@ -113,7 +113,7 @@ in
 
   nodes.builder = {
     imports = [ common.builderConfig ];
-    services.hydra-queue-builder-dev.useSubstitutes = lib.mkForce false;
+    services.hydra-queue-builder-dev.settings.useSubstitutes = lib.mkForce false;
     nix.settings.substituters = lib.mkForce [ ];
   };
 


### PR DESCRIPTION
The builder and queue runner modules now keep their reloadable knobs in a `settings` submodule. I forgot to move these `useSubstitutes` uses there.