### PR TITLE
hydra-evaluator: Take its settings from its own TOML file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,8 +2000,11 @@ dependencies = [
  "fs-err",
  "futures",
  "hydra-tracing",
+ "serde",
  "sqlx",
+ "thiserror",
  "tokio",
+ "toml",
  "tracing",
 ]
 

--- a/nixos-modules/builder-module.nix
+++ b/nixos-modules/builder-module.nix
@@ -23,7 +23,12 @@ in
       };
 
       settings = lib.mkOption {
-        description = "Builder settings written to the TOML config file";
+        description = ''
+          Settings for the builder, written to `/etc/hydra/builder.toml`.
+
+          Every service in Rust in hydra has its own separate TOML configuration file,
+          with just the settings it needs.
+        '';
         type = lib.types.submodule {
           options = {
             pingInterval = lib.mkOption {

--- a/nixos-modules/queue-runner-module.nix
+++ b/nixos-modules/queue-runner-module.nix
@@ -19,7 +19,13 @@ in
       enable = lib.mkEnableOption "QueueRunner";
 
       settings = lib.mkOption {
-        description = "Reloadable settings for queue runner";
+        description = ''
+          Reloadable settings for the queue runner, written to
+          `/etc/hydra/queue-runner.toml`.
+
+          Every service in Rust in hydra has its own separate TOML configuration file,
+          with just the settings it needs.
+        '';
         type = lib.types.submodule {
           options = {
             hydraDataDir = lib.mkOption {

--- a/nixos-modules/web-app.nix
+++ b/nixos-modules/web-app.nix
@@ -15,6 +15,8 @@ let
 
   hydraConf = pkgs.writeScript "hydra.conf" cfg.extraConfig;
 
+  evaluatorFormat = pkgs.formats.toml { };
+
   hydraEnv = {
     HYDRA_DATABASE_URL = cfg.dbUrl;
     HYDRA_CONFIG = "${baseDir}/hydra.conf";
@@ -131,6 +133,26 @@ in
         default = 3000;
         description = ''
           TCP port the web server should listen to.
+        '';
+      };
+
+      evaluatorSettings = mkOption {
+        type = types.submodule {
+          freeformType = evaluatorFormat.type;
+          options = {
+            max_concurrent_evals = mkOption {
+              type = types.ints.positive;
+              default = 4;
+              description = "How many jobsets to evaluate at once.";
+            };
+          };
+        };
+        default = { };
+        description = ''
+          Settings for `hydra-evaluator`, written to `/etc/hydra/evaluator.toml`.
+
+          Every service in Rust in hydra has its own separate TOML configuration file,
+          with just the settings it needs.
         '';
       };
 
@@ -313,10 +335,16 @@ in
       };
     };
 
+    environment.etc."hydra/evaluator.toml".source =
+      evaluatorFormat.generate "evaluator.toml" cfg.evaluatorSettings;
+
     systemd.services.hydra-evaluator = {
       wantedBy = [ "multi-user.target" ];
       requires = [ "hydra-init.service" ];
-      restartTriggers = [ hydraConf ];
+      restartTriggers = [
+        hydraConf
+        config.environment.etc."hydra/evaluator.toml".source
+      ];
       after = [
         "hydra-init.service"
         "network.target"
@@ -335,9 +363,15 @@ in
         ExecStart = escapeShellArgs [
           "@${cfg.evaluatorExecutable}"
           "hydra-evaluator"
+          "--config-path"
+          "/etc/hydra/evaluator.toml"
         ];
+        # `--unlock` goes through the same argument parsing, so it needs the
+        # path too.
         ExecStopPost = escapeShellArgs [
           "${cfg.evaluatorExecutable}"
+          "--config-path"
+          "/etc/hydra/evaluator.toml"
           "--unlock"
         ];
         User = "hydra";

--- a/subprojects/hydra-evaluator/Cargo.toml
+++ b/subprojects/hydra-evaluator/Cargo.toml
@@ -10,8 +10,11 @@ clap                 = { workspace = true, features = [ "derive" ] }
 color-eyre.workspace = true
 fs-err.workspace     = true
 futures.workspace    = true
+serde                = { workspace = true, features = [ "derive" ] }
 sqlx                 = { workspace = true, features = [ "runtime-tokio", "tls-rustls-ring-webpki", "postgres" ] }
+thiserror.workspace  = true
 tokio                = { workspace = true, features = [ "full" ] }
+toml.workspace       = true
 tracing.workspace    = true
 
 db            = { path = "../crates/db" }

--- a/subprojects/hydra-evaluator/src/config.rs
+++ b/subprojects/hydra-evaluator/src/config.rs
@@ -1,61 +1,66 @@
-use std::collections::HashMap;
+//! What the evaluator is configured with.
+//!
+//! Its own file, as the queue runner and the builder have theirs.
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ConfigError {
+    #[error("reading {path}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("parsing {path}")]
+    Toml {
+        path: String,
+        #[source]
+        source: toml::de::Error,
+    },
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct HydraConfig {
-    options: HashMap<String, String>,
+    /// How many jobsets to evaluate at once.
+    #[serde(default = "default_max_concurrent_evals")]
+    max_concurrent_evals: u64,
+}
+
+fn default_max_concurrent_evals() -> u64 {
+    4
 }
 
 impl HydraConfig {
-    pub(crate) fn load() -> Self {
-        let mut options = HashMap::new();
-
-        let path = match std::env::var("HYDRA_CONFIG") {
-            Ok(p) if !p.is_empty() => p,
-            _ => return Self { options },
-        };
-
-        let contents = match fs_err::read_to_string(&path) {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!("could not read HYDRA_CONFIG at {path}: {e}");
-                return Self { options };
+    /// Read the file, or take the defaults if it is not there.
+    ///
+    /// Absent is fine -- every setting has a default -- but present and
+    /// unreadable is not, since that is a configuration someone wrote and
+    /// expects to be in effect.
+    pub(crate) fn load(path: &str) -> Result<Self, ConfigError> {
+        let contents = match fs_err::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::info!("no configuration at {path}, using defaults");
+                return Ok(Self::default());
+            }
+            Err(source) => {
+                return Err(ConfigError::Io {
+                    path: path.to_owned(),
+                    source,
+                });
             }
         };
 
-        for line in contents.lines() {
-            // Strip comments
-            let line = match line.find('#') {
-                Some(pos) => &line[..pos],
-                None => line,
-            };
-            let line = line.trim();
-
-            let Some(eq) = line.find('=') else {
-                continue;
-            };
-
-            let key = line[..eq].trim();
-            let value = line[eq + 1..].trim();
-
-            if key.is_empty() {
-                continue;
-            }
-
-            options.insert(key.to_owned(), value.to_owned());
-        }
-
-        Self { options }
+        toml::from_str(&contents).map_err(|source| ConfigError::Toml {
+            path: path.to_owned(),
+            source,
+        })
     }
 
-    pub(crate) fn get_int(&self, key: &str, default: u64) -> u64 {
-        match self.options.get(key) {
-            None => default,
-            Some(v) => v.parse().unwrap_or_else(|_| {
-                // The C++ evaluator failed loudly on unparsable values;
-                // at least warn so a hydra.conf typo is visible.
-                tracing::warn!("invalid value for {key} in hydra.conf: {v:?}, using {default}");
-                default
-            }),
-        }
+    /// At least one, so that a configuration of zero slows the evaluator down
+    /// rather than stopping it.
+    pub(crate) fn max_concurrent_evals(&self) -> usize {
+        usize::try_from(self.max_concurrent_evals.max(1)).unwrap_or(usize::MAX)
     }
 }

--- a/subprojects/hydra-evaluator/src/evaluator.rs
+++ b/subprojects/hydra-evaluator/src/evaluator.rs
@@ -71,8 +71,7 @@ impl Evaluator {
         config: &HydraConfig,
         eval_one: Option<(String, String)>,
     ) -> Self {
-        let max_evals =
-            usize::try_from(config.get_int("max_concurrent_evals", 4).max(1)).unwrap_or(usize::MAX);
+        let max_evals = config.max_concurrent_evals();
         Self {
             db,
             max_evals,

--- a/subprojects/hydra-evaluator/src/main.rs
+++ b/subprojects/hydra-evaluator/src/main.rs
@@ -27,6 +27,10 @@ use queries::JobsetQueries as _;
 #[derive(clap::Parser, Debug)]
 #[command(name = "hydra-evaluator", about = "Hydra jobset evaluation scheduler")]
 struct Cli {
+    /// Path to the evaluator's configuration file
+    #[arg(short, long, default_value = "evaluator.toml")]
+    config_path: String,
+
     /// Clear startTime on all jobsets and exit
     #[arg(long)]
     unlock: bool,
@@ -57,7 +61,7 @@ async fn main() -> color_eyre::Result<()> {
         return Ok(());
     }
 
-    let config = HydraConfig::load();
+    let config = HydraConfig::load(&cli.config_path)?;
 
     let eval_one = match (cli.project, cli.jobset) {
         (Some(p), Some(j)) => Some((p, j)),

--- a/subprojects/hydra/lib/Hydra/Config.pm
+++ b/subprojects/hydra/lib/Hydra/Config.pm
@@ -19,6 +19,23 @@ our %configGeneralOpts = (-UseApacheInclude => 1, -IncludeAgain => 1, -IncludeRe
 
 my $hydraConfigCache;
 
+# Settings that used to live in `hydra.conf` and now belong to a component's
+# own configuration file. Left here they are silently inert, which looks
+# exactly like the setting having no effect, so say so once.
+our %movedSettings = (
+    max_concurrent_evals => "`max_concurrent_evals` in /etc/hydra/evaluator.toml",
+);
+
+sub warnAboutMovedSettings {
+    my ($config) = @_;
+
+    for my $key (sort keys %movedSettings) {
+        next unless exists $config->{$key};
+        warn "hydra.conf sets `$key', which is no longer read from there. "
+            . "Set $movedSettings{$key} instead.\n";
+    }
+}
+
 sub getHydraConfig {
     return $hydraConfigCache if defined $hydraConfigCache;
 
@@ -36,6 +53,8 @@ sub getHydraConfig {
     } else {
         $hydraConfigCache = {};
     }
+
+    warnAboutMovedSettings($hydraConfigCache);
 
     return $hydraConfigCache;
 }


### PR DESCRIPTION
The evaluator previously read `hydra.conf`, the Perl configuration, with a hand-rolled parser. This is not nice. Let's just use TOML like the other components.

The evaluator currently reads just one setting, `max_concurrent_evals`, which nothing else reads. So the shared file bought no sharing and cost a second syntax to parse in Rust. Do `/etc/hydra/evaluator.toml` instead, as the queue runner and the builder already have their own.

Also, make `Hydra::Config` warn when a moved setting is still in `hydra.conf`. That way, users are prompted to move them to the TOML file instead.