### PR TITLE
hydra-eval-jobset: Stop passing the fetched inputs to code that ignores them

### DIFF
--- a/subprojects/hydra/script/hydra-eval-jobset
+++ b/subprojects/hydra/script/hydra-eval-jobset
@@ -507,7 +507,7 @@ sub getPrevJobsetEval {
 
 # Check whether to add the build described by $buildInfo.
 sub checkBuild {
-    my ($db, $jobset, $eval, $inputInfo, $buildInfo, $buildMap, $prevEval, $jobOutPathMap) = @_;
+    my ($db, $jobset, $eval, $buildInfo, $buildMap, $prevEval, $jobOutPathMap) = @_;
 
     my @outputNames = sort keys %{$buildInfo->{outputs}};
     die unless scalar @outputNames;
@@ -896,7 +896,7 @@ sub checkJobsetWrapped {
                 ($job->{attr} ne "" ? "in job ‘$job->{attr}’" : "at top-level") .
                 ":\n" . $job->{error} . "\n\n" if defined $job->{error};
 
-            checkBuild($db, $jobset, $ev, $inputInfo, $job, \%buildMap, $prevEval, $jobOutPathMap)
+            checkBuild($db, $jobset, $ev, $job, \%buildMap, $prevEval, $jobOutPathMap)
                 unless defined $job->{error};
 
             if (defined $job->{constituents}) {


### PR DESCRIPTION
`checkBuild` takes `$inputInfo` and never reads it. That matters more than the usual dead argument: `$inputInfo` is the fetched inputs, so while it is in the signature, turning a job into a build looks like it depends on having fetched anything -- when in fact everything past `nix-eval-jobs` works from the jobs alone.