### PR TITLE
hydra: Configure the two kinds of email notification separately

### DIFF
--- a/subprojects/hydra-manual/src/plugins/README.md
+++ b/subprojects/hydra-manual/src/plugins/README.md
@@ -82,7 +82,18 @@ Sends email notification if build status changes.
 
 ### Configuration options
 
-- `email_notification`
+- `email_notifications.build` --- mail about finished builds, to whoever
+  maintains the job
+- `email_notification` --- deprecated; enables this and the separate
+  `email_notifications.eval`. Setting it as well as the block is an error.
+
+### Example
+
+```xml
+<email_notifications>
+  build = 1
+</email_notifications>
+```
 
 ## Gitea status
 

--- a/subprojects/hydra-manual/src/projects.md
+++ b/subprojects/hydra-manual/src/projects.md
@@ -250,8 +250,29 @@ This provides immediate feedback to maintainers or committers when a change caus
 The feature can be turned on by adding the following line to `hydra.conf`
 
 ``` conf
-email_notification = 1
+<email_notifications>
+  build = 1
+</email_notifications>
 ```
+
+Evaluation errors are a separate switch in the same block, because they go to a
+different person --- the project's owner, rather than whoever maintains the
+job:
+
+``` conf
+<email_notifications>
+  build = 1
+  eval = 1
+</email_notifications>
+```
+
+The owner must also have "Receive evaluation error notifications" set on their
+user page; unlike build notification, it is off by default.
+
+A plain `email_notification = 1` --- without the s --- still works and turns on
+both, but it is deprecated in favour of the block above. Setting it as well as
+the block is an error rather than one of them winning: they are two ways of
+saying the same thing, and which you meant is not for Hydra to guess.
 
 By default, Hydra only sends email notifications if a previously successful build starts to fail.
 In order to force Hydra to send an email for each build (including e.g. successful or cancelled ones), the environment variable `HYDRA_FORCE_SEND_MAIL` can be declared:

--- a/subprojects/hydra-tests/Hydra/Config/email_notification.t
+++ b/subprojects/hydra-tests/Hydra/Config/email_notification.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use Hydra::Config;
+use Test2::V0;
+
+# Hydra's two kinds of mail are configured separately, in an
+# `email_notifications` block. The deprecated singular `email_notification`
+# used to turn on both and has to keep doing so, but the two cannot be
+# combined.
+
+subtest "nothing set" => sub {
+    my $config = {};
+    is(buildEmailNotificationEnabled($config), F(), "no build mail");
+    is(evalEmailNotificationEnabled($config), F(), "no evaluation mail");
+};
+
+subtest "the deprecated key enables both" => sub {
+    my $config = { email_notification => 1 };
+    is(buildEmailNotificationEnabled($config), T(), "build mail");
+    is(evalEmailNotificationEnabled($config), T(), "evaluation mail");
+};
+
+subtest "the block's settings are independent" => sub {
+    my $build_only = { email_notifications => { build => 1 } };
+    is(buildEmailNotificationEnabled($build_only), T(), "build on");
+    is(evalEmailNotificationEnabled($build_only), F(),
+        "turning on build mail does not turn on evaluation mail");
+
+    my $eval_only = { email_notifications => { eval => 1 } };
+    is(evalEmailNotificationEnabled($eval_only), T(), "eval on");
+    is(buildEmailNotificationEnabled($eval_only), F(),
+        "turning on evaluation mail does not turn on build mail");
+};
+
+subtest "setting both the block and the deprecated key is an error" => sub {
+    my $config = {
+        email_notification => 1,
+        email_notifications => { eval => 0 },
+    };
+    like(
+        dies { buildEmailNotificationEnabled($config) },
+        qr/sets both/,
+        "says the two ways of spelling it cannot be combined"
+    );
+};
+
+subtest "only 1 enables" => sub {
+    is(buildEmailNotificationEnabled({ email_notifications => { build => 0 } }), F(), "0 is off");
+    is(buildEmailNotificationEnabled({ email_notifications => { build => "" } }), F(), "empty is off");
+};
+
+subtest "the plural written as a scalar is a mistake worth naming" => sub {
+    like(
+        dies { buildEmailNotificationEnabled({ email_notifications => 1 }) },
+        qr/is a block/,
+        "says it is a block, and points at the singular spelling"
+    );
+};
+
+done_testing;

--- a/subprojects/hydra/lib/Hydra/Config.pm
+++ b/subprojects/hydra/lib/Hydra/Config.pm
@@ -11,6 +11,8 @@ our @EXPORT = qw(
     getHydraConfig
     getLDAPConfig
     getLDAPConfigAmbient
+    buildEmailNotificationEnabled
+    evalEmailNotificationEnabled
 );
 
 our %configGeneralOpts = (-UseApacheInclude => 1, -IncludeAgain => 1, -IncludeRelative => 1);
@@ -44,6 +46,73 @@ sub loadConfig {
     my %opts = (%configGeneralOpts, -ConfigFile => $sourceFile);
 
     return { Config::General->new(%opts)->getall };
+}
+
+# Hydra sends two unrelated kinds of mail, and `email_notification` used to
+# turn on both at once. They are separate switches now, because wanting one
+# rarely means wanting the other: build results go to whoever maintains the
+# job, while evaluation errors go to the project's owner alone.
+#
+#     <email_notifications>
+#       build = 1
+#       eval = 1
+#     </email_notifications>
+#
+# The old key still works and still means both, so an existing `hydra.conf`
+# keeps behaving as it did. It is spelled without the s, which is what lets the
+# block take the plural name: `Config::General` cannot have a scalar and a
+# block of the same name.
+my $warnedEmailNotification;
+
+sub emailNotificationEnabled {
+    my ($config, $key) = @_;
+
+    my $legacy = $config->{"email_notification"};
+    my $block = $config->{"email_notifications"};
+
+    if (defined $block && ref $block ne "HASH") {
+        die "hydra.conf: `email_notifications' is a block:\n\n"
+            . "  <email_notifications>\n"
+            . "    build = 1\n"
+            . "    eval = 1\n"
+            . "  </email_notifications>\n\n"
+            . "You may have meant the deprecated `email_notification', without the s.\n";
+    }
+
+    # Refusing both rather than picking a winner: the two say the same thing in
+    # different words, and a `hydra.conf` that sets both is one whose author
+    # believes something about the result. Same reason the legacy LDAP
+    # configuration refuses to coexist with the current one.
+    if (defined $legacy && defined $block) {
+        die "hydra.conf sets both `email_notification' and the `email_notifications'\n"
+            . "block. The former is deprecated and means both kinds; drop it and say\n"
+            . "what you want in the block.\n";
+    }
+
+    if (defined $legacy && !$warnedEmailNotification) {
+        $warnedEmailNotification = 1;
+        warn "hydra.conf sets `email_notification', which is deprecated: use the "
+            . "`email_notifications' block instead, which says which kinds of mail "
+            . "you want rather than enabling all of them.\n";
+    }
+
+    # Compared as a string: these come out of `hydra.conf` as text, and an empty
+    # value is a perfectly ordinary way to write "off" without warning about it
+    # not being a number.
+    my $value = defined $block ? $block->{$key} : $legacy;
+    return defined $value && $value eq "1";
+}
+
+# Whether to mail about finished builds.
+sub buildEmailNotificationEnabled {
+    my ($config) = @_;
+    return emailNotificationEnabled($config, "build");
+}
+
+# Whether to mail a project's owner about its jobsets' evaluation errors.
+sub evalEmailNotificationEnabled {
+    my ($config) = @_;
+    return emailNotificationEnabled($config, "eval");
 }
 
 sub is_ldap_in_legacy_mode {

--- a/subprojects/hydra/lib/Hydra/Controller/Jobset.pm
+++ b/subprojects/hydra/lib/Hydra/Controller/Jobset.pm
@@ -6,6 +6,7 @@ use warnings;
 use base 'Hydra::Base::Controller::ListBuilds';
 use Hydra::Helper::Nix;
 use Hydra::Helper::CatalystUtils;
+use Hydra::Config;
 
 
 sub jobsetChain :Chained('/') :PathPart('jobset') :CaptureArgs(2) {
@@ -47,7 +48,7 @@ sub jobset_GET {
 
     $c->stash->{totalShares} = getTotalShares($c->model('DB')->schema);
 
-    $c->stash->{emailNotification} = $c->config->{email_notification} // 0;
+    $c->stash->{buildEmailNotification} = buildEmailNotificationEnabled($c->config);
 
     $self->status_ok($c, entity => $c->stash->{jobset});
 }
@@ -177,7 +178,7 @@ sub edit : Chained('jobsetChain') PathPart Args(0) {
     $c->stash->{edit} = !defined $c->stash->{params}->{cloneJobset};
     $c->stash->{cloneJobset} = defined $c->stash->{params}->{cloneJobset};
     $c->stash->{totalShares} = getTotalShares($c->model('DB')->schema);
-    $c->stash->{emailNotification} = $c->config->{email_notification} // 0;
+    $c->stash->{buildEmailNotification} = buildEmailNotificationEnabled($c->config);
 }
 
 

--- a/subprojects/hydra/lib/Hydra/Controller/Project.pm
+++ b/subprojects/hydra/lib/Hydra/Controller/Project.pm
@@ -6,6 +6,7 @@ use warnings;
 use base 'Hydra::Base::Controller::ListBuilds';
 use Hydra::Helper::Nix;
 use Hydra::Helper::CatalystUtils;
+use Hydra::Config;
 
 
 sub projectChain :Chained('/') :PathPart('project') :CaptureArgs(1) {
@@ -126,7 +127,7 @@ sub create_jobset : Chained('projectChain') PathPart('create-jobset') Args(0) {
     $c->stash->{template} = 'edit-jobset.tt';
     $c->stash->{create} = 1;
     $c->stash->{totalShares} = getTotalShares($c->model('DB')->schema);
-    $c->stash->{emailNotification} = $c->config->{email_notification} // 0;
+    $c->stash->{buildEmailNotification} = buildEmailNotificationEnabled($c->config);
 }
 
 

--- a/subprojects/hydra/lib/Hydra/Helper/Email.pm
+++ b/subprojects/hydra/lib/Hydra/Helper/Email.pm
@@ -6,6 +6,7 @@ use Email::MIME;
 use Email::Sender::Simple qw(sendmail);
 use Exporter 'import';
 use Hydra::Helper::Nix;
+use Hydra::Config;
 use Sys::Hostname::Long;
 use Try::Tiny;
 
@@ -49,7 +50,7 @@ sub sendJobsetErrorNotification {
 
     chomp $errorMsg;
 
-    return unless $config->{email_notification} // 0;
+    return unless evalEmailNotificationEnabled($config);
     return if $jobset->project->owner->emailonerror == 0;
     return if $errorMsg eq "";
 

--- a/subprojects/hydra/lib/Hydra/Plugin/EmailNotification.pm
+++ b/subprojects/hydra/lib/Hydra/Plugin/EmailNotification.pm
@@ -9,10 +9,11 @@ use Template;
 use Hydra::Helper::Nix;
 use Hydra::Helper::CatalystUtils;
 use Hydra::Helper::Email;
+use Hydra::Config;
 
 sub isEnabled {
     my ($self) = @_;
-    return ($self->{config}->{email_notification} // 0) == 1;
+    return buildEmailNotificationEnabled($self->{config});
 }
 
 my $template = <<EOF;

--- a/subprojects/hydra/root/edit-jobset.tt
+++ b/subprojects/hydra/root/edit-jobset.tt
@@ -173,16 +173,26 @@
   </div>
 
   <div class="form-group row">
-    <label class="col-sm-3" for="editjobsetenableemail">Email notification</label>
+    <label class="col-sm-3" for="editjobsetenableemail">Build email notification</label>
     <div class="col-sm-9">
-      <input type="checkbox" id="editjobsetenableemail" name="enableemail" [% IF jobset.enableemail %]checked[% END %] [% IF !emailNotification %]disabled[% END %]/>
+      <input type="checkbox" id="editjobsetenableemail" name="enableemail"
+        [% IF !buildEmailNotification %]
+          title="The server has not enabled email notification for finished builds" disabled
+        [% ELSIF jobset.enableemail %]
+          checked
+        [% END %]
+      />
     </div>
   </div>
 
   <div class="form-group row">
     <label class="col-sm-3" for="editjobsetemailoverride">Email override</label>
     <div class="col-sm-9">
-      <input type="text" class="form-control" id="editjobsetemailoverride" name="emailoverride" [% HTML.attributes(value => jobset.emailoverride) %] [% IF !emailNotification %]disabled[% END %]/>
+      <input type="text" class="form-control" id="editjobsetemailoverride" name="emailoverride" [% HTML.attributes(value => jobset.emailoverride) %]
+        [% IF !buildEmailNotification %]
+          title="The server has not enabled email notification for finished builds" disabled
+        [% END %]
+      />
     </div>
   </div>
 

--- a/subprojects/hydra/root/jobset.tt
+++ b/subprojects/hydra/root/jobset.tt
@@ -163,9 +163,9 @@
         <th>Enable Dynamic RunCommand Hooks:</th>
         <td>[% c.config.dynamicruncommand.enable ? project.enable_dynamic_run_command ? jobset.enable_dynamic_run_command ? "Yes" : "No (not enabled by jobset)" : "No (not enabled by project)" : "No (not enabled by server)" %]</td>
       </tr>
-      [% IF emailNotification %]
+      [% IF buildEmailNotification %]
       <tr>
-        <th>Enable email notification:</th>
+        <th>Enable build email notification:</th>
         <td>[% jobset.enableemail ? "Yes" : "No" %]</td>
       </tr>
       <tr>


### PR DESCRIPTION
`email_notification` turned on two unrelated things at once. Build results go to whoever maintains the job; evaluation errors go to the project's owner alone. Wanting one is not much evidence of wanting the other, and until now there was no way to say so. Now there is:

    <email_notifications>
      build = 1
      eval = 1
    </email_notifications>

The old key still works and still means both, so an existing `hydra.conf` keeps behaving as it did.

Setting it *and* the block is an error to avoid guessing in the face of ambiguity, and to promote cleanly switching from the old style to the new style. (The legacy LDAP configuration in this file similarly will error if mixed.)

It can coexist with the block at all only because it lacks the "s" -- `Config::General` has no way to hold a scalar and a block of the same name, so we had to choose a new name.

Also, jobset's checkbox becomes "Build email notification", and says why when it is greyed out (like the dynamic `RunCommand` one does). It only ever governed build mail.