### PR TITLE
sql/upgrade-88: rewrite each table only once

### DIFF
--- a/subprojects/hydra/sql/migrations/upgrade-88.sql
+++ b/subprojects/hydra/sql/migrations/upgrade-88.sql
@@ -1,32 +1,35 @@
-ALTER TABLE Jobsets ALTER COLUMN errorTime TYPE bigint;
-ALTER TABLE Jobsets ALTER COLUMN lastCheckedTime TYPE bigint;
-
 -- recreate trigger
 DROP TRIGGER IF EXISTS JobsetSchedulingChanged ON Jobsets;
-ALTER TABLE Jobsets ALTER COLUMN triggerTime TYPE bigint;
+ALTER TABLE Jobsets
+  ALTER COLUMN errorTime TYPE bigint,
+  ALTER COLUMN lastCheckedTime TYPE bigint,
+  ALTER COLUMN triggerTime TYPE bigint,
+  ALTER COLUMN startTime TYPE bigint;
 create trigger JobsetSchedulingChanged after update on Jobsets for each row
   when (((old.triggerTime is distinct from new.triggerTime) and (new.triggerTime is not null))
         or (old.checkInterval != new.checkInterval)
         or (old.enabled != new.enabled))
   execute procedure notifyJobsetSchedulingChanged();
 
-ALTER TABLE Jobsets ALTER COLUMN startTime TYPE bigint;
+ALTER TABLE Builds
+  ALTER COLUMN timestamp TYPE bigint,
+  ALTER COLUMN startTime TYPE bigint,
+  ALTER COLUMN stopTime TYPE bigint,
+  ALTER COLUMN notificationPendingSince TYPE bigint;
 
-ALTER TABLE Builds ALTER COLUMN timestamp TYPE bigint;
-ALTER TABLE Builds ALTER COLUMN startTime TYPE bigint;
-ALTER TABLE Builds ALTER COLUMN stopTime TYPE bigint;
-ALTER TABLE Builds ALTER COLUMN notificationPendingSince TYPE bigint;
-
-ALTER TABLE BuildSteps ALTER COLUMN startTime TYPE bigint;
-ALTER TABLE BuildSteps ALTER COLUMN stopTime TYPE bigint;
+ALTER TABLE BuildSteps
+  ALTER COLUMN startTime TYPE bigint,
+  ALTER COLUMN stopTime TYPE bigint;
 
 ALTER TABLE BuildMetrics ALTER COLUMN timestamp TYPE bigint;
 
-ALTER TABLE CachedPathInputs ALTER COLUMN timestamp TYPE bigint;
-ALTER TABLE CachedPathInputs ALTER COLUMN lastSeen TYPE bigint;
+ALTER TABLE CachedPathInputs
+  ALTER COLUMN timestamp TYPE bigint,
+  ALTER COLUMN lastSeen TYPE bigint;
 
-ALTER TABLE CachedCVSInputs ALTER COLUMN timestamp TYPE bigint;
-ALTER TABLE CachedCVSInputs ALTER COLUMN lastSeen TYPE bigint;
+ALTER TABLE CachedCVSInputs
+  ALTER COLUMN timestamp TYPE bigint,
+  ALTER COLUMN lastSeen TYPE bigint;
 
 ALTER TABLE EvaluationErrors ALTER COLUMN errorTime TYPE bigint;
 
@@ -36,5 +39,6 @@ ALTER TABLE NewsItems ALTER COLUMN createTime TYPE bigint;
 
 ALTER TABLE TaskRetries ALTER COLUMN retry_at TYPE bigint;
 
-ALTER TABLE RunCommandLogs ALTER COLUMN start_time TYPE bigint;
-ALTER TABLE RunCommandLogs ALTER COLUMN end_time TYPE bigint;
+ALTER TABLE RunCommandLogs
+  ALTER COLUMN start_time TYPE bigint,
+  ALTER COLUMN end_time TYPE bigint;


### PR DESCRIPTION
Every `ALTER COLUMN ... TYPE` statement rewrites the table. Grouping the columns per table turns 4 rewrites of Builds (238 GB on hydra.nixos.org) and 2 of BuildSteps (118 GB) into one each. Resulting schema is identical, so instances that already ran 88 are unaffected.