### PR TITLE
db: force drvPath index in resolve_drv_output_chains

### DIFF
--- a/subprojects/crates/db/src/connection.rs
+++ b/subprojects/crates/db/src/connection.rs
@@ -398,7 +398,9 @@ impl Connection {
                       AND o.name = i.chain[r.step]
                       AND o.path IS NOT NULL
                       AND (s.status = 0 OR s.status = 13)
-                    ORDER BY s.build DESC
+                    -- `+ 0`: otherwise the planner walks buildsteps_pkey
+                    -- backwards instead of using IndexBuildStepsOnDrvPath.
+                    ORDER BY s.build + 0 DESC
                     LIMIT 1
                 ) sub
                 WHERE r.step <= array_length(i.chain, 1)


### PR DESCRIPTION
> [!NOTE]
>
> We are waiting to see if this will fix prod before merging it

With ORDER BY s.build DESC LIMIT 1 the planner walked buildsteps_pkey backwards filtering on drvPath. For a never-built drv that is a full scan of BuildSteps (>10 min on hydra.nixos.org), stalling the dispatcher. `+ 0` makes it use IndexBuildStepsOnDrvPath instead (0.4 ms).