### PR TITLE
nixos-modules: escape `%` in `HYDRA_DATABASE_URL`

### DIFF
--- a/nixos-modules/postgresql.nix
+++ b/nixos-modules/postgresql.nix
@@ -50,9 +50,11 @@ in
         "postgresql.service"
       ];
       environment = {
-        HYDRA_DATABASE_URL = "${cfg.dbUrl}${
-          if lib.hasInfix "?" cfg.dbUrl then "&" else "?"
-        }application_name=hydra-init";
+        # See the comment on `dbUrlWithAppName` in web-app.nix for why `%`
+        # has to be doubled here.
+        HYDRA_DATABASE_URL =
+          lib.replaceStrings [ "%" ] [ "%%" ]
+            "${cfg.dbUrl}${if lib.hasInfix "?" cfg.dbUrl then "&" else "?"}application_name=hydra-init";
         HYDRA_CONFIG = "${baseDir}/hydra.conf";
         HYDRA_DATA = baseDir;
         PGPASSFILE = "${baseDir}/pgpass";

--- a/nixos-modules/web-app.nix
+++ b/nixos-modules/web-app.nix
@@ -23,8 +23,17 @@ let
 
   # The database URL with an `application_name` query parameter added, to
   # distinguish where queries come from in Postgres statistics.
+  #
+  # `%` is doubled because these end up in systemd `Environment=`, where a
+  # bare `%` starts a specifier: the percent-encoded socket directory in the
+  # default URL (`%2Frun%2Fpostgresql`) otherwise makes systemd drop the
+  # whole assignment as an invalid specifier, and the services silently fall
+  # back to connecting as their own Unix user.
   dbUrlWithAppName =
-    name: "${cfg.dbUrl}${if hasInfix "?" cfg.dbUrl then "&" else "?"}application_name=${name}";
+    name:
+    replaceStrings [ "%" ] [ "%%" ] (
+      "${cfg.dbUrl}${if hasInfix "?" cfg.dbUrl then "&" else "?"}application_name=${name}"
+    );
 
   env = {
     NIX_REMOTE = "daemon";


### PR DESCRIPTION
The default database URL reaches Postgres over a Unix socket, so its "host" is a percent-encoded directory: `%2Frun%2Fpostgresql`. systemd reads `%` in `Environment=` as the start of a specifier, fails to resolve `%2`, and drops the whole assignment:

    Failed to resolve specifiers in HYDRA_DATABASE_URL=..., ignoring: Invalid slot

The services then fall back to `postgres:///hydra`, which carries no user, so libpq connects as the service's own Unix user — `hydra-www`, `hydra-queue-runner` — and peer auth rejects it, since the `hydra-users` ident map only maps those to the `hydra` role. The `install` test saw this as a 500 from the web UI.

Double the `%` on the copies bound for systemd; see the comment on `dbUrlWithAppName`. `environment.variables` is a plain shell environment and the queue runner reads its URL from TOML, so neither needs it.

Assisted-by: Claude Code (Opus 5)