### PR TITLE
Serve and upload build traces the way Nix asks for them

### DIFF
--- a/subprojects/crates/binary-cache/examples/upload_build_trace_entry.rs
+++ b/subprojects/crates/binary-cache/examples/upload_build_trace_entry.rs
@@ -19,18 +19,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         output_name: "debug".parse().unwrap(),
     };
     tracing::info!(
-        "has realisation before: {}",
-        client.has_realisation(&id).await?
+        "has build trace before: {}",
+        client.has_build_trace_entry(&id).await?
     );
-    // TODO put back after we add back `query_raw_realisation` with Nix 2.35.
 
-    // let raw = local.query_raw_realisation(&id)?;
-    // let realisation = raw.as_rust()?;
-    // client.write_realisation(realisation).await?;
-    // tracing::info!(
-    //     "has realisation after: {}",
-    //     client.has_realisation(&id).await?
-    // );
+    // A build trace entry is just the output path that a derivation's output
+    // resolved to, so make one up rather than asking a store for it. The
+    // client signs it on the way out.
+    client
+        .write_build_trace_entry(harmonia_store_derivation::realisation::Realisation {
+            key: id.clone(),
+            value: harmonia_store_derivation::realisation::UnkeyedRealisation {
+                out_path: "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bash-5.2p37"
+                    .parse()
+                    .unwrap(),
+                signatures: Default::default(),
+            },
+        })
+        .await?;
+    tracing::info!(
+        "has build trace after: {}",
+        client.has_build_trace_entry(&id).await?
+    );
 
     let stats = client.s3_stats();
     tracing::info!(

--- a/subprojects/crates/binary-cache/src/cfg.rs
+++ b/subprojects/crates/binary-cache/src/cfg.rs
@@ -19,7 +19,7 @@ pub struct S3CacheConfig {
     pub compression: Compression,
     pub write_nar_listing: bool,
     pub write_debug_info: bool,
-    pub write_realisation: bool,
+    pub write_build_trace: bool,
     pub secret_key_files: SmallVec<[std::path::PathBuf; 4]>,
     pub parallel_compression: bool,
     pub compression_level: Option<i32>,
@@ -47,7 +47,7 @@ impl S3CacheConfig {
             compression: Compression::Xz,
             write_nar_listing: false,
             write_debug_info: false,
-            write_realisation: false,
+            write_build_trace: false,
             secret_key_files: SmallVec::default(),
             parallel_compression: false,
             compression_level: Option::default(),
@@ -102,10 +102,10 @@ impl S3CacheConfig {
     }
 
     #[must_use]
-    pub fn with_write_realisation(mut self, write_realisation: Option<&str>) -> Self {
-        if let Some(write_realisation) = write_realisation {
-            let s = write_realisation.trim().to_ascii_lowercase();
-            self.write_realisation = s.as_str() == "1" || s.as_str() == "true";
+    pub fn with_write_build_trace(mut self, write_build_trace: Option<&str>) -> Self {
+        if let Some(write_build_trace) = write_build_trace {
+            let s = write_build_trace.trim().to_ascii_lowercase();
+            self.write_build_trace = s.as_str() == "1" || s.as_str() == "true";
         }
         self
     }
@@ -715,7 +715,7 @@ aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvb123KEY"
         assert_eq!(config.compression, Compression::Xz);
         assert!(!config.write_nar_listing);
         assert!(!config.write_debug_info);
-        assert!(!config.write_realisation);
+        assert!(!config.write_build_trace);
         assert!(config.secret_key_files.is_empty());
         assert!(!config.parallel_compression);
         assert_eq!(config.compression_level, None);
@@ -766,15 +766,15 @@ aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvb123KEY"
         let config = S3CacheConfig::new(client_config.clone()).with_write_debug_info(None);
         assert!(!config.write_debug_info);
 
-        let config = S3CacheConfig::new(client_config.clone()).with_write_realisation(Some("TRUE"));
-        assert!(config.write_realisation);
+        let config = S3CacheConfig::new(client_config.clone()).with_write_build_trace(Some("TRUE"));
+        assert!(config.write_build_trace);
 
         let config =
-            S3CacheConfig::new(client_config.clone()).with_write_realisation(Some("  True  "));
-        assert!(config.write_realisation);
+            S3CacheConfig::new(client_config.clone()).with_write_build_trace(Some("  True  "));
+        assert!(config.write_build_trace);
 
-        let config = S3CacheConfig::new(client_config.clone()).with_write_realisation(None);
-        assert!(!config.write_realisation);
+        let config = S3CacheConfig::new(client_config.clone()).with_write_build_trace(None);
+        assert!(!config.write_build_trace);
 
         let secret_keys = vec![
             std::path::PathBuf::from("/path/to/key1"),
@@ -1083,7 +1083,7 @@ aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvb123KEY"
             .with_compression(Some(Compression::Zstd))
             .with_write_nar_listing(Some("true"))
             .with_write_debug_info(Some("1"))
-            .with_write_realisation(Some("1"))
+            .with_write_build_trace(Some("1"))
             .with_parallel_compression(Some("true"))
             .with_compression_level(Some(6))
             .with_narinfo_compression(Some(Compression::Bzip2))
@@ -1100,7 +1100,7 @@ aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvb123KEY"
         assert_eq!(config.compression, Compression::Zstd);
         assert!(config.write_nar_listing);
         assert!(config.write_debug_info);
-        assert!(config.write_realisation);
+        assert!(config.write_build_trace);
         assert!(config.parallel_compression);
         assert_eq!(config.compression_level, Some(6));
         assert_eq!(config.narinfo_compression, Compression::Bzip2);

--- a/subprojects/crates/binary-cache/src/lib.rs
+++ b/subprojects/crates/binary-cache/src/lib.rs
@@ -25,7 +25,7 @@ use smallvec::SmallVec;
 
 use harmonia_store_path::{StoreDir, StorePath};
 
-// Realisation writing is now done by the caller, not via FFI query.
+// Build trace entries are written by the caller, not via an FFI query.
 
 mod cfg;
 mod compression;
@@ -254,6 +254,15 @@ async fn run_multipart_upload(
 /// Stream a NAR by serializing the store path directly from the
 /// filesystem, like harmonia-cache does when serving NARs. This avoids
 /// holding a nix-daemon connection for the duration of the stream.
+/// Where one build trace entry lives in a binary cache:
+/// `build-trace-v2/<drvBaseName>/<outputName>.doi`, two path segments
+/// encoding the key. See
+/// <https://nix.dev/manual/nix/2.35/protocols/binary-cache>.
+#[must_use]
+pub fn build_trace_entry_key(id: &harmonia_store_derivation::realisation::DrvOutput) -> String {
+    format!("build-trace-v2/{}/{}.doi", id.drv_path, id.output_name)
+}
+
 fn read_nar_stream(
     store_dir: &StoreDir,
     path: &StorePath,
@@ -720,7 +729,7 @@ impl S3BinaryCacheClient {
             narinfo.info.download_size = Some(file_size as u64);
         }
 
-        // Realisation writing for CA derivations is handled by the caller
+        // Build trace entries for CA derivations are written by the caller
         // (e.g. the queue-runner after resolving and building a CA drv),
         // not here during path copy.
 
@@ -755,24 +764,24 @@ impl S3BinaryCacheClient {
         Ok(())
     }
 
-    /// Write a pre-constructed [`Realisation`] to the binary cache.
+    /// Write one build trace entry to the binary cache.
     ///
-    /// Signs the realisation with the cache's secret keys before uploading.
-    #[tracing::instrument(skip(self, realisation), err)]
-    pub async fn write_realisation(
+    /// Signs it with the cache's secret keys before uploading. Only the value
+    /// is written: the key is the object's own path.
+    #[tracing::instrument(skip(self, entry), err)]
+    pub async fn write_build_trace_entry(
         &self,
-        mut realisation: harmonia_store_derivation::realisation::Realisation,
+        mut entry: harmonia_store_derivation::realisation::Realisation,
     ) -> Result<(), CacheError> {
         let keys = self
             .signing_keys
             .iter()
             .filter_map(|s| s.expose_secret().parse().ok())
             .collect::<SmallVec<[harmonia_utils_signature::SecretKey; 4]>>();
-        realisation.value.sign_mut(&realisation.key, &keys);
+        entry.value.sign_mut(&entry.key, &keys);
 
-        let json = serde_json::to_string(&realisation)?;
-        let id = &realisation.key;
-        self.upsert_file(&format!("realisations/{id}.doi"), json, "application/json")
+        let json = serde_json::to_string(&entry.value)?;
+        self.upsert_file(&build_trace_entry_key(&entry.key), json, "application/json")
             .await?;
         Ok(())
     }
@@ -973,19 +982,19 @@ impl S3BinaryCacheClient {
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn download_realisation(
+    pub async fn download_build_trace_entry(
         &self,
         id: &harmonia_store_derivation::realisation::DrvOutput,
     ) -> Result<Option<Bytes>, CacheError> {
-        self.get_object(&format!("realisations/{id}.doi")).await
+        self.get_object(&build_trace_entry_key(id)).await
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn has_realisation(
+    pub async fn has_build_trace_entry(
         &self,
         id: &harmonia_store_derivation::realisation::DrvOutput,
     ) -> Result<bool, CacheError> {
-        Ok(self.download_realisation(id).await?.is_some())
+        Ok(self.download_build_trace_entry(id).await?.is_some())
     }
 
     #[tracing::instrument(skip(self, paths))]
@@ -1253,7 +1262,7 @@ impl S3BinaryCacheClient {
         narinfo.info.download_size = Some(file_size);
 
         let narinfo = clear_sigs_and_sign(narinfo, &self.cfg.store_dir, &self.signing_keys);
-        // TODO: we also need to integrate realisation into this!
+        // TODO: we also need to integrate build trace entries into this!
         let path = narinfo.path.clone();
         let key = self.upload_narinfo(narinfo.clone()).await?;
         self.presence_cache

--- a/subprojects/hydra-builder/src/state.rs
+++ b/subprojects/hydra-builder/src/state.rs
@@ -455,8 +455,8 @@ impl State {
         // releases them. Pin them onto the persistent roots connection first,
         // or a GC in the gap collects the outputs and the upload fails.
         if let BuildResultInner::Success(s) = &build_result.inner {
-            for realisation in s.built_outputs.values() {
-                pin_path(roots, &realisation.out_path).await;
+            for entry in s.built_outputs.values() {
+                pin_path(roots, &entry.out_path).await;
             }
         }
         drop(conn);
@@ -582,7 +582,7 @@ impl State {
         let outputs: BTreeMap<OutputName, StorePath> = success
             .built_outputs
             .into_iter()
-            .map(|(name, realisation)| (name, realisation.out_path))
+            .map(|(name, entry)| (name, entry.out_path))
             .collect();
 
         timings.build_elapsed = before_build.elapsed();

--- a/subprojects/hydra-queue-runner/src/state/mod.rs
+++ b/subprojects/hydra-queue-runner/src/state/mod.rs
@@ -2032,18 +2032,19 @@ impl State {
             }
         }
 
-        // Write realisations for CA floating outputs to binary caches.
-        // This maps (resolved_drv_path, output_name) -> concrete_output_path,
+        // Write build trace entries for CA floating outputs to binary caches.
+        // These map (resolved_drv_path, output_name) -> concrete_output_path,
         // allowing clients to look up outputs by derivation path.
         //
-        // TODO: also write realisations to the local store's SQLite
-        // `Realisations` table (for non-S3 / FFI stores) once nix is
-        // updated to 2.35, which uses path-based DrvOutput matching
-        // the harmonia types.
+        // TODO: this only reaches S3 caches, so a Hydra backed by anything
+        // else has no build trace entries to offer. `BuildStepOutputs` in the
+        // database already records the same mapping and is what the
+        // `build-trace-v2/` route serves from; what is missing there is the
+        // signature, which is computed just below.
         {
             let has_ca_floating = item.step_info.step.has_ca_floating_outputs();
             if has_ca_floating {
-                // Overflow-only steps write their realisations to the overflow store.
+                // Overflow-only steps write their build trace entries to the overflow store.
                 let s3_stores: Vec<binary_cache::S3BinaryCacheClient> =
                     if self.step_wants_overflow(&item.step_info.step) {
                         self.overflow_store
@@ -2062,7 +2063,7 @@ impl State {
                             .collect()
                     };
                 for (output_name, out_path) in &output.outputs {
-                    let realisation = Realisation {
+                    let entry = Realisation {
                         key: DrvOutput {
                             drv_path: drv_path.clone(),
                             output_name: output_name.clone(),
@@ -2073,9 +2074,9 @@ impl State {
                         },
                     };
                     for s3 in &s3_stores {
-                        if let Err(e) = s3.write_realisation(realisation.clone()).await {
+                        if let Err(e) = s3.write_build_trace_entry(entry.clone()).await {
                             tracing::warn!(
-                                "Failed to write realisation for {drv_path}^{output_name}: {e}"
+                                "Failed to write build trace entry for {drv_path}^{output_name}: {e}"
                             );
                         }
                     }
@@ -2914,7 +2915,7 @@ impl State {
                     "create_step: {drv_path} outputs in overflow store, awaiting copy to default store"
                 );
                 step.try_mark_upload_scheduled();
-                let realisation_keys = step
+                let build_trace_entry_keys = step
                     .get_output_paths()
                     .unwrap_or_default()
                     .into_keys()
@@ -2923,7 +2924,7 @@ impl State {
                             drv_path: drv_path.clone(),
                             output_name,
                         };
-                        format!("realisations/{id}.doi")
+                        binary_cache::build_trace_entry_key(&id)
                     })
                     .collect();
                 self.metrics.nr_overflow_copies_queued.inc();
@@ -2931,7 +2932,7 @@ impl State {
                     .schedule_copy(
                         paths,
                         format!("log/{drv_path}"),
-                        realisation_keys,
+                        build_trace_entry_keys,
                         Some(drv_path.clone()),
                     )
                     .await;

--- a/subprojects/hydra-queue-runner/src/state/uploader.rs
+++ b/subprojects/hydra-queue-runner/src/state/uploader.rs
@@ -76,8 +76,8 @@ struct Message {
 struct CopyMessage {
     store_paths: Vec<StorePath>,
     log_remote_path: String,
-    /// Realisation object keys to copy alongside, best effort.
-    realisation_keys: Vec<String>,
+    /// Build trace entry keys to copy alongside, best effort.
+    build_trace_entry_keys: Vec<String>,
     /// Drv path to report on the completion channel once the copy was
     /// attempted. Set for steps whose finished flag is gated on the copy.
     notify_drv: Option<StorePath>,
@@ -181,21 +181,21 @@ impl Uploader {
         &self,
         store_paths: Vec<StorePath>,
         log_remote_path: String,
-        realisation_keys: Vec<String>,
+        build_trace_entry_keys: Vec<String>,
         notify_drv: Option<StorePath>,
     ) {
         tracing::info!("Scheduling copy from overflow store: {store_paths:?}");
         self.copy_queue.send(CopyMessage {
             store_paths,
             log_remote_path,
-            realisation_keys,
+            build_trace_entry_keys,
             notify_drv,
         });
         let _ = self.save_copy_state().await;
     }
 
     /// Process one queued overflow→default copy: the closure of its store
-    /// paths, the build log and any realisations. Returns `None` when the
+    /// paths, the build log and any build trace entries. Returns `None` when the
     /// queue is empty, otherwise whether all objects were copied.
     pub async fn copy_once(
         &self,
@@ -225,7 +225,7 @@ impl Uploader {
         }
 
         for key in std::iter::once(&msg.log_remote_path)
-            .chain(msg.realisation_keys.iter())
+            .chain(msg.build_trace_entry_keys.iter())
             .map(String::as_str)
         {
             if let Err(e) = dest.copy_object_from(source, key).await {

--- a/subprojects/hydra-tests/Hydra/Controller/Root/build-trace.t
+++ b/subprojects/hydra-tests/Hydra/Controller/Root/build-trace.t
@@ -1,0 +1,65 @@
+use strict;
+use warnings;
+use Setup;
+use File::Basename ();
+use JSON::MaybeXS qw(decode_json);
+
+my %ctx = test_init(
+    nix_config => qq|
+    experimental-features = ca-derivations
+    |,
+    # A `file:` store is not a local store to `isLocalStore`, and the binary
+    # cache routes serve from nothing else.
+    use_external_destination_store => 0,
+);
+
+use Test2::V0;
+use HTTP::Request::Common;
+setup_catalyst_test($ctx{context});
+
+require Hydra::Schema;
+require Hydra::Helper::Nix;
+
+my $db = $ctx{context}->db();
+
+my $project = $db->resultset('Projects')->create({name => "tests", displayname => "", owner => "root"});
+my $jobset = createBaseJobset($db, "content-addressed", "content-addressed.nix", $ctx{jobsdir});
+
+ok(evalSucceeds($ctx{context}, $jobset), "Evaluating jobs/content-addressed.nix succeeds");
+my @builds = queuedBuildsForJobset($jobset);
+ok(runBuilds($ctx{context}, @builds), "Building jobs/content-addressed.nix succeeds");
+
+my ($build) = grep { $_->nixname eq "empty-dir" } @builds;
+$build->discard_changes();
+is($build->buildstatus, 0, "The content-addressed build succeeded");
+
+my $drv = File::Basename::basename($build->drvpath);
+my $outPath = File::Basename::basename($build->buildoutputs->find({ name => "out" })->path);
+
+subtest "serving a build trace" => sub {
+    my $response = request(GET "/build-trace-v2/$drv/out.doi");
+    ok($response->is_success, "A built content-addressed derivation has a build trace");
+
+    # A build trace entry, whose `outPath` carries no store directory:
+    # https://nix.dev/manual/nix/2.35/protocols/json/build-trace-entry
+    is(decode_json($response->content),
+        { outPath => $outPath, signatures => [] },
+        "naming the output it resolved to");
+};
+
+subtest "a build trace that does not exist" => sub {
+    my $response = request(GET "/build-trace-v2/00000000000000000000000000000000-nope.drv/out.doi");
+    is($response->code, 404, "404s");
+    is($response->content, "does not exist\n", "from the route itself");
+};
+
+# A key the constraints reject never reaches the route, so it answers something
+# other than the route's own "does not exist".
+subtest "a malformed key" => sub {
+    for my $bad ("$drv/out", "not-a-store-path/out.doi") {
+        my $response = request(GET "/build-trace-v2/$bad");
+        isnt($response->content, "does not exist\n", "'$bad' is not served");
+    }
+};
+
+done_testing;

--- a/subprojects/hydra-tests/content-addressed/basic.t
+++ b/subprojects/hydra-tests/content-addressed/basic.t
@@ -56,6 +56,7 @@ for my $build (@builds) {
 
 # XXX: deststoredir is undefined: Use of uninitialized value $ctx{"deststoredir"} in concatenation (.) or string at t/content-addressed/basic.t line 58.
 # XXX: This test seems to not do what it seems to be doing. See documentation: https://metacpan.org/pod/Test2::V0#isnt($got,-$do_not_want,-$name)
-isnt(<$ctx{deststoredir}/realisations/*>, "", "The destination store should have the realisations of the built derivations registered");
+isnt(<$ctx{deststoredir}/build-trace-v2/*>, "",
+    "The destination store should have the build traces of the built derivations registered");
 
 done_testing;

--- a/subprojects/hydra/lib/Hydra/Controller/Root.pm
+++ b/subprojects/hydra/lib/Hydra/Controller/Root.pm
@@ -21,8 +21,22 @@ use Types::Standard qw/StrMatch/;
 use WWW::Form::UrlEncoded::PP qw();
 
 use constant NARINFO_REGEX => qr{^([a-z0-9]{32})\.narinfo$};
-# e.g.: https://hydra.example.com/realisations/sha256:a62128132508a3a32eef651d6467695944763602f226ac630543e947d9feb140!out.doi
-use constant REALISATIONS_REGEX => qr{^(sha256:[a-z0-9]{64}![a-z]+)\.doi$};
+# e.g.: https://hydra.example.com/build-trace-v2/2sxdgnzp1nlxb0kbczsjnjvlpm9zjqvv-foo.drv/out.doi
+#
+# `build-trace-v2/<drvBaseName>/<outputName>.doi`, per the binary cache
+# layout in the Nix manual:
+# https://nix.dev/manual/nix/2.35/protocols/binary-cache
+# Two path segments, encoding the key: a derivation's store path -- with
+# no store directory on it -- and an output name.
+#
+# The prefix (`build-trace-v2`) is spelled out in the `:Path` below
+# rather than kept in a constant: Catalyst does not evaluate `Path`
+# attribute values, it takes them literally, so a constant there would
+# name the route after itself. `Args` type constraints are different --
+# those are eval'd in the controller's package, which is why the regexes
+# below can be constants.
+use constant BUILD_TRACE_DRV_REGEX => qr{^[a-z0-9]{32}-[^/]+$};
+use constant BUILD_TRACE_OUTPUT_REGEX => qr{^([a-zA-Z_][a-zA-Z0-9_.-]*)\.doi$};
 
 # Put this controller at top-level.
 __PACKAGE__->config->{namespace} = '';
@@ -371,18 +385,71 @@ sub nix_cache_info :Path('nix-cache-info') :Args(0) {
 }
 
 
-sub realisations :Path('realisations') :Args(StrMatch[REALISATIONS_REGEX]) {
-    my ($self, $c, $realisation) = @_;
+# The output paths recorded in the database carry the store directory; a
+# build trace names them without it.
+sub stripStoreDir {
+    my ($storeDir, $path) = @_;
+    die "path '$path' is not in the Nix store '$storeDir'\n"
+        unless substr($path, 0, length($storeDir) + 1) eq "$storeDir/";
+    return substr($path, length($storeDir) + 1);
+}
+
+
+# Which output path a derivation's output resolved to. `BuildStepOutputs`, with
+# `BuildSteps.drvPath`, records exactly that. We just need to make sure we
+# handle derivation resolution.
+#
+# TODO this duplicates a very similar SQL query in hydra queue runner:
+# `resolve_drv_output_chains` in `crates/db/src/connection.rs` joins the same
+# two tables and takes the same resolution hop, spelling it as a `LEFT JOIN`
+# on the resolved step and a `COALESCE`. It also admits a Resolved step
+# (status 13) as the outer step, where we split the two cases apart; that is
+# the difference to reconcile if these are ever merged.
+sub lookupBuildTrace {
+    my ($c, $drvPath, $outputName) = @_;
+    my $storeDir = $MACHINE_LOCAL_STORE->storeDir;
+
+    my $drvPathInStore = "$storeDir/$drvPath";
+
+    my $output = $c->model('DB::BuildStepOutputs')->search(
+        { "me.name" => $outputName
+        , "me.path" => { "!=" => undef }
+        , "buildstep.status" => 0
+        # Either the derivation asked about was built directly, or -- being
+        # content-addressed -- it was resolved first and built under the
+        # resolved name, which is the step the outputs hang off. The Resolved
+        # step records that name, without a store directory.
+        , -or =>
+            [ "buildstep.drvpath" => $drvPathInStore
+            , "buildstep.drvpath" => { -in => \[
+                "select ? || '/' || resolveddrvpath from buildsteps"
+                . " where drvpath = ? and status = 13",
+                $storeDir, $drvPathInStore ] }
+            ]
+        },
+        { join => "buildstep"
+        # A derivation may have been built more than once; any successful
+        # attempt is as good an answer as another, so take the newest.
+        , order_by => { -desc => "buildstep.stoptime" }
+        , rows => 1
+        })->single;
+
+    return defined $output ? stripStoreDir($storeDir, $output->path) : undef;
+}
+
+
+sub build_trace :Path('build-trace-v2') :Args(StrMatch[BUILD_TRACE_DRV_REGEX], StrMatch[BUILD_TRACE_OUTPUT_REGEX]) {
+    my ($self, $c, $drvPath, $outputFile) = @_;
 
     if (!isLocalStore) {
         notFound($c, "There is no binary cache here.");
     }
 
     else {
-        my ($rawDrvOutput) = $realisation =~ REALISATIONS_REGEX;
-        my $rawRealisation = $MACHINE_LOCAL_STORE->queryRawRealisation($rawDrvOutput);
+        my ($outputName) = $outputFile =~ BUILD_TRACE_OUTPUT_REGEX;
+        my $outPath = lookupBuildTrace($c, $drvPath, $outputName);
 
-        if (!$rawRealisation) {
+        if (!defined $outPath) {
             $c->response->status(404);
             $c->response->content_type('text/plain');
             $c->stash->{plain}->{data} = "does not exist\n";
@@ -391,8 +458,16 @@ sub realisations :Path('realisations') :Args(StrMatch[REALISATIONS_REGEX]) {
             return;
         }
 
-        $c->response->content_type('text/plain');
-        $c->stash->{plain}->{data} = $rawRealisation;
+        # A build trace entry, as described in the Nix manual:
+        # https://nix.dev/manual/nix/2.35/protocols/json/build-trace-entry
+        # Only the value is written, the key being the URL itself.
+        #
+        # TODO: sign these. `require-sigs` defaults on, so a client rejects an
+        # unsigned build trace, which makes this correct but not yet
+        # substitutable. See the note on BuildStepOutputs.
+        $c->response->content_type('application/json');
+        $c->stash->{plain}->{data} = encode_json(
+            { outPath => $outPath, signatures => [] });
         $c->forward('Hydra::View::Plain');
     }
 }

--- a/subprojects/hydra/sql/hydra.sql
+++ b/subprojects/hydra/sql/hydra.sql
@@ -311,6 +311,13 @@ create table BuildSteps (
 );
 
 
+-- Joined with BuildSteps.drvPath this makes the build trace: which
+-- output path a derivation's output actually resolved to. Hydra serves
+-- the corresponding `build-trace-v2/` routes as part of its on-the-fly
+-- binary cache.
+--
+-- TODO: signatures. We should store signatures in the database,
+-- otherwise these build trace entries cannot be used safely.
 create table BuildStepOutputs (
     build         integer not null,
     stepnr        integer not null,

--- a/subprojects/nix-perl/lib/Nix/Store.pm
+++ b/subprojects/nix-perl/lib/Nix/Store.pm
@@ -20,7 +20,6 @@ our @EXPORT = qw(
     StoreWrapper::addToStore
     StoreWrapper::derivationSystem
     StoreWrapper::addTempRoot
-    StoreWrapper::queryRawRealisation
 
     signString
     StoreWrapper::storeDir

--- a/subprojects/nix-perl/lib/Nix/Store.xs
+++ b/subprojects/nix-perl/lib/Nix/Store.xs
@@ -7,11 +7,9 @@
 #undef do_close
 
 #include "nix/store/derivations.hh"
-#include "nix/store/realisation.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/store-open.hh"
 #include "nix/util/source-accessor.hh"
-#include <nlohmann/json.hpp>
 
 using namespace nix;
 
@@ -141,19 +139,6 @@ StoreWrapper::queryPathInfo(char * path, int base32)
         } catch (Error & e) {
             croak("%s", e.what());
         }
-
-SV *
-StoreWrapper::queryRawRealisation(char * outputId)
-    PPCODE:
-      try {
-        auto realisation = THIS->store->queryRealisation(DrvOutput::parse(*THIS->store, outputId));
-        if (realisation)
-            XPUSHs(sv_2mortal(newSVpv(static_cast<nlohmann::json>(*realisation).dump().c_str(), 0)));
-        else
-            XPUSHs(sv_2mortal(newSVpv("", 0)));
-      } catch (Error & e) {
-        croak("%s", e.what());
-      }
 
 
 SV *


### PR DESCRIPTION
Note that this changes a URL, which is a breaking change, but since

- content-addressed derivations are experimental and not yet enabled at `hydra.nixos.org`

- the route it changes never worked

there is nothing here worth preserving compatibility with.

It bears reiterating that this commit only changes code which is *dead* with respect to `hydra.nixos.org`.

Implementation details:

Nix 2.35 moved build traces about: a `DrvOutput` became a derivation's store path and an output name rather than a hash, the cache directory went from `realisations/` to
`build-trace-v2/<drvBaseName>/<outputName>.doi`, and the file there stopped carrying its own key, holding just the value.

What we were doing had simply not caught up. Uploading to the binary cache still wrote under `realisations/`, and wrote a whole `Realisation`, `{"key": ..., "value": ...}`, keeping to the old convention of a file that names itself. Both were right once; neither is something a current client looks for or can parse.

The queue runner upload code path presumably did work, just was out of date for the latest clients (that enabled this experimental feature). The on-demand code path was in worse shape -- totally broken:

1. It matched the old `sha256:<hex>!<output>.doi` key, which the binding it called could no longer parse, so it could not have answered even the Nix we build against.

2. It asked the local Nix store, which we would rather get rid of *altogether*, and which has no build traces to give in any case, since the queue runner only ever writes them to S3.

For the on-demand code path, Hydra should in fact bypass both these issues by always using its database instead. `BuildStepOutputs` already records what a build trace is, on every build whatever the backend, so there was nothing to migrate and nothing new to teach the queue runner. That leaves one of our Nix bindings --- `queryRawRealisation` --- unused, so we can get rid of it.

Neither direction was tested, which is how both went unnoticed: the one test that looks was asserting the stale directory exists. Now at least the on-demand way is tested.

The on-demand build trace entry is unsigned, however. See the new TODO on `BuildStepOutputs`: it is there because we need to track more information in the database if we are to fix this properly. What we upload is signed already, so that path does not have to wait.

Finally, stop saying "realisation", which is a term we are in the process of getting rid of. A build trace is the whole map; one record in it is a build trace entry, which is what most of this deals in. The harmonia type keeps its name, being someone else's.