### PR TITLE
Build rust crates with crane, cache CI with hestia

### DIFF
--- a/.github/workflows/cache-gc.yml
+++ b/.github/workflows/cache-gc.yml
@@ -1,0 +1,26 @@
+name: Cache GC
+concurrency:
+  group: hestia-gc
+  cancel-in-progress: false
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Plan only; do not delete anything.
+        type: boolean
+        default: false
+permissions:
+  contents: read
+jobs:
+  gc:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: Mic92/hestia@v2
+      - run: "$HESTIA_BIN" gc ${{ inputs.dry-run && '--dry-run' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   tests:
     strategy:
@@ -28,4 +30,6 @@ jobs:
       with:
         name: hydra-test-cache
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - uses: Mic92/hestia@v2
+    - run: nix-build -A packages.${{ matrix.system }}.hydra-cargo-deps
     - run: nix-build -A checks.${{ matrix.system }}.systemTests -A checks.${{ matrix.system }}.validate-openapi -A checks.${{ matrix.system }}.formatter

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1787326676,
+        "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "692f7e9ef2ece8125b466f66f2af532b3edaed0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "foreman": {
       "flake": false,
       "locked": {
@@ -66,6 +81,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "foreman": "foreman",
         "nix": "nix",
         "nix-eval-jobs": "nix-eval-jobs",

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
     inputs.nixpkgs.follows = "nixpkgs";
   };
 
+  inputs.crane.url = "github:ipetkov/crane";
+
   outputs =
     {
       self,
@@ -35,6 +37,7 @@
       nix-eval-jobs,
       foreman,
       treefmt-nix,
+      crane,
       ...
     }:
     let
@@ -56,39 +59,62 @@
         builtins.substring 0 8 (self.lastModifiedDate or "19700101")
       }.${self.shortRev or "DIRTY"}";
 
+      # makeScope adds non-derivation attrs that fail `nix flake check`
+      nonPackageAttrs = [
+        "newScope"
+        "callPackage"
+        "overrideScope"
+        "packages"
+        "version"
+        "releaseVersion"
+        "craneLib"
+        "rustWorkspace"
+      ];
+
+      mkRustScope = pkgs: self': {
+        craneLib = crane.mkLib pkgs;
+        rustWorkspace = self'.callPackage ./packaging/rust-workspace.nix { };
+        hydra-cargo-deps = self'.rustWorkspace.cargoArtifacts;
+        hydra-builder = self'.callPackage ./subprojects/hydra-builder/package.nix { };
+      };
+
       mkHydraComponents =
         { pkgs, nixComponents }:
-        pkgs.lib.makeScope pkgs.newScope (self': {
-          inherit version releaseVersion;
-          nix-eval-jobs = self'.callPackage nix-eval-jobs {
-            inherit nixComponents;
-          };
-          nix-perl = self'.callPackage ./subprojects/nix-perl/package.nix {
-            inherit (nixComponents) nix-store;
-          };
-          hydra = self'.callPackage ./subprojects/hydra/package.nix {
-            inherit nixComponents;
-            rawSrc = self;
-          };
-          hydra-tests = self'.callPackage ./subprojects/hydra-tests/package.nix {
-            inherit nixComponents;
-          };
-          hydra-manual = self'.callPackage ./subprojects/hydra-manual/package.nix {
-          };
-          hydra-linters = self'.callPackage ./subprojects/hydra-linters/package.nix {
-          };
-          hydra-queue-runner = self'.callPackage ./subprojects/hydra-queue-runner/package.nix {
-          };
-          hydra-builder = self'.callPackage ./subprojects/hydra-builder/package.nix {
-          };
-        });
+        pkgs.lib.makeScope pkgs.newScope (
+          self':
+          mkRustScope pkgs self'
+          // {
+            inherit version releaseVersion;
+            nix-eval-jobs = self'.callPackage nix-eval-jobs {
+              inherit nixComponents;
+            };
+            nix-perl = self'.callPackage ./subprojects/nix-perl/package.nix {
+              inherit (nixComponents) nix-store;
+            };
+            hydra = self'.callPackage ./subprojects/hydra/package.nix {
+              inherit nixComponents;
+              rawSrc = self;
+            };
+            hydra-tests = self'.callPackage ./subprojects/hydra-tests/package.nix {
+              inherit nixComponents;
+            };
+            hydra-manual = self'.callPackage ./subprojects/hydra-manual/package.nix {
+            };
+            hydra-linters = self'.callPackage ./subprojects/hydra-linters/package.nix {
+            };
+            hydra-queue-runner = self'.callPackage ./subprojects/hydra-queue-runner/package.nix {
+            };
+          }
+        );
       mkHydraBuilder =
-        { pkgs, nixComponents }:
-        pkgs.lib.makeScope pkgs.newScope (self': {
-          inherit version releaseVersion;
-          hydra-builder = self'.callPackage ./subprojects/hydra-builder/package.nix {
-          };
-        });
+        { pkgs }:
+        pkgs.lib.makeScope pkgs.newScope (
+          self':
+          mkRustScope pkgs self'
+          // {
+            inherit version releaseVersion;
+          }
+        );
 
       treefmtConfig =
         { ... }:
@@ -216,15 +242,7 @@
               );
               hydraComponents = mkHydraComponents { inherit pkgs nixComponents; };
             in
-            # makeScope adds non-derivation attrs that fail `nix flake check`
-            removeAttrs hydraComponents [
-              "newScope"
-              "callPackage"
-              "overrideScope"
-              "packages"
-              "version"
-              "releaseVersion"
-            ]
+            removeAttrs hydraComponents nonPackageAttrs
             // {
               default = hydraComponents.hydra-tests;
             }
@@ -233,34 +251,9 @@
             forEachSystemIncDarwin (
               system:
               let
-                inherit (nixpkgs) lib;
-                pkgs = nixpkgs.legacyPackages.${system};
-                nixDependencies = lib.makeScope pkgs.newScope (
-                  import (nix + "/packaging/dependencies.nix") {
-                    inherit pkgs;
-                    inherit (pkgs) stdenv;
-                    inputs = { };
-                  }
-                );
-                nixComponents = lib.makeScope nixDependencies.newScope (
-                  import (nix + "/packaging/components.nix") {
-                    officialRelease = true;
-                    inherit lib pkgs;
-                    src = nix;
-                    maintainers = [ ];
-                  }
-                );
-                hydraBuilder = mkHydraBuilder { inherit pkgs nixComponents; };
+                hydraBuilder = mkHydraBuilder { pkgs = nixpkgs.legacyPackages.${system}; };
               in
-              # makeScope adds non-derivation attrs that fail `nix flake check`
-              removeAttrs hydraBuilder [
-                "newScope"
-                "callPackage"
-                "overrideScope"
-                "packages"
-                "version"
-                "releaseVersion"
-              ]
+              removeAttrs hydraBuilder nonPackageAttrs
             )
           );
 

--- a/packaging/cargo-output-hashes.nix
+++ b/packaging/cargo-output-hashes.nix
@@ -1,5 +1,0 @@
-# Shared outputHashes for cargoLock across all Rust crates.
-# Update this file when the harmonia dependency changes.
-{
-  "harmonia-store-derivation-0.0.0-alpha.0" = "sha256-dy3QJKJDZBLEeyZpjFTt/wjdB/xqAKLBREMmR1qEba4=";
-}

--- a/packaging/rust-workspace.nix
+++ b/packaging/rust-workspace.nix
@@ -1,0 +1,75 @@
+# One dependency build (cargoArtifacts) shared by every workspace crate, so
+# CI only recompiles hydra's own crates.
+{
+  lib,
+  craneLib,
+  protobuf,
+  pkg-config,
+  rust-jemalloc-sys,
+}:
+let
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../.cargo
+      ../.sqlx
+      ../subprojects/hydra-queue-runner/Cargo.toml
+      ../subprojects/hydra-queue-runner/src
+      ../subprojects/hydra-queue-runner/examples
+      ../subprojects/hydra-builder/Cargo.toml
+      ../subprojects/hydra-builder/src
+      ../subprojects/crates
+      # For unit tests which want to spin up a fresh database
+      ../subprojects/hydra/sql/hydra.sql
+      ../subprojects/proto
+    ];
+  };
+
+  commonArgs = {
+    inherit src;
+    pname = "hydra-rust-workspace";
+    version = "0.0.0";
+    strictDeps = true;
+
+    nativeBuildInputs = [
+      pkg-config
+      protobuf
+    ];
+
+    buildInputs = [
+      rust-jemalloc-sys
+    ];
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+in
+{
+  inherit cargoArtifacts;
+
+  mkCrate =
+    {
+      pname,
+      version,
+      features ? [ ],
+      meta,
+    }:
+    craneLib.buildPackage (
+      commonArgs
+      // {
+        inherit
+          pname
+          version
+          meta
+          cargoArtifacts
+          ;
+        cargoExtraArgs = lib.concatStringsSep " " (
+          [ "--package ${pname}" ]
+          ++ lib.optional (features != [ ]) "--features ${lib.concatStringsSep "," features}"
+        );
+        # FIXME: get these passing in a prod build
+        doCheck = false;
+      }
+    );
+}

--- a/subprojects/hydra-builder/package.nix
+++ b/subprojects/hydra-builder/package.nix
@@ -1,61 +1,13 @@
 {
   lib,
   version,
-
-  rustPlatform,
-
-  protobuf,
-  pkg-config,
-  rust-jemalloc-sys,
+  rustWorkspace,
   withOtel ? false,
 }:
 
-rustPlatform.buildRustPackage {
+rustWorkspace.mkCrate {
   pname = "hydra-builder";
   inherit version;
-
-  src = lib.fileset.toSource {
-    root = ../..;
-    fileset = lib.fileset.unions [
-      ../../Cargo.toml
-      ../../Cargo.lock
-      ../../.cargo
-      ../../subprojects/hydra-builder/Cargo.toml
-      ../../subprojects/hydra-builder/src
-      ../../subprojects/crates
-      # For unit tests which want to spin up a fresh database
-      ../../subprojects/hydra/sql/hydra.sql
-      ../../subprojects/proto
-    ];
-  };
-
-  cargoLock = {
-    lockFile = ../../Cargo.lock;
-    outputHashes = import ../../packaging/cargo-output-hashes.nix;
-  };
-
-  # The source fileset above intentionally excludes hydra-queue-runner,
-  # so drop it from the workspace members to keep cargo from trying to
-  # load its (absent) manifest.
-  postPatch = ''
-    sed -i 's|"subprojects/hydra-queue-runner", ||' Cargo.toml
-  '';
-
-  buildAndTestSubdir = "subprojects/hydra-builder";
-  buildFeatures = lib.optional withOtel "otel";
-
-  nativeBuildInputs = [
-    pkg-config
-    protobuf
-  ];
-
-  buildInputs = [
-    protobuf
-    rust-jemalloc-sys
-  ];
-
-  # FIXME: get these passing in a prod build
-  doCheck = false;
-
+  features = lib.optional withOtel "otel";
   meta.description = "Hydra builder (Rust)";
 }

--- a/subprojects/hydra-queue-runner/package.nix
+++ b/subprojects/hydra-queue-runner/package.nix
@@ -1,63 +1,13 @@
 {
   lib,
   version,
-
-  rustPlatform,
-
-  protobuf,
-  pkg-config,
-  rust-jemalloc-sys,
+  rustWorkspace,
   withOtel ? false,
 }:
 
-rustPlatform.buildRustPackage {
+rustWorkspace.mkCrate {
   pname = "hydra-queue-runner";
   inherit version;
-
-  src = lib.fileset.toSource {
-    root = ../..;
-    fileset = lib.fileset.unions [
-      ../../Cargo.toml
-      ../../Cargo.lock
-      ../../.cargo
-      ../../.sqlx
-      ../../subprojects/hydra-queue-runner/Cargo.toml
-      ../../subprojects/hydra-queue-runner/src
-      ../../subprojects/hydra-queue-runner/examples
-      ../../subprojects/crates
-      # For unit tests which want to spin up a fresh database
-      ../../subprojects/hydra/sql/hydra.sql
-      ../../subprojects/proto
-    ];
-  };
-
-  cargoLock = {
-    lockFile = ../../Cargo.lock;
-    outputHashes = import ../../packaging/cargo-output-hashes.nix;
-  };
-
-  # The source fileset above intentionally excludes hydra-builder,
-  # so drop it from the workspace members to keep cargo from trying to
-  # load its (absent) manifest.
-  postPatch = ''
-    sed -i 's|"subprojects/hydra-builder", ||' Cargo.toml
-  '';
-
-  buildAndTestSubdir = "subprojects/hydra-queue-runner";
-  buildFeatures = lib.optional withOtel "otel";
-
-  nativeBuildInputs = [
-    pkg-config
-    protobuf
-  ];
-
-  buildInputs = [
-    protobuf
-    rust-jemalloc-sys
-  ];
-
-  # FIXME: get these passing in a prod build
-  doCheck = false;
-
+  features = lib.optional withOtel "otel";
   meta.description = "Hydra queue runner (Rust)";
 }


### PR DESCRIPTION
Crane shares one dependency build between the rust crates. Hestia caches CI builds in the actions cache, which also works for fork PRs without the cachix token.