### PR TITLE
hydra-eval-jobset: clear stale eval errors for static declarative projects

### DIFF
--- a/subprojects/hydra-tests/Hydra/Plugin/DeclarativeJobsets/static.t
+++ b/subprojects/hydra-tests/Hydra/Plugin/DeclarativeJobsets/static.t
@@ -1,0 +1,47 @@
+use feature 'unicode_strings';
+use strict;
+use warnings;
+use Test2::V0;
+use Setup;
+
+my $ctx = test_context();
+my $db = $ctx->db;
+
+my $project = $db->resultset('Projects')->create({
+    name => "tests",
+    displayname => "",
+    owner => "root",
+    declfile => "declarative/static-project.json",
+    decltype => "path",
+    declvalue => $ctx->jobsdir,
+});
+
+# This logic lives in the Project controller.
+# Not great to duplicate it here.
+# TODO: refactor and deduplicate.
+my $jobset = $project->jobsets->create({
+    name=> ".jobsets",
+    nixexprinput => "",
+    nixexprpath => "",
+    emailoverride => "",
+    triggertime => time,
+});
+
+subtest "Evaluating the static declarative specification" => sub {
+    ok(evalSucceeds($ctx, $jobset), "Evaluating the static declarative spec with return code 0");
+
+    my $declared = $project->jobsets->find({ name => "my-static-jobset" });
+    ok($declared, "The declared jobset exists");
+    is($declared->description, "my-static-jobset", "The jobset's description matches");
+};
+
+subtest "A stale evaluation error is cleared by the next successful check" => sub {
+    # Simulate a previous transient failure, e.g. the declarative input
+    # temporarily failing to fetch.
+    $jobset->update({ errormsg => "transient fetch failure", errortime => time - 60 });
+
+    ok(evalSucceeds($ctx, $jobset), "Re-evaluating the static declarative spec with return code 0");
+    is($jobset->errormsg, "", "The stale evaluation error is cleared");
+};
+
+done_testing;

--- a/subprojects/hydra-tests/jobs/declarative/static-project.json
+++ b/subprojects/hydra-tests/jobs/declarative/static-project.json
@@ -1,0 +1,21 @@
+{
+    "my-static-jobset": {
+        "enabled": 1,
+        "hidden": false,
+        "description": "my-static-jobset",
+        "nixexprinput": "src",
+        "nixexprpath": "one-job.nix",
+        "checkinterval": 300,
+        "schedulingshares": 100,
+        "enableemail": false,
+        "emailoverride": "",
+        "keepnr": 3,
+        "inputs": {
+            "src": {
+                "type": "string",
+                "value": "unused",
+                "emailresponsible": false
+            }
+        }
+    }
+}

--- a/subprojects/hydra/script/hydra-eval-jobset
+++ b/subprojects/hydra/script/hydra-eval-jobset
@@ -752,6 +752,7 @@ sub checkJobsetWrapped {
                 $db->txn_do(sub {
                     $jobset->update({ lastcheckedtime => time, fetcherrormsg => undef });
                 });
+                setJobsetError($jobset, "", time);
                 return;
             } else {
                 # Update the jobset with the spec's inputs, and the continue


### PR DESCRIPTION
## Motivation

When a declarative project's spec file is a static JSON document (all of its top-level values are jobset definitions), `checkJobsetWrapped` takes an early-return path on success: it syncs the jobsets via `handleDeclarativeJobsetJson`, updates `lastcheckedtime`, clears `fetcherrormsg`, and returns. Unlike the regular evaluation path, it never clears `errormsg`/`errortime` via `setJobsetError`.

As a result, a single transient failure (e.g., the declarative input briefly failing to fetch) leaves the `.jobsets` jobset showing "Last checked: …, with errors!" forever, even though every subsequent check succeeds. The stale error also remains visible in the jobset's "Evaluation Errors" tab.

## Fix

Clear the jobset error on the static-declarative success path the same way the regular evaluation path does, by calling `setJobsetError($jobset, "", time)` after a successful check.

## Tests

Adds `Hydra/Plugin/DeclarativeJobsets/static.t` (plus a static-spec fixture), which covers the static declarative path and asserts that a pre-seeded evaluation error is cleared by the next successful check. The new subtest fails before the fix and passes after.

Claude Opus 5 helped me generate this patch and PR, but I also reviewed it by hand. Thanks for reading!