### PR TITLE
Fix Hydra build on macOS

### DIFF
--- a/subprojects/hydra-builder/Cargo.toml
+++ b/subprojects/hydra-builder/Cargo.toml
@@ -45,7 +45,6 @@ harmonia-utils-hash.workspace       = true
 
 gethostname.workspace = true
 nix                   = { workspace = true, features = [ "fs" ] }
-procfs-core.workspace = true
 
 binary-cache.workspace             = true
 daemon-client-utils.workspace      = true
@@ -55,6 +54,9 @@ hydra-tracing                      = { workspace = true, features = [ "tonic" ] 
 nix-support.workspace              = true
 store-path-utils.workspace         = true
 store-transfer.workspace           = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs-core.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 sysinfo.workspace = true

--- a/subprojects/hydra-builder/src/system.rs
+++ b/subprojects/hydra-builder/src/system.rs
@@ -1,5 +1,7 @@
 use color_eyre::eyre;
 use hashbrown::HashMap;
+
+#[cfg(target_os = "linux")]
 use procfs_core::FromRead as _;
 
 #[derive(Debug, Clone, Copy)]

--- a/subprojects/hydra-queue-runner/Cargo.toml
+++ b/subprojects/hydra-queue-runner/Cargo.toml
@@ -47,7 +47,6 @@ http-body-util.workspace = true
 hyper                    = { workspace = true, features = [ "full" ] }
 hyper-util.workspace     = true
 jiff.workspace           = true
-procfs.workspace         = true
 prometheus               = { workspace = true, features = [ "process" ] }
 tower                    = { workspace = true, features = [ "util" ] }
 tower-http               = { workspace = true, features = [ "trace" ] }
@@ -76,6 +75,9 @@ store-transfer.workspace                 = true
 [dev-dependencies]
 harmonia-file-nar = { workspace = true, features = [ "test" ] }
 tempfile          = "3.23.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator.workspace = true

--- a/subprojects/hydra-queue-runner/src/io/mod.rs
+++ b/subprojects/hydra-queue-runner/src/io/mod.rs
@@ -16,7 +16,7 @@ pub use response_types::{
     BuildsResponse, DumpResponse, JobsetsResponse, MachinesResponse, QueueResponse,
     StepInfoResponse, StepsResponse,
 };
-pub use stats::{BuildQueueStats, CgroupStats, CpuStats, IoStats, MemoryStats, Process};
+pub use stats::{BuildQueueStats, Process};
 pub use step::Step;
 pub use step_info::StepInfo;
 pub use uploads::UploadsResponse;

--- a/subprojects/hydra-queue-runner/src/io/stats/linux.rs
+++ b/subprojects/hydra-queue-runner/src/io/stats/linux.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, thiserror::Error)]
-pub enum CgroupError {
+enum CgroupError {
     #[error("reading cgroup file")]
     Io(#[from] std::io::Error),
 
@@ -22,32 +22,8 @@ pub enum CgroupError {
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BuildQueueStats {
-    active_runnable: u64,
-    total_runnable: u64,
-    nr_runnable_waiting: u64,
-    nr_runnable_disabled: u64,
-    avg_runnable_time: u64,
-    wait_time_ms: u64,
-}
-
-impl From<crate::state::BuildQueueStats> for BuildQueueStats {
-    fn from(v: crate::state::BuildQueueStats) -> Self {
-        Self {
-            active_runnable: v.active_runnable,
-            total_runnable: v.total_runnable,
-            nr_runnable_waiting: v.nr_runnable_waiting,
-            nr_runnable_disabled: v.nr_runnable_disabled,
-            avg_runnable_time: v.avg_runnable_time,
-            wait_time_ms: v.wait_time,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
 #[allow(clippy::struct_field_names)]
-pub struct MemoryStats {
+struct MemoryStats {
     current_bytes: u64,
     peak_bytes: u64,
     swap_current_bytes: u64,
@@ -92,7 +68,7 @@ impl MemoryStats {
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct IoStats {
+struct IoStats {
     total_read_bytes: u64,
     total_write_bytes: u64,
 }
@@ -132,7 +108,7 @@ impl IoStats {
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::struct_field_names)]
-pub struct CpuStats {
+struct CpuStats {
     usage_usec: u128,
     user_usec: u128,
     system_usec: u128,
@@ -178,7 +154,7 @@ impl CpuStats {
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CgroupStats {
+struct CgroupStats {
     memory: MemoryStats,
     io: IoStats,
     cpu: CpuStats,
@@ -210,16 +186,15 @@ impl CgroupStats {
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Process {
-    pid: i32,
+pub(super) struct ProcessExtra {
     vsize_bytes: u64,
     rss_bytes: u64,
     shared_bytes: u64,
     cgroup: Option<CgroupStats>,
 }
 
-impl Process {
-    pub fn new() -> Option<Self> {
+impl ProcessExtra {
+    pub(super) fn new() -> Option<Self> {
         let me = procfs::process::Process::myself().ok()?;
         let page_size = procfs::page_size();
         let statm = me.statm().ok()?;
@@ -227,7 +202,6 @@ impl Process {
         let rss = statm.resident * page_size;
         let shared = statm.shared * page_size;
         Some(Self {
-            pid: me.pid,
             vsize_bytes: vsize,
             rss_bytes: rss,
             shared_bytes: shared,
@@ -239,81 +213,5 @@ impl Process {
                 }
             },
         })
-    }
-}
-
-#[derive(Debug, Clone, Copy, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StoreStats {
-    nar_info_read: u64,
-    nar_info_read_averted: u64,
-    nar_info_missing: u64,
-    nar_info_write: u64,
-    path_info_cache_size: u64,
-    nar_read: u64,
-    nar_read_bytes: u64,
-    nar_read_compressed_bytes: u64,
-    nar_write: u64,
-    nar_write_averted: u64,
-    nar_write_bytes: u64,
-    nar_write_compressed_bytes: u64,
-    nar_write_compression_time_ms: u64,
-    nar_compression_savings: f64,
-    nar_compression_speed: f64,
-}
-
-impl StoreStats {
-    #[must_use]
-    pub fn new(v: &StoreStats) -> Self {
-        Self {
-            nar_info_read: v.nar_info_read,
-            nar_info_read_averted: v.nar_info_read_averted,
-            nar_info_missing: v.nar_info_missing,
-            nar_info_write: v.nar_info_write,
-            path_info_cache_size: v.path_info_cache_size,
-            nar_read: v.nar_read,
-            nar_read_bytes: v.nar_read_bytes,
-            nar_read_compressed_bytes: v.nar_read_compressed_bytes,
-            nar_write: v.nar_write,
-            nar_write_averted: v.nar_write_averted,
-            nar_write_bytes: v.nar_write_bytes,
-            nar_write_compressed_bytes: v.nar_write_compressed_bytes,
-            nar_write_compression_time_ms: v.nar_write_compression_time_ms,
-            nar_compression_savings: 0.0, // not available via daemon protocol
-            nar_compression_speed: 0.0,   // not available via daemon protocol
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct S3Stats {
-    put: u64,
-    put_bytes: u64,
-    put_time_ms: u64,
-    put_speed: f64,
-    get: u64,
-    get_bytes: u64,
-    get_time_ms: u64,
-    get_speed: f64,
-    head: u64,
-    cost_dollar_approx: f64,
-}
-
-impl S3Stats {
-    #[must_use]
-    pub fn new(v: &binary_cache::S3Stats) -> Self {
-        Self {
-            put: v.put,
-            put_bytes: v.put_bytes,
-            put_time_ms: v.put_time_ms,
-            put_speed: v.put_speed(),
-            get: v.get,
-            get_bytes: v.get_bytes,
-            get_time_ms: v.get_time_ms,
-            get_speed: v.get_speed(),
-            head: v.head,
-            cost_dollar_approx: v.cost_dollar_approx(),
-        }
     }
 }

--- a/subprojects/hydra-queue-runner/src/io/stats/mod.rs
+++ b/subprojects/hydra-queue-runner/src/io/stats/mod.rs
@@ -1,0 +1,122 @@
+#[cfg_attr(target_os = "linux", path = "linux.rs")]
+#[cfg_attr(not(target_os = "linux"), path = "other.rs")]
+mod process;
+
+use process::ProcessExtra;
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Process {
+    pid: i32,
+    #[serde(flatten)]
+    extra: ProcessExtra,
+}
+
+impl Process {
+    pub fn new() -> Option<Self> {
+        Some(Self {
+            pid: std::process::id().try_into().ok()?,
+            extra: ProcessExtra::new()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildQueueStats {
+    active_runnable: u64,
+    total_runnable: u64,
+    nr_runnable_waiting: u64,
+    nr_runnable_disabled: u64,
+    avg_runnable_time: u64,
+    wait_time_ms: u64,
+}
+
+impl From<crate::state::BuildQueueStats> for BuildQueueStats {
+    fn from(v: crate::state::BuildQueueStats) -> Self {
+        Self {
+            active_runnable: v.active_runnable,
+            total_runnable: v.total_runnable,
+            nr_runnable_waiting: v.nr_runnable_waiting,
+            nr_runnable_disabled: v.nr_runnable_disabled,
+            avg_runnable_time: v.avg_runnable_time,
+            wait_time_ms: v.wait_time,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoreStats {
+    nar_info_read: u64,
+    nar_info_read_averted: u64,
+    nar_info_missing: u64,
+    nar_info_write: u64,
+    path_info_cache_size: u64,
+    nar_read: u64,
+    nar_read_bytes: u64,
+    nar_read_compressed_bytes: u64,
+    nar_write: u64,
+    nar_write_averted: u64,
+    nar_write_bytes: u64,
+    nar_write_compressed_bytes: u64,
+    nar_write_compression_time_ms: u64,
+    nar_compression_savings: f64,
+    nar_compression_speed: f64,
+}
+
+impl StoreStats {
+    #[must_use]
+    pub fn new(v: &StoreStats) -> Self {
+        Self {
+            nar_info_read: v.nar_info_read,
+            nar_info_read_averted: v.nar_info_read_averted,
+            nar_info_missing: v.nar_info_missing,
+            nar_info_write: v.nar_info_write,
+            path_info_cache_size: v.path_info_cache_size,
+            nar_read: v.nar_read,
+            nar_read_bytes: v.nar_read_bytes,
+            nar_read_compressed_bytes: v.nar_read_compressed_bytes,
+            nar_write: v.nar_write,
+            nar_write_averted: v.nar_write_averted,
+            nar_write_bytes: v.nar_write_bytes,
+            nar_write_compressed_bytes: v.nar_write_compressed_bytes,
+            nar_write_compression_time_ms: v.nar_write_compression_time_ms,
+            nar_compression_savings: 0.0, // not available via daemon protocol
+            nar_compression_speed: 0.0,   // not available via daemon protocol
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct S3Stats {
+    put: u64,
+    put_bytes: u64,
+    put_time_ms: u64,
+    put_speed: f64,
+    get: u64,
+    get_bytes: u64,
+    get_time_ms: u64,
+    get_speed: f64,
+    head: u64,
+    cost_dollar_approx: f64,
+}
+
+impl S3Stats {
+    #[must_use]
+    pub fn new(v: &binary_cache::S3Stats) -> Self {
+        Self {
+            put: v.put,
+            put_bytes: v.put_bytes,
+            put_time_ms: v.put_time_ms,
+            put_speed: v.put_speed(),
+            get: v.get,
+            get_bytes: v.get_bytes,
+            get_time_ms: v.get_time_ms,
+            get_speed: v.get_speed(),
+            head: v.head,
+            cost_dollar_approx: v.cost_dollar_approx(),
+        }
+    }
+}

--- a/subprojects/hydra-queue-runner/src/io/stats/other.rs
+++ b/subprojects/hydra-queue-runner/src/io/stats/other.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ProcessExtra {}
+
+impl ProcessExtra {
+    pub(super) fn new() -> Option<Self> {
+        Some(Self {})
+    }
+}

--- a/subprojects/hydra/lib/Hydra/Helper/Nix.pm
+++ b/subprojects/hydra/lib/Hydra/Helper/Nix.pm
@@ -15,7 +15,6 @@ use IPC::Run;
 use IPC::Run3;
 use LWP::UserAgent;
 use JSON::MaybeXS;
-use UUID4::Tiny qw(is_uuid4_string);
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
@@ -589,7 +588,7 @@ sub constructRunCommandLogPath {
     my ($runlog) = @_;
     my $uuid = $runlog->uuid;
 
-    if (!is_uuid4_string($uuid)) {
+    if ($uuid !~ qr/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/is) {
         die "UUID was invalid."
     }
 

--- a/subprojects/hydra/lib/Hydra/Schema/Result/RunCommandLogs.pm
+++ b/subprojects/hydra/lib/Hydra/Schema/Result/RunCommandLogs.pm
@@ -174,7 +174,7 @@ __PACKAGE__->belongs_to(
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZVpYU6k3d/k/nitjpdgf/A
 
 use POSIX qw(WEXITSTATUS WIFEXITED WIFSIGNALED WTERMSIG);
-use UUID4::Tiny qw(create_uuid_string);
+use UUID::URandom qw(create_uuid_string);
 
 
 =head2 new

--- a/subprojects/hydra/package.nix
+++ b/subprojects/hydra/package.nix
@@ -125,7 +125,7 @@ let
         TextDiff
         TextTable
         URIdb
-        UUID4Tiny
+        UUIDURandom
         YAML
         XMLSimple
       ])


### PR DESCRIPTION
These changes make sure that no Linux-only dependencies are required to build Hydra:
- **cargo: Make all procfs usage limited to Linux**
- **Replace UUID4::Tiny with UUID::URandom**

This along with these PRs in Nixpkgs allows to build Hydra on macOS:
- https://github.com/NixOS/nixpkgs/pull/551477
- https://github.com/NixOS/nixpkgs/pull/551478
- https://github.com/NixOS/nixpkgs/pull/552359

Note that tests are still failing on macOS, but at least the build works.
