### PR TITLE
flake: Fix the overlay by not mistaking a scope for a package set

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,6 @@
         "packages"
         "version"
         "releaseVersion"
-        "craneLib"
         "rustWorkspace"
       ];
 
@@ -96,25 +95,40 @@
         );
 
       mkNixComponents =
-        { pkgs, nixDependencies }:
-        pkgs.lib.makeScope nixDependencies.newScope (
+        {
+          lib,
+          pkgs,
+          # From a scope with dependencies for Nix
+          newScope,
+        }:
+        lib.makeScope newScope (
           import (nix + "/packaging/components.nix") {
             officialRelease = true;
-            inherit (pkgs) lib;
-            inherit pkgs;
+            inherit lib pkgs;
             src = nix;
             maintainers = [ ];
           }
         );
 
       mkHydraComponents =
-        { pkgs, nixComponents }:
-        pkgs.lib.makeScope pkgs.newScope (
+        {
+          lib,
+          # From a scope with dependencies for Nix
+          newScope,
+          craneLib,
+          nixComponents,
+        }:
+        lib.makeScope newScope (
           import ./packaging/components.nix {
-            inherit version releaseVersion crane;
+            inherit
+              version
+              releaseVersion
+              craneLib
+              nixComponents
+              ;
             nix-eval-jobs-src = nix-eval-jobs;
             rawSrc = self;
-          } { inherit pkgs nixComponents; }
+          }
         );
 
       treefmtConfig =
@@ -134,15 +148,18 @@
     rec {
 
       overlays.default = final: prev: {
+        craneLib = crane.mkLib final;
         nixDependenciesForHydra = mkNixDependencies final;
         nixComponentsForHydra = mkNixComponents {
+          inherit (final) lib;
           pkgs = final;
-          nixDependencies = final.nixDependenciesForHydra;
+          inherit (final.nixDependenciesForHydra) newScope;
         };
         hydraComponents = mkHydraComponents {
+          inherit (final) lib craneLib;
           # Base package set should still use Nix's deps, so things that
           # link Nix agree on libraries.
-          pkgs = final.nixDependenciesForHydra;
+          inherit (final.nixDependenciesForHydra) newScope;
           nixComponents = final.nixComponentsForHydra;
         };
         inherit (final.hydraComponents)
@@ -216,8 +233,17 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           nixDependencies = mkNixDependencies pkgs;
-          nixComponents = mkNixComponents { inherit pkgs nixDependencies; };
-          hydraComponents = mkHydraComponents { inherit pkgs nixComponents; };
+          nixComponents = mkNixComponents {
+            inherit (pkgs) lib;
+            inherit pkgs;
+            inherit (nixDependencies) newScope;
+          };
+          hydraComponents = mkHydraComponents {
+            inherit (pkgs) lib;
+            craneLib = crane.mkLib pkgs;
+            inherit (pkgs) newScope;
+            inherit nixComponents;
+          };
         in
         removeAttrs hydraComponents nonPackageAttrs
         // {

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -1,21 +1,22 @@
 # The scope holding every component hydra itself builds, on top of a Nix
-# component set. `flake.nix` instantiates it once per package set.
+# component set. Like Nix's own `packaging/components.nix`, this is the scope
+# function; the caller applies `makeScope`.
 {
   version,
   releaseVersion,
-  crane,
+  craneLib,
   # Source of the `nix-eval-jobs` flake input, which carries its own package.nix.
   nix-eval-jobs-src,
   # The flake itself, which `hydra` wants unfiltered for its version stamp.
   rawSrc,
+  nixComponents,
 }:
-
-{ pkgs, nixComponents }:
 
 self': {
   inherit version releaseVersion;
-  craneLib = crane.mkLib pkgs;
-  rustWorkspace = self'.callPackage ./rust-workspace.nix { };
+  rustWorkspace = self'.callPackage ./rust-workspace.nix {
+    inherit craneLib;
+  };
   hydra-cargo-deps = self'.rustWorkspace.cargoArtifacts;
   nix-eval-jobs = self'.callPackage nix-eval-jobs-src {
     inherit nixComponents;


### PR DESCRIPTION
I thought I was being clever passing in `nixDependenciesForHydra` as `pkgs` (using "pkgs" in more of "local scope" "*an* ambient package set" rather than "*the* ambient package set" way). But actually, I broke the overlay because `nixDependenciesForHydra.lib` did not actually exist.

I only noticed this when I went to bump staging-hydra in Nix infra.

Now, fix that, and while we're at it, shuffle around the function arguments a bit more purely as a matter of taste. For example:

- passing in `newScope` does the "local scope" naming idea much better without this pitfall.

- The double-parameter `packaging/components.nix` was kinda cute but ultimately pointless so I made it take a single attribute set parameter.