### PR TITLE
db: use sqlx's checked query macros throughout

### DIFF
--- a/.sqlx/query-076b04c2681f81b032ea0a2adb950f12a9c4dd8d3ec5ffbfaa588605c8c5b318.json
+++ b/.sqlx/query-076b04c2681f81b032ea0a2adb950f12a9c4dd8d3ec5ffbfaa588605c8c5b318.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO BuildSteps (build, stepnr, type, busy, drvPath, status) VALUES ($1, $2, 0, 1, $3, NULL)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "076b04c2681f81b032ea0a2adb950f12a9c4dd8d3ec5ffbfaa588605c8c5b318"
+}

--- a/.sqlx/query-4bb9b56c3008369ec6885c3799a2e69dc2baa0024b2664365b5f17d0c1e9a099.json
+++ b/.sqlx/query-4bb9b56c3008369ec6885c3799a2e69dc2baa0024b2664365b5f17d0c1e9a099.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE Users SET fullName = 'second' WHERE userName = 'b'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "4bb9b56c3008369ec6885c3799a2e69dc2baa0024b2664365b5f17d0c1e9a099"
+}

--- a/.sqlx/query-647357964b008140d9108b9cd880225eee332b5c6173d599992e6a134987b568.json
+++ b/.sqlx/query-647357964b008140d9108b9cd880225eee332b5c6173d599992e6a134987b568.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH RECURSIVE input AS (\n                SELECT (ordinality)::int AS idx,\n                       elem->>'root' AS drv,\n                       ARRAY(SELECT jsonb_array_elements_text(elem->'chain')) AS chain\n                FROM jsonb_array_elements($1::jsonb)\n                    WITH ORDINALITY AS t(elem, ordinality)\n            ),\n            resolve(idx, drv_path, step) AS (\n                SELECT idx, drv, 1 FROM input\n\n                UNION ALL\n\n                SELECT r.idx, sub.path, r.step + 1\n                FROM resolve r\n                JOIN input i ON i.idx = r.idx\n                CROSS JOIN LATERAL (\n                    SELECT o.path\n                    FROM buildsteps s\n                    -- If this step was resolved, look up outputs from\n                    -- the resolved drv's successful buildstep instead.\n                    -- resolvedDrvPath is a bare basename; drvPath is a\n                    -- full path, so strip the directory prefix to compare.\n                    LEFT JOIN buildsteps sr\n                        ON sr.drvPath = $2 || '/' || s.resolvedDrvPath\n                        AND sr.status = 0\n                    JOIN buildstepoutputs o\n                        ON o.build = COALESCE(sr.build, s.build)\n                        AND o.stepnr = COALESCE(sr.stepnr, s.stepnr)\n                    WHERE s.drvPath = r.drv_path\n                      AND o.name = i.chain[r.step]\n                      AND o.path IS NOT NULL\n                      AND (s.status = 0 OR s.status = 13)\n                    -- `+ 0`: otherwise the planner walks buildsteps_pkey\n                    -- backwards instead of using IndexBuildStepsOnDrvPath.\n                    ORDER BY s.build + 0 DESC\n                    LIMIT 1\n                ) sub\n                WHERE r.step <= array_length(i.chain, 1)\n                  AND r.drv_path IS NOT NULL\n            )\n            SELECT i.idx AS \"idx!\", r.drv_path\n            FROM input i\n            LEFT JOIN resolve r\n                ON r.idx = i.idx\n                AND r.step = array_length(i.chain, 1) + 1\n            ORDER BY i.idx\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "idx!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "drv_path",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Jsonb",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "647357964b008140d9108b9cd880225eee332b5c6173d599992e6a134987b568"
+}

--- a/.sqlx/query-773405379023f2cf3b00cda321b91df097b33af4099d7400495b8a93369181af.json
+++ b/.sqlx/query-773405379023f2cf3b00cda321b91df097b33af4099d7400495b8a93369181af.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO Users (userName, fullName, emailAddress, password)\n             VALUES ('a', '', 'a@example.org', ''), ('b', '', 'b@example.org', '')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "773405379023f2cf3b00cda321b91df097b33af4099d7400495b8a93369181af"
+}

--- a/.sqlx/query-7d0d677d2c1342b89a34f98c0d51817d2cb42e81f5c4189d967da1a731b09fc3.json
+++ b/.sqlx/query-7d0d677d2c1342b89a34f98c0d51817d2cb42e81f5c4189d967da1a731b09fc3.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO BuildSteps (build, stepnr, type, busy, drvPath, status, resolvedDrvPath) VALUES ($1, $2, 0, 0, $3, $4, $5)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4",
+        "Text",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7d0d677d2c1342b89a34f98c0d51817d2cb42e81f5c4189d967da1a731b09fc3"
+}

--- a/.sqlx/query-7e5ddb762f97d5af64af699f529c68ef12085d8fbff7e7e02ea42134beb7e312.json
+++ b/.sqlx/query-7e5ddb762f97d5af64af699f529c68ef12085d8fbff7e7e02ea42134beb7e312.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT busy, status FROM buildsteps WHERE build = $1 AND stepnr = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "busy",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "status",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "7e5ddb762f97d5af64af699f529c68ef12085d8fbff7e7e02ea42134beb7e312"
+}

--- a/.sqlx/query-9dff3e231a13a1b08bb2e60a6ff19f27be8ad5d73ae9288aebff0b512da61c84.json
+++ b/.sqlx/query-9dff3e231a13a1b08bb2e60a6ff19f27be8ad5d73ae9288aebff0b512da61c84.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_notify($1::text, '')",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_notify",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9dff3e231a13a1b08bb2e60a6ff19f27be8ad5d73ae9288aebff0b512da61c84"
+}

--- a/.sqlx/query-ae02552cba62b6daf6ac60d37259a31dad10fb20499a2c47a65f09589c847820.json
+++ b/.sqlx/query-ae02552cba62b6daf6ac60d37259a31dad10fb20499a2c47a65f09589c847820.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_notify($1::text, $2::text)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_notify",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "ae02552cba62b6daf6ac60d37259a31dad10fb20499a2c47a65f09589c847820"
+}

--- a/.sqlx/query-b1757a1a361ea87b2a7006e2c9d08f8c1864b73694cda8266790fee63e0b1b15.json
+++ b/.sqlx/query-b1757a1a361ea87b2a7006e2c9d08f8c1864b73694cda8266790fee63e0b1b15.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE Users SET fullName = 'first' WHERE userName = 'a'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "b1757a1a361ea87b2a7006e2c9d08f8c1864b73694cda8266790fee63e0b1b15"
+}

--- a/.sqlx/query-b54d8de8b93e66769f44965a8d94685640d4fca008d3de70524f10a87a38c7a1.json
+++ b/.sqlx/query-b54d8de8b93e66769f44965a8d94685640d4fca008d3de70524f10a87a38c7a1.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO BuildStepOutputs (build, stepnr, name, path) VALUES ($1, $2, $3, $4)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b54d8de8b93e66769f44965a8d94685640d4fca008d3de70524f10a87a38c7a1"
+}

--- a/.sqlx/query-b6db34d73f82bac28dc6b5eaf3c15e6b8adfec0bd67bddf69dd4c592fe3a0b95.json
+++ b/.sqlx/query-b6db34d73f82bac28dc6b5eaf3c15e6b8adfec0bd67bddf69dd4c592fe3a0b95.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid()",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_terminate_backend",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b6db34d73f82bac28dc6b5eaf3c15e6b8adfec0bd67bddf69dd4c592fe3a0b95"
+}

--- a/.sqlx/query-cc271ad3ccc4a5daf175bace220f831363f4cb0fbf6f62654c94b05a9d9a777e.json
+++ b/.sqlx/query-cc271ad3ccc4a5daf175bace220f831363f4cb0fbf6f62654c94b05a9d9a777e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE Users SET fullName = 'first' WHERE userName = 'b'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "cc271ad3ccc4a5daf175bace220f831363f4cb0fbf6f62654c94b05a9d9a777e"
+}

--- a/.sqlx/query-db39e8ab99e8881becb9b62ae42454893ac66cef582db3aee1b7b290aedfd27c.json
+++ b/.sqlx/query-db39e8ab99e8881becb9b62ae42454893ac66cef582db3aee1b7b290aedfd27c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE Users SET fullName = 'second' WHERE userName = 'a'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "db39e8ab99e8881becb9b62ae42454893ac66cef582db3aee1b7b290aedfd27c"
+}

--- a/.sqlx/query-e073e5f4dba7c13033fb98ba99966a0bc20107fd6196dbc4b1548a2d9f464af6.json
+++ b/.sqlx/query-e073e5f4dba7c13033fb98ba99966a0bc20107fd6196dbc4b1548a2d9f464af6.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT o.path AS \"path!\"\n              FROM buildsteps s\n              JOIN buildstepoutputs o\n                  ON s.build = o.build AND s.stepnr = o.stepnr\n              WHERE s.drvPath = $1\n                AND o.name = $2\n                AND o.path IS NOT NULL\n                AND s.status = 0\n              ORDER BY s.build DESC\n              LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "e073e5f4dba7c13033fb98ba99966a0bc20107fd6196dbc4b1548a2d9f464af6"
+}

--- a/.sqlx/query-e4fc9a0d196bcb44b8b16ed163b9f0b1aa9e2f24f8fbd552376712fe94e6122e.json
+++ b/.sqlx/query-e4fc9a0d196bcb44b8b16ed163b9f0b1aa9e2f24f8fbd552376712fe94e6122e.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT o.name, o.path AS \"path!\"\n              FROM buildstepoutputs o\n              JOIN buildsteps s ON s.build = o.build AND s.stepnr = o.stepnr\n              WHERE s.drvpath = $1 AND o.path IS NOT NULL",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "path!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "e4fc9a0d196bcb44b8b16ed163b9f0b1aa9e2f24f8fbd552376712fe94e6122e"
+}

--- a/subprojects/crates/db/src/connection.rs
+++ b/subprojects/crates/db/src/connection.rs
@@ -377,8 +377,8 @@ impl Connection {
                 .collect(),
         );
 
-        let rows = sqlx::query_as::<_, (i32, Option<String>)>(
-            "
+        let rows = sqlx::query!(
+            r#"
             WITH RECURSIVE input AS (
                 SELECT (ordinality)::int AS idx,
                        elem->>'root' AS drv,
@@ -419,23 +419,23 @@ impl Connection {
                 WHERE r.step <= array_length(i.chain, 1)
                   AND r.drv_path IS NOT NULL
             )
-            SELECT i.idx, r.drv_path
+            SELECT i.idx AS "idx!", r.drv_path
             FROM input i
             LEFT JOIN resolve r
                 ON r.idx = i.idx
                 AND r.step = array_length(i.chain, 1) + 1
             ORDER BY i.idx
-            ",
+            "#,
+            json_input,
+            store_dir.to_str(),
         )
-        .bind(&json_input)
-        .bind(store_dir.to_str())
         .fetch_all(&mut *self.conn)
         .await?;
 
         let mut results = vec![None; chains.len()];
-        for (idx, path) in rows {
-            let i = usize::try_from(idx - 1)?;
-            results[i] = path.map(|p| store_dir.parse(&p)).transpose()?;
+        for row in rows {
+            let i = usize::try_from(row.idx - 1)?;
+            results[i] = row.drv_path.map(|p| store_dir.parse(&p)).transpose()?;
         }
         Ok(results)
     }
@@ -450,8 +450,8 @@ impl Connection {
     ) -> crate::Result<Option<StorePath>> {
         let drv_display = store_dir.display(drv_path).to_string();
         let output_name_str: &str = output_name.as_ref();
-        let row: Option<(String,)> = sqlx::query_as(
-            r"SELECT o.path
+        let row = sqlx::query_scalar!(
+            r#"SELECT o.path AS "path!"
               FROM buildsteps s
               JOIN buildstepoutputs o
                   ON s.build = o.build AND s.stepnr = o.stepnr
@@ -460,14 +460,14 @@ impl Connection {
                 AND o.path IS NOT NULL
                 AND s.status = 0
               ORDER BY s.build DESC
-              LIMIT 1",
+              LIMIT 1"#,
+            drv_display,
+            output_name_str,
         )
-        .bind(&drv_display)
-        .bind(output_name_str)
         .fetch_optional(&mut *self.conn)
         .await?;
 
-        row.map(|(path,)| Ok(store_dir.parse(&path)?)).transpose()
+        row.map(|path| Ok(store_dir.parse(&path)?)).transpose()
     }
 }
 
@@ -819,21 +819,21 @@ impl Transaction<'_> {
         drv_path: &StorePath,
     ) -> crate::Result<BTreeMap<OutputName, StorePath>> {
         let drv_path = store_dir.display(drv_path).to_string();
-        let items: Vec<(String, String)> = sqlx::query_as(
-            r"SELECT o.name, o.path
+        let items = sqlx::query!(
+            r#"SELECT o.name, o.path AS "path!"
               FROM buildstepoutputs o
               JOIN buildsteps s ON s.build = o.build AND s.stepnr = o.stepnr
-              WHERE s.drvpath = $1 AND o.path IS NOT NULL",
+              WHERE s.drvpath = $1 AND o.path IS NOT NULL"#,
+            drv_path,
         )
-        .bind(drv_path)
         .fetch_all(&mut *self.tx)
         .await?;
 
         items
             .into_iter()
-            .map(|(name, path)| -> crate::Result<_> {
-                let name: OutputName = name.parse()?;
-                let path: StorePath = store_dir.parse(&path)?;
+            .map(|row| -> crate::Result<_> {
+                let name: OutputName = row.name.parse()?;
+                let path: StorePath = store_dir.parse(&row.path)?;
                 Ok((name, path))
             })
             .collect()
@@ -1352,13 +1352,9 @@ impl Transaction<'_> {
 impl Transaction<'_> {
     #[tracing::instrument(skip(self), err)]
     async fn notify_any(&mut self, channel: &str, msg: &str) -> crate::Result<()> {
-        sqlx::query(
-            r"SELECT pg_notify(chan, payload) from (values ($1, $2)) notifies(chan, payload)",
-        )
-        .bind(channel)
-        .bind(msg)
-        .execute(&mut *self.tx)
-        .await?;
+        sqlx::query!("SELECT pg_notify($1::text, $2::text)", channel, msg)
+            .execute(&mut *self.tx)
+            .await?;
         Ok(())
     }
 
@@ -1471,12 +1467,14 @@ mod tests {
         resolved_drv_path: Option<&StorePath>,
     ) {
         let sd = test_store_dir();
-        sqlx::query("INSERT INTO BuildSteps (build, stepnr, type, busy, drvPath, status, resolvedDrvPath) VALUES ($1, $2, 0, 0, $3, $4, $5)")
-            .bind(build)
-            .bind(stepnr)
-            .bind(sd.display(drv_path).to_string())
-            .bind(status)
-            .bind(resolved_drv_path.map(|p| p.to_string()))
+        sqlx::query!(
+            "INSERT INTO BuildSteps (build, stepnr, type, busy, drvPath, status, resolvedDrvPath) VALUES ($1, $2, 0, 0, $3, $4, $5)",
+            build,
+            stepnr,
+            sd.display(drv_path).to_string(),
+            status,
+            resolved_drv_path.map(ToString::to_string),
+        )
             .execute(&mut *conn.conn)
             .await
             .unwrap();
@@ -1489,13 +1487,13 @@ mod tests {
         name: &str,
         path: &StorePath,
     ) {
-        sqlx::query(
+        sqlx::query!(
             "INSERT INTO BuildStepOutputs (build, stepnr, name, path) VALUES ($1, $2, $3, $4)",
+            build,
+            stepnr,
+            name,
+            test_store_dir().display(path).to_string(),
         )
-        .bind(build)
-        .bind(stepnr)
-        .bind(name)
-        .bind(test_store_dir().display(path).to_string())
         .execute(&mut *conn.conn)
         .await
         .unwrap();
@@ -1504,24 +1502,27 @@ mod tests {
     #[tokio::test]
     async fn clear_busy_step_finalizes_only_the_named_step() {
         async fn insert_busy(conn: &mut Connection, build: i32, stepnr: i32, drv: &StorePath) {
-            sqlx::query("INSERT INTO BuildSteps (build, stepnr, type, busy, drvPath, status) VALUES ($1, $2, 0, 1, $3, NULL)")
-                .bind(build)
-                .bind(stepnr)
-                .bind(test_store_dir().display(drv).to_string())
+            sqlx::query!(
+                "INSERT INTO BuildSteps (build, stepnr, type, busy, drvPath, status) VALUES ($1, $2, 0, 1, $3, NULL)",
+                build,
+                stepnr,
+                test_store_dir().display(drv).to_string(),
+            )
                 .execute(&mut *conn.conn)
                 .await
                 .unwrap();
         }
 
         async fn busy_status(conn: &mut Connection, build: i32, stepnr: i32) -> (i32, Option<i32>) {
-            sqlx::query_as::<_, (i32, Option<i32>)>(
+            let row = sqlx::query!(
                 "SELECT busy, status FROM buildsteps WHERE build = $1 AND stepnr = $2",
+                build,
+                stepnr,
             )
-            .bind(build)
-            .bind(stepnr)
             .fetch_one(&mut *conn.conn)
             .await
-            .unwrap()
+            .unwrap();
+            (row.busy, row.status)
         }
 
         let (_pg, mut conn) = setup().await;
@@ -1928,10 +1929,11 @@ mod tests {
     async fn deadlock_is_retryable_serialization_failure() {
         let (_pg, pool) = test_utils::TestPg::new().await;
 
+        // Any two rows will do; users are the simplest table to seed.
         let mut setup = Connection::new(pool.acquire().await.unwrap());
-        sqlx::raw_sql(
-            "CREATE TABLE deadlock_test (id int PRIMARY KEY, v int);
-             INSERT INTO deadlock_test VALUES (1, 0), (2, 0);",
+        sqlx::query!(
+            "INSERT INTO Users (userName, fullName, emailAddress, password)
+             VALUES ('a', '', 'a@example.org', ''), ('b', '', 'b@example.org', '')"
         )
         .execute(&mut *setup.conn)
         .await
@@ -1941,13 +1943,13 @@ mod tests {
         let mut conn_b = Connection::new(pool.acquire().await.unwrap());
 
         let mut tx_a = conn_a.begin_transaction().await.unwrap();
-        sqlx::query("UPDATE deadlock_test SET v = 1 WHERE id = 1")
+        sqlx::query!("UPDATE Users SET fullName = 'first' WHERE userName = 'a'")
             .execute(&mut *tx_a.tx)
             .await
             .unwrap();
 
         let mut tx_b = conn_b.begin_transaction().await.unwrap();
-        sqlx::query("UPDATE deadlock_test SET v = 1 WHERE id = 2")
+        sqlx::query!("UPDATE Users SET fullName = 'first' WHERE userName = 'b'")
             .execute(&mut *tx_b.tx)
             .await
             .unwrap();
@@ -1955,8 +1957,10 @@ mod tests {
         // Each transaction now reaches for the row the other holds, closing the
         // cycle; Postgres aborts one of them with a deadlock error.
         let (res_a, res_b) = tokio::join!(
-            sqlx::query("UPDATE deadlock_test SET v = 2 WHERE id = 2").execute(&mut *tx_a.tx),
-            sqlx::query("UPDATE deadlock_test SET v = 2 WHERE id = 1").execute(&mut *tx_b.tx),
+            sqlx::query!("UPDATE Users SET fullName = 'second' WHERE userName = 'b'")
+                .execute(&mut *tx_a.tx),
+            sqlx::query!("UPDATE Users SET fullName = 'second' WHERE userName = 'a'")
+                .execute(&mut *tx_b.tx),
         );
 
         let victim = match (res_a, res_b) {

--- a/subprojects/crates/db/src/lib.rs
+++ b/subprojects/crates/db/src/lib.rs
@@ -196,7 +196,7 @@ mod tests {
 
     async fn notify(db: &Database, channel: &str) {
         let mut conn = db.get().await.unwrap();
-        sqlx::query(&format!("NOTIFY {channel}"))
+        sqlx::query!("SELECT pg_notify($1::text, '')", channel)
             .execute(conn.raw())
             .await
             .unwrap();
@@ -214,11 +214,11 @@ mod tests {
         // Kill the backend that holds the LISTEN; a NOTIFY sent now would
         // be lost, so the stream must report this instead of hiding it.
         let mut conn = db.get().await.unwrap();
-        sqlx::query(
+        sqlx::query!(
             "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
              WHERE datname = current_database() AND pid <> pg_backend_pid()",
         )
-        .execute(conn.raw())
+        .fetch_all(conn.raw())
         .await
         .unwrap();
         drop(conn);


### PR DESCRIPTION
Four queries in `connection.rs` were still the unchecked `sqlx::query`/`query_as` forms, along with the helpers and a few one-off queries in its tests. Two predate the offline cache covering test targets, but the recursive derived-path resolver was left unchecked by mistake.

Now that `sqlx-prepare.sh` covers everything, let's fix all of this.

Two tests had no schema to check against and are reshaped rather than left out:

- the `NOTIFY` assembled from a channel name goes through `pg_notify` with the channel as a parameter. This matches how the other notifications are already sent.

- the deadlock reproducer contends on two `Users` rows instead of a table it created for itself.

Only these remain:

- the schema load and `SET` statements in tests are not queries

- the SQLite presence cache in `binary-cache` cannot be checked alongside the workspace's PostgreSQL `DATABASE_URL` until we upgrade to sqlx 0.9 and can use its `sqlx.toml` to set up multiple databases.