### PR TITLE
tests: sort cached output NAR entries

### DIFF
--- a/subprojects/hydra-queue-runner/src/state/cached_output.rs
+++ b/subprojects/hydra-queue-runner/src/state/cached_output.rs
@@ -413,12 +413,12 @@ mod tests {
         let products = format!("file json /nix/store/{output}/data.json\n");
         let events = vec![
             start_dir(""),
+            file("data.json", b"{}"),
             start_dir("nix-support"),
             file("hydra-build-products", products.as_bytes()),
             file("hydra-metrics", b"coverage 87.5 %\n"),
             file("hydra-release-name", b"cached-1.0\n"),
             NarEvent::EndDirectory,
-            file("data.json", b"{}"),
             NarEvent::EndDirectory,
         ];
 


### PR DESCRIPTION
This PR fixes a test fixture that generated an invalid NAR by emitting directory entries out of canonical bytewise order, causing Harmonia’s parser to reject it.

- emit the cached-output test NAR's root entries in canonical bytewise order
- keep the synthetic fixture accepted by Harmonia's NAR parser

## Testing

- `cargo test -p hydra-queue-runner state::cached_output::tests::extracts_build_products_and_metrics_from_nar -- --exact`
- `cargo test`
- `cargo fmt --all -- --check`
